### PR TITLE
Add service settings and stop service functionality

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -40,6 +40,10 @@
             android:enabled="true"
             android:exported="false" />
         <receiver
+            android:name=".service.StopServiceReceiver"
+            android:enabled="true"
+            android:exported="false" />
+        <receiver
             android:name=".service.BootReceiver"
             android:enabled="true"
             android:exported="false"

--- a/app/src/main/java/com/greenart7c3/nostrsigner/LocalPreferences.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/LocalPreferences.kt
@@ -60,6 +60,7 @@ private enum class SettingsKeys(val key: String) {
     AUTO_CHECK_UPDATES("auto_check_updates"),
     UPDATE_CHECK_FREQUENCY("update_check_frequency"),
     LAST_UPDATE_CHECK_TIME("last_update_check_time"),
+    START_SERVICE_ON_BOOT("start_service_on_boot"),
     WEBDAV_URL("webdav_url"),
     WEBDAV_USERNAME("webdav_username"),
     WEBDAV_PASSWORD_ENCRYPTED("webdav_password_encrypted"),
@@ -139,6 +140,7 @@ object LocalPreferences {
                 putBoolean(SettingsKeys.KILL_SWITCH.key, settings.killSwitch.value)
                 putString(SettingsKeys.LANGUAGE_PREFS.key, settings.language)
                 putStringSet(SettingsKeys.AUTH_WHITELIST.key, settings.authWhitelist.toSet())
+                putBoolean(SettingsKeys.START_SERVICE_ON_BOOT.key, settings.startServiceOnBoot)
             }
         }
     }
@@ -254,6 +256,7 @@ object LocalPreferences {
                 } catch (_: IllegalArgumentException) {
                     UpdateCheckFrequency.DAILY
                 },
+                startServiceOnBoot = getBoolean(SettingsKeys.START_SERVICE_ON_BOOT.key, true),
             )
         }
     }
