### PR TITLE
Add mnemonic account index support for BIP-39 key derivation

### DIFF
--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/AccountStateViewModel.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/AccountStateViewModel.kt
@@ -74,7 +74,7 @@ class AccountStateViewModel(npub: String?) : ViewModel() {
         tryLoginExistingAccount(route, npub)
     }
 
-    fun isValidKey(key: String, password: String): Pair<KeyPair?, String> {
+    fun isValidKey(key: String, password: String, accountIndex: Long = 0): Pair<KeyPair?, String> {
         try {
             val signer =
                 if (key.startsWith("ncryptsec")) {
@@ -83,7 +83,7 @@ class AccountStateViewModel(npub: String?) : ViewModel() {
                 } else if (key.startsWith("nsec")) {
                     NostrSignerInternal(KeyPair(privKey = key.bechToBytes()))
                 } else if (key.contains(" ") && Nip06().isValidMnemonic(key)) {
-                    val keyPair = KeyPair(privKey = Nip06().privateKeyFromMnemonic(key))
+                    val keyPair = KeyPair(privKey = Nip06().privateKeyFromMnemonic(key, accountIndex))
                     NostrSignerInternal(keyPair)
                 } else {
                     NostrSignerInternal(KeyPair(Hex.decode(key)))

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/LoginScreen.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/LoginScreen.kt
@@ -833,6 +833,7 @@ fun LoginPage(
     var isMnemonicMode by rememberSaveable { mutableStateOf(false) }
     var mnemonicWordCount by rememberSaveable { mutableIntStateOf(12) }
     var mnemonicWords by remember { mutableStateOf(List(12) { "" }) }
+    var mnemonicAccountIndex by rememberSaveable { mutableIntStateOf(0) }
     val clipboardManager = LocalClipboard.current
 
     Scaffold(
@@ -956,6 +957,28 @@ fun LoginPage(
                                             }
                                         }
                                     },
+                                )
+
+                                Spacer(modifier = Modifier.height(16.dp))
+
+                                OutlinedTextField(
+                                    modifier = Modifier.fillMaxWidth(),
+                                    shape = RoundedCornerShape(18.dp),
+                                    value = if (mnemonicAccountIndex == 0) "" else mnemonicAccountIndex.toString(),
+                                    onValueChange = { value ->
+                                        mnemonicAccountIndex = value.filter { it.isDigit() }.toIntOrNull() ?: 0
+                                        if (errorMessage.isNotEmpty()) errorMessage = ""
+                                    },
+                                    label = { Text(stringResource(R.string.mnemonic_account_index)) },
+                                    placeholder = { Text("0") },
+                                    supportingText = {
+                                        Text(stringResource(R.string.mnemonic_account_index_description, mnemonicAccountIndex))
+                                    },
+                                    keyboardOptions = KeyboardOptions(
+                                        keyboardType = KeyboardType.Number,
+                                        imeAction = ImeAction.Done,
+                                    ),
+                                    singleLine = true,
                                 )
                             } else {
                                 Text(
@@ -1161,7 +1184,7 @@ fun LoginPage(
                                         Amber.instance.applicationIOScope.launch {
                                             isLoading = true
                                             try {
-                                                val isValid = accountViewModel.isValidKey(mnemonicStr, "")
+                                                val isValid = accountViewModel.isValidKey(mnemonicStr, "", mnemonicAccountIndex.toLong())
                                                 isLoading = false
                                                 if (isValid.first != null) {
                                                     keyPair = isValid.first!!

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/MnemonicLoginInput.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/MnemonicLoginInput.kt
@@ -22,7 +22,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -150,20 +149,12 @@ private fun WordField(
     nextFocusRequester: FocusRequester?,
     imeAction: ImeAction,
 ) {
-    // Tracks the last word that was chosen from the dropdown so we can suppress
-    // the menu after selection (selecting changes `word`, which would otherwise
-    // re-open the menu immediately).
-    var selectedWord by remember { mutableStateOf("") }
-
-    // When the word is set externally (e.g. paste), `onValueChange` is never
-    // called so `selectedWord` stays "" and the dropdown would open.  Sync it
-    // here: if `word` is already a complete BIP-39 word there is no need to
-    // show suggestions.
-    LaunchedEffect(word) {
-        if (word in wordList) {
-            selectedWord = word
-        }
-    }
+    // `remember(word)` resets this state synchronously whenever `word` changes.
+    // Initialising to `word` when it is already a complete BIP-39 entry
+    // suppresses the dropdown immediately — no async gap — covering both the
+    // paste case (word set externally, onValueChange never called) and the
+    // case where the user finishes typing a valid word.
+    var selectedWord by remember(word) { mutableStateOf(if (word in wordList) word else "") }
 
     val suggestions = remember(word) {
         if (word.length >= 2) {

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/MnemonicLoginInput.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/MnemonicLoginInput.kt
@@ -22,6 +22,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -153,6 +154,16 @@ private fun WordField(
     // the menu after selection (selecting changes `word`, which would otherwise
     // re-open the menu immediately).
     var selectedWord by remember { mutableStateOf("") }
+
+    // When the word is set externally (e.g. paste), `onValueChange` is never
+    // called so `selectedWord` stays "" and the dropdown would open.  Sync it
+    // here: if `word` is already a complete BIP-39 word there is no need to
+    // show suggestions.
+    LaunchedEffect(word) {
+        if (word in wordList) {
+            selectedWord = word
+        }
+    }
 
     val suggestions = remember(word) {
         if (word.length >= 2) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -385,6 +385,8 @@
     <string name="mnemonic_12_words">12 words</string>
     <string name="mnemonic_24_words">24 words</string>
     <string name="mnemonic_words_entered">%1$d of %2$d words entered</string>
+    <string name="mnemonic_account_index">Account index</string>
+    <string name="mnemonic_account_index_description">Use a different index if this mnemonic was used to create multiple accounts (m/44\'/1237\'/%1$d\'/0/0)</string>
     <string name="sign_policy">Sign policy</string>
     <string name="handle_application_permissions">How to handle this application permissions?</string>
     <string name="sign_policy_manual_new_app">Manually approve each permission</string>


### PR DESCRIPTION
## Summary
This PR adds support for deriving keys from different account indices when using BIP-39 mnemonics during login. Users can now specify which account index to use (following the BIP-44 derivation path m/44'/1237'/[index]'/0/0), enabling support for multiple accounts derived from the same mnemonic phrase.

## Key Changes
- **LoginScreen.kt**: Added `mnemonicAccountIndex` state variable and UI input field allowing users to specify the account index (0-based) when importing from a mnemonic
- **AccountStateViewModel.kt**: Updated `isValidKey()` method to accept an optional `accountIndex` parameter (defaults to 0) and pass it to the `Nip06().privateKeyFromMnemonic()` function
- **MnemonicLoginInput.kt**: Improved dropdown suppression logic by initializing `selectedWord` state with the current word value, preventing the dropdown from reopening immediately after selecting a valid BIP-39 word
- **strings.xml**: Added two new string resources for the account index UI field and its description

## Implementation Details
- The account index input field only accepts numeric values and displays a helpful description showing the BIP-44 derivation path being used
- The field defaults to index 0 and clears the error message when the user modifies the input
- The mnemonic account index is passed as a `Long` to maintain compatibility with the underlying `Nip06` implementation
- The dropdown fix in `MnemonicLoginInput.kt` uses `remember(word)` to synchronously reset state when the word changes, covering both paste operations and manual typing scenarios

https://claude.ai/code/session_01HhkSjWq7GehQprrUb7FeV5