### PR TITLE
Update foreground service to use ServiceCompat for Android 14+ compatibility

### DIFF
--- a/app/src/main/java/com/greenart7c3/nostrsigner/service/ConnectivityService.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/service/ConnectivityService.kt
@@ -2,11 +2,14 @@ package com.greenart7c3.nostrsigner.service
 
 import android.app.Service
 import android.content.Intent
+import android.content.pm.ServiceInfo
 import android.net.ConnectivityManager
 import android.net.Network
 import android.net.NetworkCapabilities
+import android.os.Build
 import android.os.IBinder
 import android.util.Log
+import androidx.core.app.ServiceCompat
 import com.greenart7c3.nostrsigner.Amber
 import com.greenart7c3.nostrsigner.BuildFlavorChecker
 import com.greenart7c3.nostrsigner.LocalPreferences
@@ -169,7 +172,18 @@ class ConnectivityService : Service() {
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         Log.d(Amber.TAG, "onStartCommand")
-        startForeground(1, Amber.instance.stats.createForegroundNotification())
+        val foregroundServiceType =
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE
+            } else {
+                0
+            }
+        ServiceCompat.startForeground(
+            this,
+            1,
+            Amber.instance.stats.createForegroundNotification(),
+            foregroundServiceType,
+        )
         return START_STICKY
     }
 }


### PR DESCRIPTION
## Summary
Updated the `ConnectivityService` to use `ServiceCompat.startForeground()` with proper foreground service type declaration for Android 14 (UPSIDE_DOWN_CAKE) and later versions.

## Key Changes
- Replaced direct `startForeground()` call with `ServiceCompat.startForeground()` from AndroidX Core library
- Added conditional foreground service type declaration:
  - Uses `ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE` on Android 14+
  - Falls back to `0` (no specific type) on earlier versions
- Added necessary imports for `ServiceInfo`, `Build`, and `ServiceCompat`

## Implementation Details
The change ensures compliance with Android 14's foreground service requirements, which mandate explicit declaration of foreground service types. The `SPECIAL_USE` type is appropriate for this connectivity monitoring service. The implementation maintains backward compatibility with earlier Android versions by conditionally setting the service type based on the SDK version.

https://claude.ai/code/session_014KKpPSKZSnFrZf6tmMdCiz