@@ -498,6 +501,15 @@ object LocalPreferences {
         sharedPrefs(context).edit {
             apply {
                 putBoolean(SettingsKeys.AUTO_CHECK_UPDATES.key, enabled)
+            }
+        }
+        Amber.instance.settings = loadSettingsFromEncryptedStorage()
+    }
+
+    fun updateStartServiceOnBoot(context: Context, enabled: Boolean) {
+        sharedPrefs(context).edit {
+            apply {
+                putBoolean(SettingsKeys.START_SERVICE_ON_BOOT.key, enabled)
             }
         }
         Amber.instance.settings = loadSettingsFromEncryptedStorage()

--- a/app/src/main/java/com/greenart7c3/nostrsigner/models/AmberSettings.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/models/AmberSettings.kt
@@ -32,6 +32,7 @@ data class AmberSettings(
     val authWhitelist: List<String> = emptyList(),
     val autoCheckUpdates: Boolean = true,
     val updateCheckFrequency: UpdateCheckFrequency = UpdateCheckFrequency.DAILY,
+    val startServiceOnBoot: Boolean = true,
 ) {
     val useProxy: Boolean get() = torMode != TorMode.DISABLED
 }

--- a/app/src/main/java/com/greenart7c3/nostrsigner/relays/AmberRelayStat.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/relays/AmberRelayStat.kt
@@ -20,6 +20,7 @@ import com.greenart7c3.nostrsigner.MainActivity
 import com.greenart7c3.nostrsigner.R
 import com.greenart7c3.nostrsigner.service.KillSwitchReceiver
 import com.greenart7c3.nostrsigner.service.ReconnectReceiver
+import com.greenart7c3.nostrsigner.service.StopServiceReceiver
 import com.vitorpamplona.quartz.nip01Core.relay.client.NostrClient
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.displayUrl
@@ -121,6 +122,14 @@ class AmberRelayStats(
                 PendingIntent.FLAG_MUTABLE,
             )
 
+        val stopServiceIntent = Intent(appContext, StopServiceReceiver::class.java)
+        val stopServicePendingIntent = PendingIntent.getBroadcast(
+            appContext,
+            0,
+            stopServiceIntent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE,
+        )
+
         return NotificationCompat.Builder(appContext, channel.id)
             .setContentTitle(appContext.getString(R.string.service))
             .setContentText(appContext.getString(R.string.amber_is_running_in_background))
@@ -130,6 +139,11 @@ class AmberRelayStats(
             .setGroup(group.id)
             .setGroupSummary(true)
             .setContentIntent(contentPendingIntent)
+            .addAction(
+                R.drawable.ic_notification,
+                appContext.getString(R.string.stop_service),
+                stopServicePendingIntent,
+            )
             .build()
     }
 

--- a/app/src/main/java/com/greenart7c3/nostrsigner/service/BootReceiver.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/service/BootReceiver.kt
@@ -21,6 +21,12 @@ class BootReceiver : BroadcastReceiver() {
                 Log.d(Amber.TAG, "Received ${intent.action}")
                 Amber.instance.applicationIOScope.launch {
                     Amber.instance.isStartingAppState.first { !it }
+                    if (intent.action == Intent.ACTION_BOOT_COMPLETED &&
+                        !Amber.instance.settings.startServiceOnBoot
+                    ) {
+                        Log.d(Amber.TAG, "Skipping service start on boot (disabled in settings)")
+                        return@launch
+                    }
                     Amber.instance.startService()
                 }
             }

--- a/app/src/main/java/com/greenart7c3/nostrsigner/service/StopServiceReceiver.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/service/StopServiceReceiver.kt
@@ -1,0 +1,34 @@
+package com.greenart7c3.nostrsigner.service
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.os.Process
+import android.util.Log
+import androidx.core.app.NotificationManagerCompat
+import com.greenart7c3.nostrsigner.Amber
+import kotlin.system.exitProcess
+
+class StopServiceReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        Log.d(Amber.TAG, "StopServiceReceiver: stopping service and killing process")
+
+        try {
+            Amber.instance.client.disconnect()
+        } catch (e: Exception) {
+            Log.e(Amber.TAG, "Failed to disconnect client on stop", e)
+        }
+
+        try {
+            context.stopService(Intent(context, ConnectivityService::class.java))
+        } catch (e: Exception) {
+            Log.e(Amber.TAG, "Failed to stop ConnectivityService", e)
+        }
+
+        val notificationManager = NotificationManagerCompat.from(context)
+        notificationManager.cancelAll()
+
+        Process.killProcess(Process.myPid())
+        exitProcess(0)
+    }
+}

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/MainScreen.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/MainScreen.kt
@@ -1018,6 +1018,22 @@ fun MainScreen(
                             )
                         },
                     )
