### PR TITLE
Add CI workflow to verify offline build has no INTERNET permission

### DIFF
--- a/.github/workflows/check-offline-permissions.yml
+++ b/.github/workflows/check-offline-permissions.yml
@@ -1,0 +1,57 @@
+name: Check Offline Build Permissions
+
+on:
+  pull_request:
+    branches: [master]
+  push:
+    branches: [master]
+
+jobs:
+  check-offline-permissions:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: 21
+
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Create keystore.properties
+        run: touch keystore.properties
+
+      - name: Generate merged manifest for offline build
+        run: ./gradlew processOfflineDebugManifest --no-daemon
+
+      - name: Check for INTERNET permission in offline merged manifest
+        run: |
+          MANIFEST=$(find app/build/intermediates/merged_manifests -name "AndroidManifest.xml" | grep -i offline | head -1)
+          if [ -z "$MANIFEST" ]; then
+            echo "ERROR: Could not find merged manifest for offline build"
+            exit 1
+          fi
+          echo "Checking: $MANIFEST"
+          if grep -q 'android.permission.INTERNET' "$MANIFEST"; then
+            echo ""
+            echo "ERROR: android.permission.INTERNET found in offline build manifest!"
+            echo "The offline flavor must not include INTERNET permission."
+            echo ""
+            echo "Offending lines:"
+            grep 'android.permission.INTERNET' "$MANIFEST"
+            exit 1
+          else
+            echo "OK: No INTERNET permission in offline build manifest"
+          fi


### PR DESCRIPTION
## Summary
This PR adds a GitHub Actions workflow to automatically verify that the offline build flavor does not include the `android.permission.INTERNET` permission.

## Key Changes
- Added `.github/workflows/check-offline-permissions.yml` workflow that:
  - Runs on pull requests and pushes to the master branch
  - Sets up JDK 21 and caches Gradle dependencies
  - Generates the merged manifest for the offline debug build variant
  - Validates that the `android.permission.INTERNET` permission is not present in the offline build's manifest
  - Fails the build with a clear error message if the permission is found

## Implementation Details
- The workflow uses `processOfflineDebugManifest` Gradle task to generate the merged manifest
- It searches for the manifest in the build intermediates directory with an offline-specific filter
- The check uses `grep` to detect the presence of `android.permission.INTERNET` in the manifest
- Provides helpful error output showing which lines contain the forbidden permission if found
- Includes a 20-minute timeout to prevent hanging builds

https://claude.ai/code/session_01CrqXjZyMNnBkPtxjW9tTvR