### PR TITLE
Fix notification intent flags and task affinity for SignerActivity

### DIFF
--- a/app/src/free/AndroidManifest.xml
+++ b/app/src/free/AndroidManifest.xml
@@ -39,6 +39,7 @@
         <activity
             android:name=".SignerActivity"
             android:exported="true"
+            android:taskAffinity=""
             android:theme="@style/Theme.NostrSigner.Modal">
             <intent-filter>
                 <action android:name="com.greenart7c3.nostrsigner.MAIN_ACTIVITY" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -71,6 +71,7 @@
         <activity
             android:name=".SignerActivity"
             android:exported="true"
+            android:taskAffinity=""
             android:theme="@style/Theme.NostrSigner.Modal">
             <intent-filter>
                 <action android:name="com.greenart7c3.nostrsigner.MAIN_ACTIVITY" />

--- a/app/src/main/java/com/greenart7c3/nostrsigner/service/NotificationUtils.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/service/NotificationUtils.kt
@@ -151,7 +151,7 @@ object NotificationUtils {
 
         val contentIntent = Intent(applicationContext, SignerActivity::class.java)
         contentIntent.putExtra("route", Route.IncomingRequest.route)
-        contentIntent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP)
+        contentIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP)
         val contentPendingIntent =
             PendingIntent.getActivity(
                 applicationContext,


### PR DESCRIPTION
## Summary
This PR fixes the notification intent handling for incoming requests by adding the `FLAG_ACTIVITY_NEW_TASK` flag and configuring `SignerActivity` with an empty task affinity to ensure proper activity stack management.

## Key Changes
- **NotificationUtils.kt**: Added `Intent.FLAG_ACTIVITY_NEW_TASK` flag to the content intent when launching `SignerActivity` from notifications. This ensures the activity is launched in a new task when invoked from a notification context.
- **AndroidManifest.xml** (both free and main variants): Added `android:taskAffinity=""` attribute to `SignerActivity` declaration. This assigns the activity to the base application task, preventing it from creating or using separate task stacks.

## Implementation Details
The combination of these changes ensures that:
1. Notifications properly launch `SignerActivity` in a new task context when the app is not already running
2. The activity respects the single-top and clear-top flags to avoid duplicate instances
3. The empty task affinity keeps the activity within the main application task stack, improving task management and user experience when navigating between the notification and the app

https://claude.ai/code/session_01XnocJeiPCgdXRq7syUxwpG