### PR TITLE
Always call connect() to retry failed relays immediately

### DIFF
--- a/app/src/main/java/com/greenart7c3/nostrsigner/Amber.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/Amber.kt
@@ -398,9 +398,10 @@ class Amber :
         }
         Log.d(TAG, "reconnecting relays")
         val wasActive = client.isActive()
-        if (!wasActive) {
-            client.connect()
-        }
+        // Always call connect() so that failed relays (socket == null) are retried
+        // directly, bypassing BasicRelayClient's internal backoff delay. For relays
+        // that are already connected (socket != null), connect() is a safe no-op.
+        client.connect()
         client.reconnect(wasActive)
         if (!BuildFlavorChecker.isOfflineFlavor()) {
             stats.updateNotification()


### PR DESCRIPTION
## Summary
Modified the relay reconnection logic to always invoke `client.connect()` instead of conditionally calling it only when the client is inactive. This ensures failed relays are retried immediately rather than waiting for the internal backoff delay.

## Key Changes
- Removed the `if (!wasActive)` guard that prevented `connect()` from being called when the client was already active
- `connect()` is now always called before `reconnect(wasActive)` to handle relay recovery
- Added clarifying comments explaining that `connect()` safely retries failed relays (with `socket == null`) while being a no-op for already-connected relays (with `socket != null`)

## Implementation Details
The change leverages the fact that `BasicRelayClient.connect()` is idempotent:
- For relays with failed connections (`socket == null`), it immediately attempts reconnection
- For relays already connected (`socket != null`), the call is safely ignored
- This approach bypasses the internal backoff delay mechanism for failed relays, enabling faster recovery

https://claude.ai/code/session_01TUMg2vAh4MxV33xAjtFXPn