### PR TITLE
feat: add export all accounts functionality

### DIFF
--- a/app/src/main/java/com/greenart7c3/nostrsigner/models/AccountExport.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/models/AccountExport.kt
@@ -1,0 +1,52 @@
+package com.greenart7c3.nostrsigner.models
+
+import androidx.compose.runtime.Immutable
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+
+/**
+ * Data model for exporting a single account's credentials and metadata
+ */
+@Immutable
+data class AccountExportData(
+    @JsonProperty("npub")
+    val npub: String,
+    @JsonProperty("name")
+    val name: String,
+    @JsonProperty("nsec")
+    val nsec: String?,
+    @JsonProperty("signPolicy")
+    val signPolicy: Int,
+    @JsonProperty("picture")
+    val picture: String?,
+    @JsonProperty("didBackup")
+    val didBackup: Boolean,
+)
+
+/**
+ * Container for bulk account export with versioning for future compatibility
+ */
+@Immutable
+data class BulkAccountExport(
+    @JsonProperty("version")
+    val version: String = "1.0",
+    @JsonProperty("exportDate")
+    val exportDate: Long = System.currentTimeMillis() / 1000,
+    @JsonProperty("accountCount")
+    val accountCount: Int,
+    @JsonProperty("accounts")
+    val accounts: List<AccountExportData>,
+) {
+    companion object {
+        private val mapper = jacksonObjectMapper()
+
+        fun toJson(export: BulkAccountExport): String {
+            return mapper.writeValueAsString(export)
+        }
+
+        fun fromJson(json: String): BulkAccountExport {
+            return mapper.readValue(json)
+        }
+    }
+}

--- a/app/src/main/java/com/greenart7c3/nostrsigner/service/AccountExportService.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/service/AccountExportService.kt
@@ -1,0 +1,88 @@
+package com.greenart7c3.nostrsigner.service
+
+import android.content.Context
+import com.greenart7c3.nostrsigner.LocalPreferences
+import com.greenart7c3.nostrsigner.models.Account
+import com.greenart7c3.nostrsigner.models.AccountExportData
+import com.greenart7c3.nostrsigner.models.BulkAccountExport
+import com.vitorpamplona.quartz.nip01Core.core.toHexKey
+import com.vitorpamplona.quartz.nip19Bech32.toNsec
+import com.vitorpamplona.quartz.nip49PrivKeyEnc.Nip49
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+object AccountExportService {
+    /**
+     * Export all accounts as an encrypted JSON file
+     *
+     * @param context Application context
+     * @param password Password for encrypting private keys (NIP-49)
+     * @param onProgress Callback for progress updates (current, total)
+     * @return Encrypted JSON string containing all account data
+     */
+    suspend fun exportAllAccountsEncrypted(
+        context: Context,
+        password: String,
+        onProgress: (current: Int, total: Int) -> Unit = { _, _ -> },
+    ): Result<String> = withContext(Dispatchers.IO) {
+        try {
+            val accountInfos = LocalPreferences.allSavedAccounts(context)
+            val totalAccounts = accountInfos.size
+
+            if (totalAccounts == 0) {
+                return@withContext Result.failure(Exception("No accounts to export"))
+            }
+
+            val exportedAccounts = mutableListOf<AccountExportData>()
+
+            accountInfos.forEachIndexed { index, accountInfo ->
+                onProgress(index + 1, totalAccounts)
+
+                val account = LocalPreferences.loadFromEncryptedStorage(context, accountInfo.npub)
+                account?.let {
+                    val exportData = accountToExportData(it, password)
+                    exportedAccounts.add(exportData)
+                }
+            }
+
+            val bulkExport = BulkAccountExport(
+                accountCount = exportedAccounts.size,
+                accounts = exportedAccounts,
+            )
+
+            val json = BulkAccountExport.toJson(bulkExport)
+
+            // Each private key is already encrypted with NIP-49 inside the JSON
+            Result.success(json)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    /**
+     * Convert an Account to exportable data with encrypted private key
+     */
+    private fun accountToExportData(account: Account, password: String): AccountExportData {
+        val privKey = account.signer.keyPair.privKey
+
+        // Encrypt private key with password (NIP-49) or use nsec if no password
+        val encryptedNsec = if (privKey != null) {
+            if (password.isNotBlank()) {
+                Nip49().encrypt(privKey.toHexKey(), password)
+            } else {
+                privKey.toNsec()
+            }
+        } else {
+            null
+        }
+
+        return AccountExportData(
+            npub = account.npub,
+            name = account.name.value,
+            nsec = encryptedNsec,
+            signPolicy = account.signPolicy,
+            picture = account.picture.value,
+            didBackup = account.didBackup,
+        )
+    }
+}

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/MainScreen.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/MainScreen.kt
@@ -69,6 +69,7 @@ import com.greenart7c3.nostrsigner.ui.actions.ActiveRelaysScreen
 import com.greenart7c3.nostrsigner.ui.actions.ActivityScreen
 import com.greenart7c3.nostrsigner.ui.actions.ConnectOrbotScreen
 import com.greenart7c3.nostrsigner.ui.actions.DefaultRelaysScreen
+import com.greenart7c3.nostrsigner.ui.actions.ExportAllAccountsScreen
 import com.greenart7c3.nostrsigner.ui.actions.QrCodeScreen
 import com.greenart7c3.nostrsigner.ui.actions.RelayLogScreen
 import com.greenart7c3.nostrsigner.ui.components.AmberBottomBar
@@ -429,6 +430,24 @@ fun MainScreen(
                                 .padding(top = verticalPadding * 1.5f)
                                 .imePadding(),
                             navController,
+                        )
+                    },
+                )
+
+                composable(
+                    Route.ExportAllAccounts.route,
+                    content = {
+                        val scrollState = rememberScrollState()
+                        ExportAllAccountsScreen(
+                            Modifier
+                                .fillMaxSize()
+                                .padding(padding)
+                                .consumeWindowInsets(padding)
+                                .verticalScrollbar(scrollState)
+                                .verticalScroll(scrollState)
+                                .padding(horizontal = verticalPadding)
+                                .padding(top = verticalPadding * 1.5f)
+                                .imePadding(),
                         )
                     },
                 )

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/SettingsScreen.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/SettingsScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.material.icons.filled.Feedback
 import androidx.compose.material.icons.filled.FilterList
 import androidx.compose.material.icons.filled.Key
 import androidx.compose.material.icons.filled.Language
