### PR TITLE
Expand offline build permission checks to include network permissions

### DIFF
--- a/.github/workflows/check-offline-permissions.yml
+++ b/.github/workflows/check-offline-permissions.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Generate merged manifest for offline build
         run: ./gradlew processOfflineDebugManifest --no-daemon
 
-      - name: Check for INTERNET permission in offline merged manifest
+      - name: Check for network permissions in offline merged manifest
         run: |
           MANIFEST=$(find app/build/intermediates/merged_manifests -name "AndroidManifest.xml" | grep -i offline | head -1)
           if [ -z "$MANIFEST" ]; then
@@ -44,14 +44,18 @@ jobs:
             exit 1
           fi
           echo "Checking: $MANIFEST"
-          if grep -q 'android.permission.INTERNET' "$MANIFEST"; then
-            echo ""
-            echo "ERROR: android.permission.INTERNET found in offline build manifest!"
-            echo "The offline flavor must not include INTERNET permission."
-            echo ""
-            echo "Offending lines:"
-            grep 'android.permission.INTERNET' "$MANIFEST"
-            exit 1
-          else
-            echo "OK: No INTERNET permission in offline build manifest"
-          fi
+          FAILED=0
+          for PERMISSION in android.permission.INTERNET android.permission.CHANGE_NETWORK_STATE android.permission.ACCESS_NETWORK_STATE; do
+            if grep -q "$PERMISSION" "$MANIFEST"; then
+              echo ""
+              echo "ERROR: $PERMISSION found in offline build manifest!"
+              echo "The offline flavor must not include network permissions."
+              echo ""
+              echo "Offending lines:"
+              grep "$PERMISSION" "$MANIFEST"
+              FAILED=1
+            else
+              echo "OK: No $PERMISSION in offline build manifest"
+            fi
+          done
+          exit $FAILED


### PR DESCRIPTION
## Summary
Enhanced the offline build manifest validation to check for multiple network-related permissions, not just `INTERNET`. This ensures the offline flavor maintains stricter isolation from network access.

## Key Changes
- Expanded permission check from single `INTERNET` permission to three network permissions:
  - `android.permission.INTERNET`
  - `android.permission.CHANGE_NETWORK_STATE`
  - `android.permission.ACCESS_NETWORK_STATE`
- Refactored check logic to loop through all permissions and report all violations
- Updated error messaging to reflect the broader scope of network permission restrictions
- Changed exit behavior to fail if any network permission is found (using `FAILED` flag)

## Implementation Details
- The check now iterates through all three permissions and collects failures rather than exiting on the first violation
- Each permission is checked independently, allowing the workflow to report all offending permissions in a single run
- The final exit code is set to 1 if any network permission was found, 0 if none were detected
- Updated step name and error messages to reflect the broader "network permissions" scope

https://claude.ai/code/session_01AoRYewAhR6nhY6hGJhLPem