### PR TITLE
Clean up stale notification subscriptions for deleted accounts

### DIFF
--- a/app/src/main/java/com/greenart7c3/nostrsigner/service/NotificationSubscription.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/service/NotificationSubscription.kt
@@ -72,6 +72,8 @@ class NotificationSubscription(
      */
     suspend fun updateFilter() {
         if (BuildFlavorChecker.isOfflineFlavor()) return
+        val activeSubKeys = mutableSetOf<String>()
+
         LocalPreferences.allAccounts(appContext).forEach { account ->
             val since = computeSince()
 
@@ -83,6 +85,7 @@ class NotificationSubscription(
             for (conn in connectionsWithLocalKey) {
                 val connPubKey = conn.localPubKey
                 val subKey = "${account.hexKey}_$connPubKey"
+                activeSubKeys.add(subKey)
                 if (!subIds.containsKey(subKey)) {
                     subIds[subKey] = UUID.randomUUID().toString()
                 }
@@ -104,6 +107,7 @@ class NotificationSubscription(
 
             // Main account subscription only for legacy connections (no localKey)
             if (hasLegacyConnections) {
+                activeSubKeys.add(account.hexKey)
                 if (!subIds.containsKey(account.hexKey)) {
                     subIds[account.hexKey] = UUID.randomUUID().toString()
                 }
@@ -121,6 +125,14 @@ class NotificationSubscription(
                         )
                     },
                 )
+            }
+        }
+
+        // Unsubscribe from any subscriptions belonging to deleted applications
+        val staleSubKeys = subIds.keys.filter { it !in activeSubKeys }
+        for (subKey in staleSubKeys) {
+            subIds.remove(subKey)?.let { subId ->
+                client.unsubscribe(subId)
             }
         }
     }


### PR DESCRIPTION
## Summary
This change adds cleanup logic to remove stale notification subscriptions when accounts or connections are deleted, preventing orphaned subscriptions from accumulating over time.

## Key Changes
- Track active subscription keys during the filter update process by maintaining an `activeSubKeys` set
- Add subscription keys for all active account-connection pairs to the tracking set
- Add subscription keys for legacy connections (accounts without local keys) to the tracking set
- Identify stale subscriptions by comparing tracked active keys against all stored subscription IDs
- Unsubscribe from and remove any subscriptions that are no longer active (belonging to deleted accounts or connections)

## Implementation Details
The cleanup logic runs at the end of `updateFilter()` after all active subscriptions have been identified and added to `activeSubKeys`. Any subscription ID in `subIds` that doesn't appear in `activeSubKeys` is considered stale and is removed from the map while also sending an unsubscribe request to the client. This ensures that deleted accounts and their associated connections don't leave behind orphaned subscriptions.

https://claude.ai/code/session_01B9zRZR3LyJejjXcMpd5N3e