### PR TITLE
Remove Java 21 requirement and unused okhttp coroutines dependency

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -148,11 +148,6 @@ android {
         }
     }
 
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_21
-        targetCompatibility JavaVersion.VERSION_21
-    }
-
     buildFeatures {
         compose = true
         buildConfig = true
@@ -245,7 +240,6 @@ dependencies {
     implementation libs.coil.svg
     // enables network for coil
     implementation libs.coil.okhttp
-    implementation libs.okhttpCoroutines
 
     implementation libs.storage
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ org.gradle.jvmargs=-Xms1024m -Xmx4096m -Dfile.encoding=UTF-8
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
-# org.gradle.parallel=true
+org.gradle.parallel=true
 # AndroidX package structure to make it clearer which packages are bundled with the
 # Android operating system, and which are packaged with your app's APK
 # https://developer.android.com/topic/libraries/support-library/androidx-rn
@@ -23,3 +23,4 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 android.enableR8.fullMode=true
 org.gradle.configuration-cache=true
+org.gradle.caching=true


### PR DESCRIPTION
## Summary
This PR removes the explicit Java 21 compiler target requirement and cleans up an unused dependency, while also enabling Gradle build optimizations.

## Key Changes
- **Removed Java 21 compilation requirement**: Deleted the `compileOptions` block that enforced `JavaVersion.VERSION_21` for both source and target compatibility, allowing the project to use a lower Java version
- **Removed unused dependency**: Deleted the `libs.okhttpCoroutines` implementation dependency that was not being used in the codebase
- **Enabled Gradle build optimizations**: 
  - Enabled parallel builds with `org.gradle.parallel=true`
  - Enabled build caching with `org.gradle.caching=true`

## Implementation Details
These changes reduce the project's Java version requirement, eliminate unused dependencies, and improve build performance through Gradle's parallel execution and caching mechanisms.

https://claude.ai/code/session_01AtWgST4nDyCNqtoEz7otfD