+import androidx.compose.material.icons.filled.SaveAlt
 import androidx.compose.material.icons.filled.Security
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.MaterialTheme
@@ -136,6 +137,20 @@ fun SettingsScreen(
                     tint = MaterialTheme.colorScheme.onBackground,
                     onClick = {
                         navController.navigate(Route.AccountBackup.route)
+                    },
+                )
+            }
+
+            Box(
+                Modifier
+                    .padding(vertical = 8.dp),
+            ) {
+                IconRow(
+                    title = stringResource(R.string.export_all_accounts_title),
+                    icon = Icons.Default.SaveAlt,
+                    tint = MaterialTheme.colorScheme.onBackground,
+                    onClick = {
+                        navController.navigate(Route.ExportAllAccounts.route)
                     },
                 )
             }

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/actions/ExportAllAccountsScreen.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/actions/ExportAllAccountsScreen.kt
@@ -1,0 +1,387 @@
+package com.greenart7c3.nostrsigner.ui.actions
+
+import android.app.Activity
+import android.widget.Toast
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.ActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Visibility
+import androidx.compose.material.icons.outlined.VisibilityOff
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.autofill.ContentType
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentType
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.unit.dp
+import com.greenart7c3.nostrsigner.LocalPreferences
+import com.greenart7c3.nostrsigner.R
+import com.greenart7c3.nostrsigner.service.AccountExportService
+import com.greenart7c3.nostrsigner.service.Biometrics.authenticate
+import com.greenart7c3.nostrsigner.ui.CenterCircularProgressIndicator
+import com.greenart7c3.nostrsigner.ui.components.AmberButton
+import com.halilibo.richtext.commonmark.CommonmarkAstNodeParser
+import com.halilibo.richtext.commonmark.MarkdownParseOptions
+import com.halilibo.richtext.markdown.BasicMarkdown
+import com.halilibo.richtext.ui.RichTextStyle
+import com.halilibo.richtext.ui.material3.RichText
+import com.halilibo.richtext.ui.resolveDefaults
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+@OptIn(ExperimentalComposeUiApi::class)
+@Composable
+fun ExportAllAccountsScreen(
+    modifier: Modifier,
+) {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    var isLoading by remember { mutableStateOf(false) }
+    var exportProgress by remember { mutableStateOf("") }
+    var accountCount by remember { mutableIntStateOf(0) }
+    var showConfirmationDialog by remember { mutableStateOf(false) }
+
+    LaunchedEffect(Unit) {
+        launch(Dispatchers.IO) {
+            accountCount = LocalPreferences.allSavedAccounts(context).size
+        }
+    }
+
+    val password = remember { mutableStateOf(TextFieldValue("")) }
+    val passwordConfirm = remember { mutableStateOf(TextFieldValue("")) }
+    var errorMessage by remember { mutableStateOf("") }
+    var showCharsPassword by remember { mutableStateOf(false) }
+    var showCharsPasswordConfirm by remember { mutableStateOf(false) }
+    val keyboardController = LocalSoftwareKeyboardController.current
+
+    // File save launcher
+    val exportLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.CreateDocument("application/octet-stream"),
+    ) { uri ->
+        uri?.let {
+            scope.launch(Dispatchers.IO) {
+                isLoading = true
+                exportProgress = context.getString(R.string.preparing_export)
+
+                val result = AccountExportService.exportAllAccountsEncrypted(
+                    context = context,
+                    password = password.value.text,
+                    onProgress = { current, total ->
+                        exportProgress = context.getString(
+                            R.string.exporting_accounts_progress,
+                            current,
+                            total,
+                        )
+                    },
+                )
+
+                result.onSuccess { encryptedData ->
+                    try {
+                        context.contentResolver.openOutputStream(it)?.use { stream ->
+                            stream.write(encryptedData.toByteArray())
+                        }
+
+                        // Mark all accounts as backed up
+                        LocalPreferences.allSavedAccounts(context).forEach { accountInfo ->
+                            LocalPreferences.loadFromEncryptedStorage(context, accountInfo.npub)?.let { account ->
+                                account.didBackup = true
+                                LocalPreferences.saveToEncryptedStorage(context, account)
+                            }
+                        }
+
+                        launch(Dispatchers.Main) {
+                            Toast.makeText(
+                                context,
+                                context.getString(R.string.export_success, accountCount),
+                                Toast.LENGTH_LONG,
+                            ).show()
+                            isLoading = false
+                            exportProgress = ""
+                        }
+                    } catch (e: Exception) {
+                        launch(Dispatchers.Main) {
+                            Toast.makeText(
+                                context,
+                                context.getString(R.string.export_failed, e.message),
+                                Toast.LENGTH_LONG,
+                            ).show()
+                            isLoading = false
+                            exportProgress = ""
+                        }
+                    }
+                }.onFailure { e ->
+                    launch(Dispatchers.Main) {
+                        Toast.makeText(
+                            context,
+                            context.getString(R.string.export_failed, e.message),
+                            Toast.LENGTH_LONG,
+                        ).show()
+                        isLoading = false
+                        exportProgress = ""
+                    }
+                }
+            }
+        }
+    }
+
+    val keyguardLauncher =
+        rememberLauncherForActivityResult(ActivityResultContracts.StartActivityForResult()) { result: ActivityResult ->
+            if (result.resultCode == Activity.RESULT_OK) {
+                showConfirmationDialog = true
+            }
+        }
+
+    Surface(
+        modifier = modifier.fillMaxSize(),
+    ) {
+        Column(
+            modifier = Modifier
+                .background(MaterialTheme.colorScheme.background)
+                .fillMaxSize()
+                .padding(16.dp),
+        ) {
+            if (isLoading) {
+                CenterCircularProgressIndicator(Modifier)
+                Text(
+                    text = exportProgress,
+                    style = MaterialTheme.typography.bodyMedium,
+                    modifier = Modifier
+                        .padding(top = 16.dp)
+                        .align(Alignment.CenterHorizontally),
+                )
+            } else {
+                // Security warning
+                val warningContent = stringResource(R.string.export_all_accounts_warning)
+                val astNode = remember {
+                    CommonmarkAstNodeParser(MarkdownParseOptions.MarkdownWithLinks).parse(warningContent)
+                }
+
+                RichText(
+                    style = RichTextStyle().resolveDefaults(),
+                    modifier = Modifier.padding(bottom = 16.dp),
+                ) {
+                    BasicMarkdown(astNode)
+                }
+
+                Text(
+                    text = stringResource(R.string.accounts_to_export, accountCount),
+                    style = MaterialTheme.typography.bodyLarge,
+                    modifier = Modifier.padding(bottom = 16.dp),
+                )
+
+                // Password input
+                OutlinedTextField(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .semantics {
+                            contentType = ContentType.Password
+                        },
+                    value = password.value,
+                    onValueChange = {
+                        password.value = it
+                        if (errorMessage.isNotEmpty()) {
+                            errorMessage = ""
+                        }
+                    },
+                    keyboardOptions = KeyboardOptions(
+                        autoCorrectEnabled = false,
+                        keyboardType = KeyboardType.Password,
+                        imeAction = ImeAction.Next,
+                    ),
+                    label = {
+                        Text(text = stringResource(R.string.encryption_password))
+                    },
+                    placeholder = {
+                        Text(text = stringResource(R.string.enter_strong_password))
+                    },
+                    trailingIcon = {
+                        IconButton(onClick = { showCharsPassword = !showCharsPassword }) {
+                            Icon(
+                                imageVector = if (showCharsPassword) Icons.Outlined.VisibilityOff else Icons.Outlined.Visibility,
+                                contentDescription = if (showCharsPassword) {
+                                    stringResource(R.string.hide_password)
+                                } else {
+                                    stringResource(R.string.show_password)
+                                },
+                            )
+                        }
+                    },
+                    visualTransformation = if (showCharsPassword) VisualTransformation.None else PasswordVisualTransformation(),
+                )
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                // Password confirmation
+                OutlinedTextField(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .semantics {
+                            contentType = ContentType.Password
+                        },
+                    value = passwordConfirm.value,
+                    onValueChange = {
+                        passwordConfirm.value = it
+                        if (errorMessage.isNotEmpty()) {
+                            errorMessage = ""
+                        }
+                    },
+                    keyboardOptions = KeyboardOptions(
+                        autoCorrectEnabled = false,
+                        keyboardType = KeyboardType.Password,
+                        imeAction = ImeAction.Done,
+                    ),
+                    keyboardActions = KeyboardActions(
+                        onDone = {
+                            keyboardController?.hide()
+                        },
+                    ),
+                    label = {
+                        Text(text = stringResource(R.string.confirm_password))
+                    },
+                    trailingIcon = {
+                        IconButton(onClick = { showCharsPasswordConfirm = !showCharsPasswordConfirm }) {
+                            Icon(
+                                imageVector = if (showCharsPasswordConfirm) Icons.Outlined.VisibilityOff else Icons.Outlined.Visibility,
+                                contentDescription = if (showCharsPasswordConfirm) {
+                                    stringResource(R.string.hide_password)
+                                } else {
+                                    stringResource(R.string.show_password)
+                                },
+                            )
+                        }
+                    },
+                    visualTransformation = if (showCharsPasswordConfirm) VisualTransformation.None else PasswordVisualTransformation(),
+                )
+
+                if (errorMessage.isNotBlank()) {
+                    Text(
+                        text = errorMessage,
+                        color = MaterialTheme.colorScheme.error,
+                        style = MaterialTheme.typography.bodySmall,
+                        modifier = Modifier.padding(top = 8.dp),
+                    )
+                }
+
+                Spacer(modifier = Modifier.weight(1f))
+
+                // Export button
+                AmberButton(
+                    modifier = Modifier.fillMaxWidth(),
+                    text = stringResource(R.string.export_all_accounts_button),
+                    onClick = {
+                        // Validate password
+                        when {
+                            password.value.text.isBlank() -> {
+                                errorMessage = context.getString(R.string.password_is_required)
+                            }
+                            password.value.text.length < 8 -> {
+                                errorMessage = context.getString(R.string.password_too_short)
+                            }
+                            password.value.text != passwordConfirm.value.text -> {
+                                errorMessage = context.getString(R.string.passwords_do_not_match)
+                            }
+                            else -> {
+                                // Require biometric authentication
+                                authenticate(
+                                    title = context.getString(R.string.export_all_accounts_title),
+                                    context = context,
+                                    keyguardLauncher = keyguardLauncher,
+                                    onApproved = {
+                                        showConfirmationDialog = true
+                                    },
+                                    onError = { _, message ->
+                                        scope.launch {
+                                            Toast.makeText(
+                                                context,
+                                                message,
+                                                Toast.LENGTH_SHORT,
+                                            ).show()
+                                        }
+                                    },
+                                )
+                            }
+                        }
+                    },
+                )
+            }
+        }
+    }
+
+    // Confirmation dialog
+    if (showConfirmationDialog) {
+        AlertDialog(
+            onDismissRequest = { showConfirmationDialog = false },
+            title = {
+                Text(text = stringResource(R.string.confirm_export_title))
+            },
+            text = {
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Text(
+                        text = stringResource(R.string.confirm_export_message, accountCount),
+                    )
+                    Text(
+                        text = stringResource(R.string.confirm_export_warning),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.error,
+                    )
+                }
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        showConfirmationDialog = false
+                        val timestamp = SimpleDateFormat("yyyyMMdd_HHmmss", Locale.US).format(Date())
+                        exportLauncher.launch("amber_backup_$timestamp.dat")
+                    },
+                ) {
+                    Text(text = stringResource(R.string.export))
+                }
+            },
+            dismissButton = {
+                TextButton(
+                    onClick = { showConfirmationDialog = false },
+                ) {
+                    Text(text = stringResource(R.string.cancel))
+                }
+            },
+        )
+    }
+}

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/navigation/Route.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/navigation/Route.kt
@@ -53,6 +53,12 @@ sealed class Route(
         icon = R.drawable.settings,
     )
 
