### PR TITLE
Improve relay reconnection handling and network change detection

### DIFF
--- a/app/src/main/java/com/greenart7c3/nostrsigner/Amber.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/Amber.kt
@@ -107,10 +107,6 @@ class Amber :
 
     val relayStats = RelayStats(client)
 
-    // TODO: I assume you want this sub to stay active in the background
-    // TODO: Find a way to call either client.reconnect or notificationSubscription.updateFilters() to
-    // keep the filter live when the relay inevitably disconnects. NostrClient doesn't try to reconnect
-    // unless the filter is refreshed or a new event is sent.
     val notificationSubscription = NotificationSubscription(client, this)
 
     // This runs on the foreground only

--- a/app/src/main/java/com/greenart7c3/nostrsigner/relays/NostrClientLoggerListener.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/relays/NostrClientLoggerListener.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.app.NotificationManager
 import android.content.Context
 import com.greenart7c3.nostrsigner.Amber
+import com.greenart7c3.nostrsigner.BuildFlavorChecker
 import com.greenart7c3.nostrsigner.LocalPreferences
 import com.greenart7c3.nostrsigner.database.LogEntity
 import com.greenart7c3.nostrsigner.service.NotificationUtils.sendErrorNotification
@@ -14,6 +15,8 @@ import com.vitorpamplona.quartz.nip01Core.relay.commands.toClient.Message
 import com.vitorpamplona.quartz.nip01Core.relay.commands.toClient.OkMessage
 import com.vitorpamplona.quartz.nip01Core.relay.commands.toRelay.Command
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 object AmberListenerSingleton {
@@ -45,6 +48,8 @@ class NostrClientLoggerListener(
     val stats: AmberRelayStats,
     val scope: CoroutineScope,
 ) : IRelayClientListener {
+    private var reconnectJob: Job? = null
+
     override fun onCannotConnect(relay: IRelayClient, errorMessage: String) {
         scope.launch {
             LocalPreferences.currentAccount(context)?.let { account ->
@@ -123,6 +128,13 @@ class NostrClientLoggerListener(
                         time = System.currentTimeMillis(),
                     ),
                 )
+            }
+        }
+        reconnectJob?.cancel()
+        reconnectJob = scope.launch {
+            delay(5_000)
+            if (!BuildFlavorChecker.isOfflineFlavor() && !Amber.instance.settings.killSwitch.value) {
+                Amber.instance.reconnect()
             }
         }
         super.onDisconnected(relay)

--- a/app/src/main/java/com/greenart7c3/nostrsigner/service/ConnectivityService.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/service/ConnectivityService.kt
@@ -54,6 +54,8 @@ class ConnectivityService : Service() {
                 if (BuildFlavorChecker.isOfflineFlavor()) return
                 if (Amber.instance.settings.killSwitch.value) return
 
+                val changed = Amber.instance.updateNetworkCapabilities(networkCapabilities)
+
                 scope.launch(Dispatchers.IO) {
                     Log.d(
                         "ServiceManager NetworkCallback",
@@ -62,7 +64,9 @@ class ConnectivityService : Service() {
                     if (!Amber.instance.client.isActive()) {
                         Amber.instance.client.connect()
                     }
-                    Amber.instance.client.reconnect(true)
+                    if (changed) {
+                        Amber.instance.client.reconnect(true)
+                    }
                 }
             }
 
@@ -143,7 +147,7 @@ class ConnectivityService : Service() {
                     }
                 },
                 5000,
-                61000,
+                30000,
             )
         }
         super.onCreate()


### PR DESCRIPTION
## Summary
This PR improves the relay connection management by implementing smarter reconnection logic and optimizing network change detection to avoid unnecessary reconnections.

## Key Changes
- **NostrClientLoggerListener**: Added delayed reconnection logic on disconnect
  - Implements a 5-second delay before attempting to reconnect
  - Cancels any pending reconnection job before scheduling a new one
  - Respects offline flavor and kill switch settings before reconnecting

- **ConnectivityService**: Optimized network capability change handling
  - Added `updateNetworkCapabilities()` call to track network changes
  - Only triggers reconnection if network capabilities actually changed
  - Reduced reconnection check interval from 61 seconds to 30 seconds

- **Amber.kt**: Removed obsolete TODO comments
  - Cleaned up outdated comments about reconnection strategy that are now addressed by the new implementation

## Implementation Details
The reconnection strategy now uses a debounced approach with a 5-second delay, preventing rapid reconnection attempts when the relay disconnects. The network change detection is more intelligent—it only reconnects when the actual network capabilities change, reducing unnecessary connection churn. These changes work together to provide more stable relay connections while respecting the app's offline mode and kill switch settings.

https://claude.ai/code/session_017tgJoYh6CKL5mVTCTE5qj8