### PR TITLE
Improve app startup performance by deferring Tor initialization

### DIFF
--- a/app/src/main/java/com/greenart7c3/nostrsigner/Amber.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/Amber.kt
@@ -262,24 +262,10 @@ class Amber :
                     LocalPreferences.switchToAccount(this@Amber, LocalPreferences.allSavedAccounts(this@Amber).first().npub)
                 }
                 LocalPreferences.reloadApp()
+
+                // Start Tor immediately in the background without blocking app startup
                 if (settings.torMode == TorMode.BUILTIN && !BuildFlavorChecker.isOfflineFlavor()) {
-                    var attempt = 0
-                    while (!TorManager.isRunning.value) {
-                        if (attempt > 0) {
-                            TorManager.showRetrying()
-                            TorManager.stop()
-                            delay(3000)
-                        }
-                        TorManager.start(this@Amber, applicationIOScope)
-                        attempt++
-                        withTimeoutOrNull(120_000L) {
-                            TorManager.isRunning.first { it }
-                        }
-                    }
-                }
-                checkForNewRelaysAndUpdateAllFilters(true)
-                if (settings.killSwitch.value) {
-                    disconnectIntentionally()
+                    TorManager.start(this@Amber, applicationIOScope)
                 }
 
                 launch(Dispatchers.Main) {
@@ -307,13 +293,43 @@ class Amber :
                         }
                     })
                 }
+
+                // Signal app startup complete so UI shows immediately
                 isStartingApp.value = false
+
+                // Wait for Tor to be ready before establishing relay connections
+                if (settings.torMode == TorMode.BUILTIN && !BuildFlavorChecker.isOfflineFlavor()) {
+                    var attempt = 0
+                    while (!TorManager.isRunning.value) {
+                        if (attempt > 0) {
+                            TorManager.showRetrying()
+                            TorManager.stop()
+                            delay(3000)
+                            TorManager.start(this@Amber, applicationIOScope)
+                        }
+                        attempt++
+                        withTimeoutOrNull(120_000L) {
+                            TorManager.isRunning.first { it }
+                        }
+                    }
+                }
+
+                checkForNewRelaysAndUpdateAllFilters(true)
+                if (settings.killSwitch.value) {
+                    disconnectIntentionally()
+                }
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to run migrations", e)
                 isStartingApp.value = false
                 if (e is CancellationException) throw e
                 if (e is FailedMigrationException) throw e
             }
+        }
+    }
+
+    suspend fun waitForTorIfNeeded() {
+        if (settings.torMode == TorMode.BUILTIN && !BuildFlavorChecker.isOfflineFlavor()) {
+            TorManager.isRunning.first { it }
         }
     }
 

--- a/app/src/main/java/com/greenart7c3/nostrsigner/service/ConnectivityService.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/service/ConnectivityService.kt
@@ -93,6 +93,8 @@ class ConnectivityService : Service() {
             while (Amber.instance.isStartingAppState.value) {
                 delay(1000)
             }
+            // Wait for Tor to be ready before connecting (if using built-in Tor)
+            Amber.instance.waitForTorIfNeeded()
             if (!BuildFlavorChecker.isOfflineFlavor() && !Amber.instance.settings.killSwitch.value) {
                 Amber.instance.client.connect()
                 Amber.instance.applicationIOScope.launch {


### PR DESCRIPTION
## Summary
Refactored the app startup flow to improve perceived performance by showing the UI immediately while Tor initialization happens in the background. This prevents the app from blocking on Tor startup, which can take several seconds.

## Key Changes
- **Non-blocking Tor startup**: Moved Tor initialization to start immediately in the background without waiting for it to be ready during app startup
- **Deferred Tor readiness check**: Moved the blocking Tor readiness wait to after `isStartingApp` is set to false, allowing the UI to render while Tor initializes
- **New helper method**: Added `waitForTorIfNeeded()` suspend function to encapsulate Tor readiness logic for reuse
- **ConnectivityService integration**: Updated `ConnectivityService` to wait for Tor readiness before attempting relay connections, ensuring proper initialization order

## Implementation Details
- Tor is now started immediately in a background coroutine without blocking
- The app UI becomes interactive before Tor finishes initializing
- Relay connections are deferred until after Tor is confirmed ready (via `waitForTorIfNeeded()`)
- The retry logic for Tor startup remains intact but executes after UI is shown
- Kill switch and relay filter checks still execute after Tor is ready

https://claude.ai/code/session_01QfnSvDcaWayKwrAM71QUeA