### PR TITLE
Add periodic update check worker for app updates

### DIFF
--- a/app/src/main/java/com/greenart7c3/nostrsigner/Amber.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/Amber.kt
@@ -13,8 +13,10 @@ import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ProcessLifecycleOwner
+import androidx.work.Constraints
 import androidx.work.ExistingPeriodicWorkPolicy
 import androidx.work.ExistingWorkPolicy
+import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
@@ -46,6 +48,7 @@ import com.greenart7c3.nostrsigner.service.ConnectivityService
 import com.greenart7c3.nostrsigner.service.NotificationSubscription
 import com.greenart7c3.nostrsigner.service.ProfileSubscription
 import com.greenart7c3.nostrsigner.service.TorManager
+import com.greenart7c3.nostrsigner.service.UpdateCheckWorker
 import com.greenart7c3.nostrsigner.service.ZapstoreUpdater
 import com.greenart7c3.nostrsigner.service.crashreports.CrashReportCache
 import com.greenart7c3.nostrsigner.service.crashreports.UnexpectedCrashSaver
@@ -248,6 +251,27 @@ class Amber :
         )
     }
 
+    private fun startUpdateCheckAlarm() {
+        if (BuildFlavorChecker.isOfflineFlavor() || BuildConfig.IS_FDROID_BUILD) return
+
+        val workManager = WorkManager.getInstance(this)
+
+        val periodicRequest = PeriodicWorkRequestBuilder<UpdateCheckWorker>(1, TimeUnit.DAYS)
+            .addTag("updateCheckWork")
+            .setConstraints(
+                Constraints.Builder()
+                    .setRequiredNetworkType(NetworkType.CONNECTED)
+                    .build(),
+            )
+            .build()
+
+        workManager.enqueueUniquePeriodicWork(
+            "UpdateCheckWorker",
+            ExistingPeriodicWorkPolicy.KEEP,
+            periodicRequest,
+        )
+    }
+
     override fun onCreate() {
         super.onCreate()
 
@@ -265,6 +289,7 @@ class Amber :
         Log.d(TAG, "onCreate Amber")
 
         startCleanLogsAlarm()
+        startUpdateCheckAlarm()
 
         HttpClientManager.setDefaultUserAgent("Amber/${BuildConfig.VERSION_NAME}")
 

--- a/app/src/main/java/com/greenart7c3/nostrsigner/service/UpdateCheckWorker.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/service/UpdateCheckWorker.kt
@@ -1,0 +1,46 @@
+package com.greenart7c3.nostrsigner.service
+
+import android.content.Context
+import android.util.Log
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import com.greenart7c3.nostrsigner.Amber
+import com.greenart7c3.nostrsigner.BuildConfig
+import com.greenart7c3.nostrsigner.BuildFlavorChecker
+import kotlin.coroutines.cancellation.CancellationException
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withTimeoutOrNull
+
+private const val CHECK_TIMEOUT_MS = 30_000L
+
+class UpdateCheckWorker(appContext: Context, workerParams: WorkerParameters) : CoroutineWorker(appContext, workerParams) {
+
+    override suspend fun doWork(): Result {
+        if (BuildFlavorChecker.isOfflineFlavor() || BuildConfig.IS_FDROID_BUILD) return Result.success()
+
+        val amber = Amber.instance
+        if (!amber.settings.autoCheckUpdates) return Result.success()
+
+        val updater = amber.zapstoreUpdater ?: return Result.success()
+
+        // Wait for app initialization to complete before checking
+        amber.isStartingAppState.first { !it }
+
+        try {
+            amber.maybeCheckForUpdates()
+
+            // If a check was actually started, wait for it to finish so the notification fires
+            // before WorkManager considers the job done.
+            if (updater.isChecking.value) {
+                withTimeoutOrNull(CHECK_TIMEOUT_MS) {
+                    updater.isChecking.first { !it }
+                }
+            }
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
+            Log.e(Amber.TAG, "UpdateCheckWorker: error checking for updates", e)
+        }
+
+        return Result.success()
+    }
+}


### PR DESCRIPTION
## Summary
Implements automatic periodic checking for app updates using WorkManager, allowing the app to notify users of available updates without requiring manual checks.

## Key Changes
- **New `UpdateCheckWorker` class**: A CoroutineWorker that performs update checks on a scheduled basis
  - Skips checks for offline and F-Droid builds
  - Respects user's auto-update preference setting
  - Waits for app initialization to complete before checking
  - Implements a 30-second timeout for update checks
  - Properly handles cancellation exceptions
  
- **Updated `Amber.kt`**: Integrated WorkManager scheduling
  - Added `startUpdateCheckAlarm()` method to schedule periodic update checks
  - Configured to run once daily with network connectivity constraint
  - Uses `ExistingPeriodicWorkPolicy.KEEP` to avoid duplicate work
  - Called during app initialization in `onCreate()`

## Implementation Details
- The worker waits for `isStartingAppState` to complete before initiating checks, ensuring the app is fully initialized
- If an update check is in progress, the worker waits (with timeout) for it to complete so notifications fire before WorkManager considers the job done
- Network connectivity is required for the periodic work to execute
- The implementation gracefully handles exceptions while preserving cancellation semantics

https://claude.ai/code/session_01W7NTiNoXZvX28kgwf42bJq