### PR TITLE
Configure Ubuntu Java trust store for Gradle JVM proxy TLS

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -51,6 +51,12 @@ systemProp.http.proxyPassword=$pass
 # Override nonProxyHosts: route all external traffic (incl. *.google.com) through proxy
 systemProp.http.nonProxyHosts=localhost|127.0.0.1
 systemProp.https.nonProxyHosts=localhost|127.0.0.1
+# Use Ubuntu's Java trust store (includes Anthropic TLS inspection CA) for all Gradle JVMs.
+# This is needed because Gradle may download a custom JDK (e.g. JetBrains) whose bundled
+# trust store doesn't include the Anthropic CA, causing TLS inspection failures.
+systemProp.javax.net.ssl.trustStore=/etc/ssl/certs/java/cacerts
+systemProp.javax.net.ssl.trustStoreType=JKS
+systemProp.javax.net.ssl.trustStorePassword=changeit
 EOF
 
   echo "Configured Maven/Gradle proxy from HTTPS_PROXY" >&2


### PR DESCRIPTION
## Summary
Configure Gradle to use Ubuntu's system Java trust store for all JVM instances, ensuring TLS inspection certificates (including Anthropic's CA) are available when Gradle downloads custom JDKs.

## Changes
- Added Java trust store configuration properties to the Gradle proxy setup in `session-start.sh`:
  - `javax.net.ssl.trustStore`: Points to Ubuntu's system cacerts at `/etc/ssl/certs/java/cacerts`
  - `javax.net.ssl.trustStoreType`: Set to JKS (Java KeyStore) format
  - `javax.net.ssl.trustStorePassword`: Uses default JKS password `changeit`

## Details
When Gradle downloads custom JDKs (e.g., JetBrains runtime), those bundled JVMs have their own isolated trust stores that don't include the Anthropic TLS inspection CA certificate. By explicitly configuring all Gradle JVMs to use the system trust store, we ensure TLS inspection works correctly for all Java processes spawned during the build, preventing certificate validation failures.

https://claude.ai/code/session_01761JmhtmzsagWwKw2DYyi3