+    data object ExportAllAccounts : Route(
+        title = Amber.instance.getString(R.string.export_all_accounts_title),
+        route = "ExportAllAccounts",
+        icon = R.drawable.settings,
+    )
+
     data object Logs : Route(
         title = Amber.instance.getString(R.string.logs),
         route = "Logs",
@@ -192,6 +198,7 @@ val routes = listOf(
     Route.Settings,
     Route.Permission,
     Route.AccountBackup,
+    Route.ExportAllAccounts,
     Route.Logs,
     Route.ActiveRelays,
     Route.Language,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -401,7 +401,24 @@
     <string name="new_app_description">Usually Nostr applications have a “Login with Amber” option that permits to use Amber as external signer; when you press that button Amber is launched and you are asked to approve some permissions.\n\nBut you have other options to use Amber:</string>
     <string name="add_a_new_application">Add a new application</string>
     <string name="account_backup">Account backup</string>
-    <string name="create_nsecbunker_description">To create a new nsecbunker you need to give it a name and select one or more relays, that’s all!</string>
+    <string name="export_all_accounts_title">Export All Accounts</string>
+    <string name="export_all_accounts_warning" tools:ignore="Typos">## IMPORTANT SECURITY NOTICE\n\nYou are about to export **ALL** your Amber accounts. This file will contain your private keys.\n\n- **Password protect** your export file with a strong password\n- **Store securely** - treat this like your wallet\n- **Never share** with anyone\n- **Delete** from your device after storing safely\n\n**Anyone with access to this file can control ALL your accounts!**</string>
+    <string name="accounts_to_export">Accounts to export: %d</string>
+    <string name="encryption_password">Encryption Password</string>
+    <string name="enter_strong_password">Enter a strong password (min 8 characters)</string>
+    <string name="confirm_password">Confirm Password</string>
+    <string name="password_too_short">Password must be at least 8 characters</string>
+    <string name="passwords_do_not_match">Passwords do not match</string>
+    <string name="export_all_accounts_button">Export All Accounts</string>
+    <string name="preparing_export">Preparing export...</string>
+    <string name="exporting_accounts_progress">Exporting account %1$d of %2$d...</string>
+    <string name="export_success">Successfully exported %d accounts</string>
+    <string name="export_failed">Export failed: %s</string>
+    <string name="confirm_export_title">Confirm Export</string>
+    <string name="confirm_export_message">You are about to export %d accounts to an encrypted file.</string>
+    <string name="confirm_export_warning">This file will contain all your private keys. Store it securely!</string>
+    <string name="export">Export</string>
+    <string name="create_nsecbunker_description">To create a new nsecbunker you need to give it a name and select one or more relays, that\'s all!</string>
     <string name="create">Create</string>
     <string name="name">Name</string>
     <string name="no_relays_added">No relays added</string>


### PR DESCRIPTION
# Export All Accounts

Closes #237

## Changes

- Added "Export All Accounts" option in Settings
- Exports all account keys to encrypted JSON file
- Password protection with NIP-49 encryption
- Biometric authentication required
- File saved with timestamp: `amber_backup_YYYYMMDD_HHMMSS.dat`

## Files

- `AccountExport.kt` - Data models for export
- `AccountExportService.kt` - Export logic with encryption
- `ExportAllAccountsScreen.kt` - UI with security warnings
- Updated Settings, Routes, and MainScreen

## Testing

Tested with multiple accounts on Android device. Export and file save working correctly.

<img width="300" height="600" alt="image" src="https://github.com/user-attachments/assets/52885af7-0c1f-4d2e-95e8-f1bce0b6b0cb" />
<img width="300" height="600" alt="image" src="https://github.com/user-attachments/assets/1fc4fc11-6806-4591-9b8d-5b4d6626c866" />
<img width="300" height="600" alt="image" src="https://github.com/user-attachments/assets/56b99ef3-b24e-4411-a099-af7cd0c43ec5" />
<img width="300" height="600" alt="image" src="https://github.com/user-attachments/assets/b58b106f-9824-4c2c-8b91-e9b09a859cbd" />
<img width="300" height="600" alt="image" src="https://github.com/user-attachments/assets/891b6fce-2951-406e-af05-41dd91a581d1" />
