### PR TITLE
Add content field to history search queries

### DIFF
--- a/app/src/main/java/com/greenart7c3/nostrsigner/database/HistoryDao.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/database/HistoryDao.kt
@@ -18,7 +18,7 @@ interface HistoryDao {
     @Query("SELECT * FROM history where pkKey = :pk ORDER BY time DESC")
     fun getAllHistoryPaging(pk: String): PagingSource<Int, HistoryEntity>
 
-    @Query("SELECT * FROM history where (kind = :query OR LOWER(type) LIKE '%' || :query || '%' OR LOWER(translatedPermission) LIKE '%' || :query || '%') AND pkKey = :pk ORDER BY time DESC")
+    @Query("SELECT * FROM history where (kind = :query OR LOWER(type) LIKE '%' || :query || '%' OR LOWER(translatedPermission) LIKE '%' || :query || '%' OR LOWER(content) LIKE '%' || :query || '%') AND pkKey = :pk ORDER BY time DESC")
     fun searchAllHistoryPaging(pk: String, query: String): PagingSource<Int, HistoryEntity>
 
     @Query("SELECT * FROM history ORDER BY time DESC")
@@ -28,7 +28,8 @@ interface HistoryDao {
         """
     SELECT * FROM history
     WHERE (kind = :query OR LOWER(type) LIKE '%' || :query || '%'
-    OR LOWER(translatedPermission) LIKE '%' || :query || '%')
+    OR LOWER(translatedPermission) LIKE '%' || :query || '%'
+    OR LOWER(content) LIKE '%' || :query || '%')
     ORDER BY time DESC
     """,
     )


### PR DESCRIPTION
## Summary
Enhanced the history search functionality to include the `content` field in search results, allowing users to find history entries by searching their content in addition to existing search criteria.

## Key Changes
- Updated `searchAllHistoryPaging()` query to include `LOWER(content)` in the search filter
- Updated `searchHistory()` query to include `LOWER(content)` in the search filter
- Both queries now search across: kind, type, translatedPermission, and content fields

## Implementation Details
The changes add `OR LOWER(content) LIKE '%' || :query || '%'` to the WHERE clause of both search queries, enabling full-text search across the content field alongside the existing search parameters. This provides users with more comprehensive search results when looking through their history.

https://claude.ai/code/session_01YNoZjniG6LgCjdPkcGRn1Q