### PR TITLE
Fix layout scrolling behavior for multi-event incoming requests

### DIFF
--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/MainScreen.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/MainScreen.kt
@@ -358,7 +358,15 @@ fun MainScreen(
                     content = {
                         val scrollState = rememberScrollState()
 
-                        val modifier = if (intents.isEmpty() || packageName == null || destinationRoute != Route.IncomingRequest.route) {
+                        val isMultiEvent = (intents.size > 1) || (bunkerRequests.size > 1)
+                        val modifier = if (isMultiEvent && destinationRoute == Route.IncomingRequest.route) {
+                            // Multi-event screens manage internal scrolling with weight(1f); outer
+                            // verticalScroll would give unbounded height breaking the layout on small screens.
+                            Modifier
+                                .fillMaxSize()
+                                .padding(padding)
+                                .padding(horizontal = verticalPadding)
+                        } else if (intents.isEmpty() || packageName == null || destinationRoute != Route.IncomingRequest.route) {
                             Modifier
                                 .fillMaxSize()
                                 .padding(padding)


### PR DESCRIPTION
## Summary
Fixed a layout issue where multi-event incoming request screens were not properly handling scroll behavior, which could cause layout problems on small screens.

## Key Changes
- Added detection for multi-event scenarios (multiple intents or bunker requests)
- Refactored modifier logic to handle multi-event incoming request screens separately
- Multi-event screens now use `fillMaxSize()` with padding instead of `verticalScroll`, allowing internal weight-based scrolling to work correctly
- This prevents unbounded height issues that were breaking layouts on smaller devices

## Implementation Details
The change introduces an `isMultiEvent` flag that checks if there are multiple intents or bunker requests. When this condition is true AND the destination is an incoming request screen, the outer modifier no longer applies `verticalScroll`. Instead, it relies on the internal layout's `weight(1f)` mechanism to manage scrolling, which provides better behavior on constrained screen sizes.

https://claude.ai/code/session_012RtPkrkHaFroq4WodsdETV