### PR TITLE
Handle ForegroundServiceStartNotAllowedException in ConnectivityService

### DIFF
--- a/app/src/main/java/com/greenart7c3/nostrsigner/service/ConnectivityService.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/service/ConnectivityService.kt
@@ -153,12 +153,20 @@ class ConnectivityService : Service() {
             } else {
                 0
             }
-        ServiceCompat.startForeground(
-            this,
-            1,
-            Amber.instance.stats.createForegroundNotification(),
-            foregroundServiceType,
-        )
+        try {
+            ServiceCompat.startForeground(
+                this,
+                1,
+                Amber.instance.stats.createForegroundNotification(),
+                foregroundServiceType,
+            )
+        } catch (e: Exception) {
+            // Android 12+ can refuse a background FGS start with ForegroundServiceStartNotAllowedException;
+            // swallow it and let the next foreground start (startServiceFromUi) retry.
+            Log.e(Amber.TAG, "Failed to start ConnectivityService in foreground", e)
+            stopSelf(startId)
+            return START_NOT_STICKY
+        }
         return START_STICKY
     }
 }


### PR DESCRIPTION
## Summary
Added exception handling for foreground service start failures in ConnectivityService, specifically to gracefully handle Android 12+ restrictions on background foreground service starts.

## Key Changes
- Wrapped `ServiceCompat.startForeground()` call in a try-catch block to handle `ForegroundServiceStartNotAllowedException`
- When the exception occurs, the service logs the error, stops itself, and returns `START_NOT_STICKY` to allow retry on the next foreground start attempt
- This prevents crashes when the system refuses a background FGS start on Android 12+

## Implementation Details
- The catch block specifically handles the case where Android 12+ refuses a background foreground service start
- By returning `START_NOT_STICKY` and calling `stopSelf()`, the service allows the next foreground start (e.g., from `startServiceFromUi`) to retry the operation
- Error is logged with appropriate tag and exception for debugging purposes

https://claude.ai/code/session_01XezpsgvyWi24DaYKGARSTG