### PR TITLE
Reorder notification filter update in ConnectivityService

### DIFF
--- a/app/src/main/java/com/greenart7c3/nostrsigner/service/ConnectivityService.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/service/ConnectivityService.kt
@@ -137,12 +137,11 @@ class ConnectivityService : Service() {
                         if (Amber.instance.settings.killSwitch.value) return
 
                         scope.launch {
-                            Amber.instance.notificationSubscription.updateFilter()
-
                             if (!Amber.instance.client.isActive()) {
                                 Amber.instance.client.connect()
                             }
                             Amber.instance.client.reconnect(true)
+                            Amber.instance.notificationSubscription.updateFilter()
                         }
                     }
                 },


### PR DESCRIPTION
## Summary
Reordered the execution of notification filter update to occur after client connection/reconnection in the ConnectivityService.

## Key Changes
- Moved `Amber.instance.notificationSubscription.updateFilter()` to execute after `Amber.instance.client.reconnect(true)` instead of before client connection operations
- This ensures the notification filter is updated only after the client has successfully connected/reconnected

## Implementation Details
The change ensures proper sequencing of operations:
1. Check if client is active, connect if needed
2. Reconnect the client
3. Update the notification subscription filter

This ordering prevents potential race conditions where the filter might be updated before the client connection is fully established.

https://claude.ai/code/session_01AyGqR5D6Kt5WHyr4uriHFN