+
+                    composable(
+                        Route.ServiceSettings.route,
+                        content = {
+                            val scrollState = rememberScrollState()
+                            ServiceSettingsScreen(
+                                modifier = Modifier
+                                    .fillMaxSize()
+                                    .padding(padding)
+                                    .verticalScrollbar(scrollState)
+                                    .verticalScroll(scrollState)
+                                    .padding(horizontal = verticalPadding)
+                                    .padding(top = verticalPadding * 1.5f),
+                            )
+                        },
+                    )
                 }
             }
 

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/ServiceSettingsScreen.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/ServiceSettingsScreen.kt
@@ -1,0 +1,70 @@
+package com.greenart7c3.nostrsigner.ui
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.greenart7c3.nostrsigner.Amber
+import com.greenart7c3.nostrsigner.LocalPreferences
+import com.greenart7c3.nostrsigner.R
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+@Composable
+fun ServiceSettingsScreen(modifier: Modifier = Modifier) {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    var startServiceOnBoot by remember { mutableStateOf(Amber.instance.settings.startServiceOnBoot) }
+
+    Column(modifier = modifier) {
+        Row(
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 4.dp)
+                .clickable {
+                    val newValue = !startServiceOnBoot
+                    startServiceOnBoot = newValue
+                    scope.launch(Dispatchers.IO) {
+                        LocalPreferences.updateStartServiceOnBoot(context, newValue)
+                    }
+                },
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(text = stringResource(R.string.start_service_on_boot))
+                Text(
+                    text = stringResource(R.string.start_service_on_boot_description),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = Color.Gray,
+                )
+            }
+            Switch(
+                checked = startServiceOnBoot,
+                onCheckedChange = { enabled ->
+                    startServiceOnBoot = enabled
+                    scope.launch(Dispatchers.IO) {
+                        LocalPreferences.updateStartServiceOnBoot(context, enabled)
+                    }
+                },
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/SettingsScreen.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/SettingsScreen.kt
@@ -1,7 +1,6 @@
 package com.greenart7c3.nostrsigner.ui
 
 import android.util.Log
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -17,11 +16,11 @@ import androidx.compose.material.icons.filled.Feedback
 import androidx.compose.material.icons.filled.FilterList
 import androidx.compose.material.icons.filled.Key
 import androidx.compose.material.icons.filled.Language
+import androidx.compose.material.icons.filled.PowerSettingsNew
 import androidx.compose.material.icons.filled.Security
 import androidx.compose.material.icons.filled.SystemUpdate
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -83,7 +82,6 @@ fun SettingsScreen(
     val context = LocalContext.current
     var torMode by remember { mutableStateOf(Amber.instance.settings.torMode) }
     var disconnectTorDialog by remember { mutableStateOf(false) }
-    var startServiceOnBoot by remember { mutableStateOf(Amber.instance.settings.startServiceOnBoot) }
     val scope = rememberCoroutineScope()
     var isLoading by remember { mutableStateOf(false) }
     var sizeInMBFormatted by remember { mutableStateOf("") }
@@ -201,35 +199,16 @@ fun SettingsScreen(
                     )
                 }
 
-                Row(
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                    verticalAlignment = Alignment.CenterVertically,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 16.dp, vertical = 8.dp)
-                        .clickable {
-                            val newValue = !startServiceOnBoot
-                            startServiceOnBoot = newValue
-                            scope.launch(Dispatchers.IO) {
-                                LocalPreferences.updateStartServiceOnBoot(context, newValue)
-                            }
-                        },
+                Box(
+                    Modifier
+                        .padding(vertical = 8.dp),
                 ) {
-                    Column(modifier = Modifier.weight(1f)) {
-                        Text(text = stringResource(R.string.start_service_on_boot))
-                        Text(
-                            text = stringResource(R.string.start_service_on_boot_description),
-                            style = MaterialTheme.typography.bodySmall,
-                            color = Color.Gray,
-                        )
-                    }
-                    Switch(
-                        checked = startServiceOnBoot,
-                        onCheckedChange = { enabled ->
-                            startServiceOnBoot = enabled
-                            scope.launch(Dispatchers.IO) {
-                                LocalPreferences.updateStartServiceOnBoot(context, enabled)
-                            }
+                    IconRow(
+                        title = stringResource(R.string.service_settings),
+                        icon = Icons.Default.PowerSettingsNew,
+                        tint = MaterialTheme.colorScheme.onBackground,
+                        onClick = {
+                            onNav(Route.ServiceSettings.route)
                         },
                     )
                 }

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/SettingsScreen.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/SettingsScreen.kt
@@ -1,6 +1,7 @@
 package com.greenart7c3.nostrsigner.ui
 
 import android.util.Log
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -20,6 +21,7 @@ import androidx.compose.material.icons.filled.Security
 import androidx.compose.material.icons.filled.SystemUpdate
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -81,6 +83,7 @@ fun SettingsScreen(
     val context = LocalContext.current
     var torMode by remember { mutableStateOf(Amber.instance.settings.torMode) }
     var disconnectTorDialog by remember { mutableStateOf(false) }
+    var startServiceOnBoot by remember { mutableStateOf(Amber.instance.settings.startServiceOnBoot) }
     val scope = rememberCoroutineScope()
     var isLoading by remember { mutableStateOf(false) }
     var sizeInMBFormatted by remember { mutableStateOf("") }
@@ -194,6 +197,39 @@ fun SettingsScreen(
                         tint = MaterialTheme.colorScheme.onBackground,
                         onClick = {
                             onNav(Route.RelaysScreen.route)
+                        },
+                    )
+                }
+
+                Row(
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 8.dp)
+                        .clickable {
+                            val newValue = !startServiceOnBoot
+                            startServiceOnBoot = newValue
+                            scope.launch(Dispatchers.IO) {
+                                LocalPreferences.updateStartServiceOnBoot(context, newValue)
+                            }
+                        },
+                ) {
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(text = stringResource(R.string.start_service_on_boot))
+                        Text(
+                            text = stringResource(R.string.start_service_on_boot_description),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = Color.Gray,
+                        )
+                    }
+                    Switch(
+                        checked = startServiceOnBoot,
+                        onCheckedChange = { enabled ->
+                            startServiceOnBoot = enabled
+                            scope.launch(Dispatchers.IO) {
+                                LocalPreferences.updateStartServiceOnBoot(context, enabled)
+                            }
                         },
                     )
                 }

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/navigation/Route.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/navigation/Route.kt
@@ -214,6 +214,12 @@ sealed class Route(
         route = "CloudBackup",
         icon = R.drawable.settings,
     )
+
+    data object ServiceSettings : Route(
+        title = Amber.instance.getString(R.string.service_settings),
+        route = "ServiceSettings",
+        icon = R.drawable.settings,
+    )
 }
 
 val routes = listOf(
@@ -248,4 +254,5 @@ val routes = listOf(
     Route.CrashReport,
     Route.UpdateSettings,
     Route.CloudBackup,
+    Route.ServiceSettings,
 )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -615,6 +615,7 @@
     <string name="update_download_failed">Download failed. Tap to retry.</string>
     <string name="download_and_install_update">Download and install update</string>
     <string name="auto_check_updates">Automatically check for updates</string>
+    <string name="service_settings">Service settings</string>
     <string name="start_service_on_boot">Start service on boot</string>
     <string name="start_service_on_boot_description">When enabled, Amber will start its background service automatically after the device boots so remote login and NIP-46 requests keep working.</string>
     <string name="update_check_frequency">Check frequency</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -616,6 +616,7 @@
     <string name="download_and_install_update">Download and install update</string>
     <string name="auto_check_updates">Automatically check for updates</string>
     <string name="service_settings">Service settings</string>
+    <string name="stop_service">Stop service</string>
     <string name="start_service_on_boot">Start service on boot</string>
     <string name="start_service_on_boot_description">When enabled, Amber will start its background service automatically after the device boots so remote login and NIP-46 requests keep working.</string>
     <string name="update_check_frequency">Check frequency</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -615,6 +615,8 @@
     <string name="update_download_failed">Download failed. Tap to retry.</string>
     <string name="download_and_install_update">Download and install update</string>
     <string name="auto_check_updates">Automatically check for updates</string>
+    <string name="start_service_on_boot">Start service on boot</string>
+    <string name="start_service_on_boot_description">When enabled, Amber will start its background service automatically after the device boots so remote login and NIP-46 requests keep working.</string>
     <string name="update_check_frequency">Check frequency</string>
     <string name="update_frequency_on_startup">Every app start</string>
     <string name="update_frequency_daily">Daily</string>


### PR DESCRIPTION
## Summary
This PR adds service management capabilities to the Amber app, allowing users to control whether the background service starts automatically on device boot and providing a way to stop the service from the notification.

## Key Changes

- **New Service Settings Screen**: Created `ServiceSettingsScreen` composable that displays a toggle for "Start service on boot" setting with descriptive text
- **Stop Service Receiver**: Implemented `StopServiceReceiver` broadcast receiver to handle service termination, including proper cleanup of client connections and notifications
- **Boot Behavior Control**: Modified `BootReceiver` to respect the new `startServiceOnBoot` setting and skip service startup if disabled
- **Notification Action**: Added a "Stop service" action button to the foreground service notification that triggers the `StopServiceReceiver`
- **Settings Persistence**: Extended `LocalPreferences` to store and retrieve the `startServiceOnBoot` preference
- **UI Navigation**: Added new `ServiceSettings` route and integrated it into the settings screen with a power settings icon
- **Manifest Registration**: Registered `StopServiceReceiver` in AndroidManifest.xml
- **String Resources**: Added localized strings for service settings UI elements

## Implementation Details

- The `startServiceOnBoot` setting defaults to `true` to maintain backward compatibility
- Service stop operation includes proper error handling for client disconnection and service termination
- The setting is persisted in SharedPreferences and synced with the app's settings model
- The notification action uses `PendingIntent.FLAG_UPDATE_CURRENT` to ensure the latest receiver is used

https://claude.ai/code/session_01N7zDP1jMW4qVeagxuyeacN