### PR TITLE
Replace deprecated usesCleartextTraffic with network security config

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,7 +27,7 @@
         android:localeConfig="@xml/locales_config"
         android:supportsRtl="true"
         android:theme="@style/Theme.NostrSigner"
-        android:usesCleartextTraffic="true"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:windowSoftInputMode="adjustResize"
         tools:targetApi="33">
         <receiver

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <base-config cleartextTrafficPermitted="true" />
+</network-security-config>

--- a/app/src/offline/AndroidManifest.xml
+++ b/app/src/offline/AndroidManifest.xml
@@ -14,7 +14,7 @@
         android:launchMode="singleTop"
         android:supportsRtl="true"
         android:theme="@style/Theme.NostrSigner"
-        android:usesCleartextTraffic="true"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:windowSoftInputMode="adjustResize"
         tools:targetApi="33">
 


### PR DESCRIPTION
## Summary
Replaced the deprecated `android:usesCleartextTraffic` attribute with a proper network security configuration file, following Android best practices for managing cleartext traffic permissions.

## Key Changes
- Created new `network_security_config.xml` file that explicitly permits cleartext traffic at the base configuration level
- Updated `app/src/main/AndroidManifest.xml` to reference the new network security config instead of using the deprecated attribute
- Updated `app/src/offline/AndroidManifest.xml` to reference the new network security config instead of using the deprecated attribute

## Implementation Details
The `network_security_config.xml` uses the `<base-config>` element with `cleartextTrafficPermitted="true"` to maintain the same cleartext traffic behavior while using the modern, recommended approach. This configuration file provides better granularity for managing security policies and is the preferred method for handling cleartext traffic in modern Android applications.

https://claude.ai/code/session_01RBEyGLZ1hh38BJAhV54tYz