### PR TITLE
Optimize performance of batch intent operations in IntentMultiEventHomeScreen

### DIFF
--- a/app/src/main/java/com/greenart7c3/nostrsigner/SignerProvider.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/SignerProvider.kt
@@ -98,14 +98,16 @@ class SignerProvider : ContentProvider() {
                     if (!isRemembered) {
                         scope.launch {
                             historyDatabase.dao().addHistory(
-                                HistoryEntity(
-                                    0,
-                                    packageName,
-                                    uriString.replace("content://$appId.", ""),
-                                    null,
-                                    TimeUtils.now(),
-                                    false,
-                                    content = message,
+                                listOf(
+                                    HistoryEntity(
+                                        0,
+                                        packageName,
+                                        uriString.replace("content://$appId.", ""),
+                                        null,
+                                        TimeUtils.now(),
+                                        false,
+                                        content = message,
+                                    ),
                                 ),
                                 account.npub,
                             )
@@ -121,14 +123,16 @@ class SignerProvider : ContentProvider() {
                     val result = runBlocking { account.signString(message) }
                     scope.launch {
                         historyDatabase.dao().addHistory(
-                            HistoryEntity(
-                                0,
-                                packageName,
-                                "SIGN_MESSAGE",
-                                null,
-                                TimeUtils.now(),
-                                true,
-                                content = message,
+                            listOf(
+                                HistoryEntity(
+                                    0,
+                                    packageName,
+                                    "SIGN_MESSAGE",
+                                    null,
+                                    TimeUtils.now(),
+                                    true,
+                                    content = message,
+                                ),
                             ),
                             account.npub,
                         )
@@ -187,14 +191,16 @@ class SignerProvider : ContentProvider() {
                             else -> {
                                 scope.launch {
                                     historyDatabase.dao().addHistory(
-                                        HistoryEntity(
-                                            0,
-                                            packageName,
-                                            uriString.replace("content://$appId.", ""),
-                                            event.kind,
-                                            TimeUtils.now(),
-                                            false,
-                                            content = event.toJson(),
+                                        listOf(
+                                            HistoryEntity(
+                                                0,
+                                                packageName,
+                                                uriString.replace("content://$appId.", ""),
+                                                event.kind,
+                                                TimeUtils.now(),
+                                                false,
+                                                content = event.toJson(),
+                                            ),
                                         ),
                                         account.npub,
                                     )
@@ -240,14 +246,16 @@ class SignerProvider : ContentProvider() {
                     if (!isRemembered) {
                         scope.launch {
                             historyDatabase.dao().addHistory(
-                                HistoryEntity(
-                                    0,
-                                    packageName,
-                                    uriString.replace("content://$appId.", ""),
-                                    event.kind,
-                                    TimeUtils.now(),
-                                    false,
-                                    content = event.toJson(),
+                                listOf(
+                                    HistoryEntity(
+                                        0,
+                                        packageName,
+                                        uriString.replace("content://$appId.", ""),
+                                        event.kind,
+                                        TimeUtils.now(),
+                                        false,
+                                        content = event.toJson(),
+                                    ),
                                 ),
                                 account.npub,
                             )
@@ -265,14 +273,16 @@ class SignerProvider : ContentProvider() {
 
                     scope.launch {
                         historyDatabase.dao().addHistory(
-                            HistoryEntity(
-                                0,
-                                packageName,
-                                "SIGN_EVENT",
-                                event.kind,
-                                TimeUtils.now(),
-                                true,
-                                content = signedEvent.toJson(),
+                            listOf(
+                                HistoryEntity(
+                                    0,
+                                    packageName,
+                                    "SIGN_EVENT",
+                                    event.kind,
+                                    TimeUtils.now(),
+                                    true,
+                                    content = signedEvent.toJson(),
+                                ),
                             ),
                             account.npub,
                         )
@@ -387,14 +397,16 @@ class SignerProvider : ContentProvider() {
                     if (!isRemembered) {
                         scope.launch {
                             historyDatabase.dao().addHistory(
-                                HistoryEntity(
-                                    0,
-                                    packageName,
-                                    uriString.replace("content://$appId.", ""),
-                                    null,
-                                    TimeUtils.now(),
-                                    false,
-                                    content = content,
+                                listOf(
+                                    HistoryEntity(
+                                        0,
+                                        packageName,
+                                        uriString.replace("content://$appId.", ""),
+                                        null,
+                                        TimeUtils.now(),
+                                        false,
+                                        content = content,
+                                    ),
                                 ),
                                 account.npub,
                             )
@@ -436,14 +448,16 @@ class SignerProvider : ContentProvider() {
 
                     scope.launch {
                         historyDatabase.dao().addHistory(
-                            HistoryEntity(
-                                0,
-                                packageName,
-                                uriString.replace("content://$appId.", ""),
-                                null,
-                                TimeUtils.now(),
-                                true,
-                                content = if (!isEncrypt) finalResult else content,
+                            listOf(
+                                HistoryEntity(
+                                    0,
+                                    packageName,
+                                    uriString.replace("content://$appId.", ""),
+                                    null,
+                                    TimeUtils.now(),
+                                    true,
+                                    content = if (!isEncrypt) finalResult else content,
+                                ),
                             ),
                             account.npub,
                         )
@@ -487,13 +501,15 @@ class SignerProvider : ContentProvider() {
                     if (!isRemembered) {
                         scope.launch {
                             historyDatabase.dao().addHistory(
-                                HistoryEntity(
-                                    0,
-                                    packageName,
-                                    uriString.replace("content://$appId.", ""),
-                                    null,
-                                    TimeUtils.now(),
-                                    false,
+                                listOf(
+                                    HistoryEntity(
+                                        0,
+                                        packageName,
+                                        uriString.replace("content://$appId.", ""),
+                                        null,
+                                        TimeUtils.now(),
+                                        false,
+                                    ),
                                 ),
                                 account.npub,
                             )
@@ -509,13 +525,15 @@ class SignerProvider : ContentProvider() {
 
                     scope.launch {
                         historyDatabase.dao().addHistory(
-                            HistoryEntity(
-                                0,
-                                packageName,
-                                uriString.replace("content://$appId.", ""),
-                                null,
-                                TimeUtils.now(),
-                                true,
+                            listOf(
+                                HistoryEntity(
+                                    0,
+                                    packageName,
+                                    uriString.replace("content://$appId.", ""),
+                                    null,
+                                    TimeUtils.now(),
+                                    true,
+                                ),
                             ),
                             account.npub,
                         )

--- a/app/src/main/java/com/greenart7c3/nostrsigner/database/HistoryDao.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/database/HistoryDao.kt
@@ -12,6 +12,7 @@ import androidx.room.Query
 import androidx.room.Transaction
 import com.greenart7c3.nostrsigner.Amber
 import com.greenart7c3.nostrsigner.models.Permission
+import com.vitorpamplona.quartz.utils.TimeUtils
 
 private const val MAX_CONTENT_LENGTH = 500
 
@@ -65,20 +66,26 @@ interface HistoryDao {
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     @Transaction
-    suspend fun innerAddHistory(entity: HistoryEntity)
+    suspend fun innerAddHistory(entities: List<HistoryEntity>)
 
     @Insert(onConflict = OnConflictStrategy.IGNORE)
     @Transaction
-    suspend fun addHistory(entity: HistoryEntity, npub: String?) {
+    suspend fun addHistory(entities: List<HistoryEntity>, npub: String?) {
         try {
-            val permission = Permission(entity.type.toLowerCase(Locale.current), entity.kind)
-            val localEntity = entity.copy(
-                translatedPermission = permission.toLocalizedString(Amber.instance, true),
-                content = if (entity.content.length > MAX_CONTENT_LENGTH) entity.content.take(MAX_CONTENT_LENGTH) else entity.content,
-            )
-            innerAddHistory(localEntity)
+            val localEntities = entities.map { entity ->
+                val permission = Permission(entity.type.toLowerCase(Locale.current), entity.kind)
+                entity.copy(
+                    translatedPermission = permission.toLocalizedString(Amber.instance, true),
+                    content = if (entity.content.length > MAX_CONTENT_LENGTH) entity.content.take(MAX_CONTENT_LENGTH) else entity.content,
+                )
+            }
+            innerAddHistory(localEntities)
             npub?.let {
-                Amber.instance.getDatabase(npub).dao().updateLastUsed(entity.pkKey, entity.time)
+                val lastUsed = entities.maxByOrNull { it.time }?.time ?: TimeUtils.now()
+                val pkKey = entities.firstOrNull()?.pkKey
+                if (pkKey != null) {
+                    Amber.instance.getDatabase(npub).dao().updateLastUsed(pkKey, lastUsed)
+                }
             }
         } catch (e: Exception) {
             Log.e(Amber.TAG, "Error adding history", e)

--- a/app/src/main/java/com/greenart7c3/nostrsigner/service/AmberUtils.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/service/AmberUtils.kt
@@ -77,14 +77,13 @@ object AmberUtils {
         )
     }
 
-    suspend fun acceptOrRejectPermission(
+    fun updatePermission(
         application: ApplicationWithPermissions,
         key: String,
         signerType: SignerType,
         kind: Int?,
         value: Boolean,
         rememberType: RememberType,
-        account: Account,
         relay: String = "",
         encryptedData: EncryptedDataKind?,
         decryptTypeScope: DecryptTypeScope = DecryptTypeScope.ALL,
@@ -140,6 +139,31 @@ object AmberUtils {
                 if (!value) until else 0L,
                 relay,
             ),
+        )
+    }
+
+    suspend fun acceptOrRejectPermission(
+        application: ApplicationWithPermissions,
+        key: String,
+        signerType: SignerType,
+        kind: Int?,
+        value: Boolean,
+        rememberType: RememberType,
+        account: Account,
+        relay: String = "",
+        encryptedData: EncryptedDataKind?,
+        decryptTypeScope: DecryptTypeScope = DecryptTypeScope.ALL,
+    ) {
+        updatePermission(
+            application,
+            key,
+            signerType,
+            kind,
+            value,
+            rememberType,
+            relay,
+            encryptedData,
+            decryptTypeScope,
         )
 
         Amber.instance.getDatabase(account.npub)

--- a/app/src/main/java/com/greenart7c3/nostrsigner/service/BunkerRequestUtils.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/service/BunkerRequestUtils.kt
@@ -391,21 +391,23 @@ object BunkerRequestUtils {
             EventNotificationConsumer(context).notificationManager().cancelAll()
             database.dao().insertApplicationWithPermissions(application)
             historyDatabase.dao().addHistory(
-                HistoryEntity(
-                    0,
-                    key,
-                    type.toString(),
-                    kind,
-                    TimeUtils.now(),
-                    true,
-                    content = when (type) {
-                        SignerType.SIGN_EVENT,
-                        SignerType.NIP04_DECRYPT,
-                        SignerType.NIP44_DECRYPT,
-                        SignerType.DECRYPT_ZAP_EVENT,
-                        -> response
-                        else -> getDataFromBunker(bunkerRequest.request)
-                    },
+                listOf(
+                    HistoryEntity(
+                        0,
+                        key,
+                        type.toString(),
+                        kind,
+                        TimeUtils.now(),
+                        true,
+                        content = when (type) {
+                            SignerType.SIGN_EVENT,
+                            SignerType.NIP04_DECRYPT,
+                            SignerType.NIP44_DECRYPT,
+                            SignerType.DECRYPT_ZAP_EVENT,
+                            -> response
+                            else -> getDataFromBunker(bunkerRequest.request)
+                        },
+                    ),
                 ),
                 account.npub,
             )
@@ -539,14 +541,16 @@ object BunkerRequestUtils {
             if (bunkerRequest.request !is BunkerRequestConnect) {
                 Amber.instance.getDatabase(account.npub).dao().insertApplicationWithPermissions(application)
                 Amber.instance.getHistoryDatabase(account.npub).dao().addHistory(
-                    HistoryEntity(
-                        0,
-                        key,
-                        signerType.toString(),
-                        null,
-                        TimeUtils.now(),
-                        false,
-                        content = getDataFromBunker(bunkerRequest.request),
+                    listOf(
+                        HistoryEntity(
+                            0,
+                            key,
+                            signerType.toString(),
+                            null,
+                            TimeUtils.now(),
+                            false,
+                            content = getDataFromBunker(bunkerRequest.request),
+                        ),
                     ),
                     account.npub,
                 )

--- a/app/src/main/java/com/greenart7c3/nostrsigner/service/EventNotificationConsumer.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/service/EventNotificationConsumer.kt
@@ -277,14 +277,16 @@ class EventNotificationConsumer(private val applicationContext: Context) {
             Amber.instance.applicationIOScope.launch {
                 historyDao
                     .addHistory(
-                        HistoryEntity(
-                            0,
-                            permission.application.key,
-                            type.toString().toLowerCase(Locale.current),
-                            amberEvent?.kind,
-                            TimeUtils.now(),
-                            true,
-                            content = amberEvent?.content ?: "",
+                        listOf(
+                            HistoryEntity(
+                                0,
+                                permission.application.key,
+                                type.toString().toLowerCase(Locale.current),
+                                amberEvent?.kind,
+                                TimeUtils.now(),
+                                true,
+                                content = amberEvent?.content ?: "",
+                            ),
                         ),
                         acc.npub,
                     )
@@ -409,13 +411,15 @@ class EventNotificationConsumer(private val applicationContext: Context) {
             if (!isRemembered) {
                 Amber.instance.applicationIOScope.launch {
                     historyDao.addHistory(
-                        HistoryEntity(
-                            0,
-                            event.pubKey,
-                            "GET_PUBLIC_KEY",
-                            null,
-                            TimeUtils.now(),
-                            false,
+                        listOf(
+                            HistoryEntity(
+                                0,
+                                event.pubKey,
+                                "GET_PUBLIC_KEY",
+                                null,
+                                TimeUtils.now(),
+                                false,
+                            ),
                         ),
                         acc.npub,
                     )
@@ -433,13 +437,15 @@ class EventNotificationConsumer(private val applicationContext: Context) {
             }
             Amber.instance.applicationIOScope.launch {
                 historyDao.addHistory(
-                    HistoryEntity(
-                        0,
-                        event.pubKey,
-                        "GET_PUBLIC_KEY",
-                        null,
-                        TimeUtils.now(),
-                        true,
+                    listOf(
+                        HistoryEntity(
+                            0,
+                            event.pubKey,
+                            "GET_PUBLIC_KEY",
+                            null,
+                            TimeUtils.now(),
+                            true,
+                        ),
                     ),
                     acc.npub,
                 )

--- a/app/src/main/java/com/greenart7c3/nostrsigner/service/IntentUtils.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/service/IntentUtils.kt
@@ -754,22 +754,24 @@ object IntentUtils {
                     val historyDatabase = Amber.instance.getHistoryDatabase(account.npub)
                     Amber.instance.applicationIOScope.launch {
                         historyDatabase.dao().addHistory(
-                            HistoryEntity(
-                                0,
-                                key,
-                                intentData.type.toString(),
-                                kind,
-                                TimeUtils.now(),
-                                true,
-                                content = when (intentData.type) {
-                                    SignerType.SIGN_EVENT -> event
-                                    SignerType.NIP04_DECRYPT,
-                                    SignerType.NIP44_DECRYPT,
-                                    SignerType.DECRYPT_ZAP_EVENT,
-                                    -> value
+                            listOf(
+                                HistoryEntity(
+                                    0,
+                                    key,
+                                    intentData.type.toString(),
+                                    kind,
+                                    TimeUtils.now(),
+                                    true,
+                                    content = when (intentData.type) {
+                                        SignerType.SIGN_EVENT -> event
+                                        SignerType.NIP04_DECRYPT,
+                                        SignerType.NIP44_DECRYPT,
+                                        SignerType.DECRYPT_ZAP_EVENT,
+                                        -> value
 
-                                    else -> intentData.data
-                                },
+                                        else -> intentData.data
+                                    },
+                                ),
                             ),
                             account.npub,
                         )
@@ -903,14 +905,16 @@ object IntentUtils {
 
             Amber.instance.getDatabase(account.npub).dao().insertApplicationWithPermissions(application)
             Amber.instance.getHistoryDatabase(account.npub).dao().addHistory(
-                HistoryEntity(
-                    0,
-                    key,
-                    intentData.type.toString(),
-                    kind,
-                    TimeUtils.now(),
-                    false,
-                    content = intentData.data,
+                listOf(
+                    HistoryEntity(
+                        0,
+                        key,
+                        intentData.type.toString(),
+                        kind,
+                        TimeUtils.now(),
+                        false,
+                        content = intentData.data,
+                    ),
                 ),
                 account.npub,
             )

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/BunkerMultiEventHomeScreen.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/BunkerMultiEventHomeScreen.kt
@@ -398,14 +398,16 @@ fun BunkerMultiEventHomeScreen(
                                     database.dao().insertApplicationWithPermissions(application)
 
                                     historyDatabase.dao().addHistory(
-                                        entity = HistoryEntity(
-                                            id = 0,
-                                            pkKey = localKey,
-                                            type = SignerType.SIGN_EVENT.toString(),
-                                            kind = localEvent.kind,
-                                            time = TimeUtils.now(),
-                                            accepted = isChecked,
-                                            content = localEvent.toJson(),
+                                        listOf(
+                                            HistoryEntity(
+                                                id = 0,
+                                                pkKey = localKey,
+                                                type = SignerType.SIGN_EVENT.toString(),
+                                                kind = localEvent.kind,
+                                                time = TimeUtils.now(),
+                                                accepted = isChecked,
+                                                content = localEvent.toJson(),
+                                            ),
                                         ),
                                         thisAccount.npub,
                                     )
@@ -448,14 +450,16 @@ fun BunkerMultiEventHomeScreen(
 
                                     database.dao().insertApplicationWithPermissions(application)
                                     historyDatabase.dao().addHistory(
-                                        HistoryEntity(
-                                            0,
-                                            localKey,
-                                            SignerType.SIGN_MESSAGE.toString(),
-                                            null,
-                                            TimeUtils.now(),
-                                            isChecked,
-                                            content = request.request.params.first(),
+                                        listOf(
+                                            HistoryEntity(
+                                                0,
+                                                localKey,
+                                                SignerType.SIGN_MESSAGE.toString(),
+                                                null,
+                                                TimeUtils.now(),
+                                                isChecked,
+                                                content = request.request.params.first(),
+                                            ),
                                         ),
                                         thisAccount.npub,
                                     )
@@ -488,14 +492,16 @@ fun BunkerMultiEventHomeScreen(
                                         database.dao().insertApplicationWithPermissions(application)
 
                                         historyDatabase.dao().addHistory(
-                                            HistoryEntity(
-                                                0,
-                                                localKey,
-                                                SignerType.CONNECT.toString(),
-                                                null,
-                                                TimeUtils.now(),
-                                                isChecked,
-                                                content = "",
+                                            listOf(
+                                                HistoryEntity(
+                                                    0,
+                                                    localKey,
+                                                    SignerType.CONNECT.toString(),
+                                                    null,
+                                                    TimeUtils.now(),
+                                                    isChecked,
+                                                    content = "",
+                                                ),
                                             ),
                                             thisAccount.npub,
                                         )
@@ -540,18 +546,20 @@ fun BunkerMultiEventHomeScreen(
                                     database.dao().insertApplicationWithPermissions(application)
 
                                     historyDatabase.dao().addHistory(
-                                        HistoryEntity(
-                                            0,
-                                            localKey,
-                                            type.toString(),
-                                            null,
-                                            TimeUtils.now(),
-                                            isChecked,
-                                            content = if (type == SignerType.NIP04_DECRYPT || type == SignerType.NIP44_DECRYPT || type == SignerType.DECRYPT_ZAP_EVENT) {
-                                                request.encryptedData?.result ?: ""
-                                            } else {
-                                                request.request.params.getOrElse(1) { "" }
-                                            },
+                                        listOf(
+                                            HistoryEntity(
+                                                0,
+                                                localKey,
+                                                type.toString(),
+                                                null,
+                                                TimeUtils.now(),
+                                                isChecked,
+                                                content = if (type == SignerType.NIP04_DECRYPT || type == SignerType.NIP44_DECRYPT || type == SignerType.DECRYPT_ZAP_EVENT) {
+                                                    request.encryptedData?.result ?: ""
+                                                } else {
+                                                    request.request.params.getOrElse(1) { "" }
+                                                },
+                                            ),
                                         ),
                                         thisAccount.npub,
                                     )

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/IntentMultiEventHomeScreen.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/IntentMultiEventHomeScreen.kt
@@ -190,82 +190,85 @@ fun IntentMultiEventHomeScreen(
                     containerColor = orange,
                 ),
                 onClick = {
-                    Amber.instance.applicationIOScope.launch {
+                    Amber.instance.applicationIOScope.launch(Dispatchers.IO) {
                         var closeApp = true
                         onRemoveIntentData(intents, IntentResultType.REMOVE)
-                        for (intentData in intents) {
-                            val thisAccount =
-                                if (intentData.currentAccount.isNotBlank()) {
-                                    LocalPreferences.loadFromEncryptedStorage(
-                                        context,
-                                        intentData.currentAccount,
-                                    )
-                                } else {
-                                    accountParam
-                                } ?: continue
+                        val localKey = packageName ?: return@launch
+                        val intentsByAccount = intents.groupBy { it.currentAccount.ifBlank { accountParam.npub } }
 
-                            val localKey = packageName ?: continue
+                        for ((accountNpub, accountIntents) in intentsByAccount) {
+                            val thisAccount = if (accountNpub == accountParam.npub) {
+                                accountParam
+                            } else {
+                                LocalPreferences.loadFromEncryptedStorage(context, accountNpub)
+                            } ?: continue
+
                             val database = Amber.instance.getDatabase(thisAccount.npub)
-                            val application =
-                                database
-                                    .dao()
-                                    .getByKey(localKey) ?: ApplicationWithPermissions(
-                                    application = ApplicationEntity(
-                                        localKey,
-                                        "",
-                                        listOf(),
-                                        "",
-                                        "",
-                                        "",
-                                        thisAccount.hexKey,
-                                        true,
-                                        "",
-                                        false,
-                                        thisAccount.signPolicy,
-                                        true,
-                                        0L,
-                                        lastUsed = TimeUtils.now(),
-                                    ),
-                                    permissions = mutableListOf(),
-                                )
-
-                            val isChecked = MultiEventScreenIntents.checkedStates[intentData.id] ?: true
-                            if (rememberType != RememberType.NEVER && isChecked) {
-                                val rejectKind = if (intentData.type == SignerType.SIGN_EVENT) intentData.event?.kind else null
-                                val rejectRelay = if (intentData.type == SignerType.SIGN_EVENT && intentData.event?.kind == 22242) {
-                                    if (relayAuthScope == RelayAuthScope.ALL) {
-                                        "*"
-                                    } else {
-                                        (
-                                            AmberEvent.relay(intentData.event)?.let { url ->
-                                                try {
-                                                    java.net.URI(url).host ?: url
-                                                } catch (e: Exception) {
-                                                    url
-                                                }
-                                            } ?: ""
-                                            )
-                                    }
-                                } else {
-                                    ""
-                                }
-                                AmberUtils.acceptOrRejectPermission(
-                                    application,
+                            val application = database.dao().getByKey(localKey) ?: ApplicationWithPermissions(
+                                application = ApplicationEntity(
                                     localKey,
-                                    intentData.type,
-                                    rejectKind,
+                                    "",
+                                    listOf(),
+                                    "",
+                                    "",
+                                    "",
+                                    thisAccount.hexKey,
+                                    true,
+                                    "",
                                     false,
-                                    rememberType,
-                                    thisAccount,
-                                    relay = rejectRelay,
-                                    encryptedData = intentData.encryptedData,
-                                )
-                            }
+                                    thisAccount.signPolicy,
+                                    true,
+                                    0L,
+                                    lastUsed = TimeUtils.now(),
+                                ),
+                                permissions = mutableListOf(),
+                            )
 
                             if (!application.application.closeApplication) {
                                 closeApp = false
                             }
+
+                            var permissionsChanged = false
+                            for (intentData in accountIntents) {
+                                val isChecked = MultiEventScreenIntents.checkedStates[intentData.id] ?: true
+                                if (rememberType != RememberType.NEVER && isChecked) {
+                                    val rejectKind = if (intentData.type == SignerType.SIGN_EVENT) intentData.event?.kind else null
+                                    val rejectRelay = if (intentData.type == SignerType.SIGN_EVENT && intentData.event?.kind == 22242) {
+                                        if (relayAuthScope == RelayAuthScope.ALL) {
+                                            "*"
+                                        } else {
+                                            (
+                                                AmberEvent.relay(intentData.event)?.let { url ->
+                                                    try {
+                                                        java.net.URI(url).host ?: url
+                                                    } catch (e: Exception) {
+                                                        url
+                                                    }
+                                                } ?: ""
+                                                )
+                                        }
+                                    } else {
+                                        ""
+                                    }
+                                    AmberUtils.updatePermission(
+                                        application,
+                                        localKey,
+                                        intentData.type,
+                                        rejectKind,
+                                        false,
+                                        rememberType,
+                                        relay = rejectRelay,
+                                        encryptedData = intentData.encryptedData,
+                                    )
+                                    permissionsChanged = true
+                                }
+                            }
+
+                            if (permissionsChanged || application.application.key.isBlank()) {
+                                database.dao().insertApplicationWithPermissions(application)
+                            }
                         }
+
                         sendRejectIntent(
                             results = intents.map {
                                 Result(
@@ -292,215 +295,203 @@ fun IntentMultiEventHomeScreen(
                         try {
                             val results = mutableListOf<Result>()
                             var closeApp = true
-
                             onRemoveIntentData(intents, IntentResultType.REMOVE)
+                            val localKey = packageName ?: return@launch
+                            val intentsByAccount = intents.groupBy { it.currentAccount.ifBlank { accountParam.npub } }
 
-                            for (intentData in intents) {
-                                val thisAccount =
-                                    if (intentData.currentAccount.isNotBlank()) {
-                                        LocalPreferences.loadFromEncryptedStorage(
-                                            context,
-                                            intentData.currentAccount,
-                                        )
-                                    } else {
-                                        accountParam
-                                    } ?: continue
-
-                                val localKey = packageName ?: continue
+                            for ((accountNpub, accountIntents) in intentsByAccount) {
+                                val thisAccount = if (accountNpub == accountParam.npub) {
+                                    accountParam
+                                } else {
+                                    LocalPreferences.loadFromEncryptedStorage(context, accountNpub)
+                                } ?: continue
 
                                 val database = Amber.instance.getDatabase(thisAccount.npub)
                                 val historyDatabase = Amber.instance.getHistoryDatabase(thisAccount.npub)
-                                val savedApplication = database.dao().getByKey(localKey)
-
-                                val application =
-                                    savedApplication ?: ApplicationWithPermissions(
-                                        application = ApplicationEntity(
-                                            localKey,
-                                            "",
-                                            listOf(),
-                                            "",
-                                            "",
-                                            "",
-                                            thisAccount.hexKey,
-                                            true,
-                                            "",
-                                            false,
-                                            thisAccount.signPolicy,
-                                            true,
-                                            0L,
-                                            lastUsed = TimeUtils.now(),
-                                        ),
-                                        permissions = mutableListOf(),
-                                    )
+                                val application = database.dao().getByKey(localKey) ?: ApplicationWithPermissions(
+                                    application = ApplicationEntity(
+                                        localKey,
+                                        "",
+                                        listOf(),
+                                        "",
+                                        "",
+                                        "",
+                                        thisAccount.hexKey,
+                                        true,
+                                        "",
+                                        false,
+                                        thisAccount.signPolicy,
+                                        true,
+                                        0L,
+                                        lastUsed = TimeUtils.now(),
+                                    ),
+                                    permissions = mutableListOf(),
+                                )
 
                                 if (!application.application.closeApplication) {
                                     closeApp = false
                                 }
 
-                                val isChecked = MultiEventScreenIntents.checkedStates[intentData.id] ?: true
+                                var permissionsChanged = false
+                                val historyList = mutableListOf<HistoryEntity>()
 
-                                if (intentData.type == SignerType.SIGN_EVENT) {
-                                    val localEvent = intentData.event!!
+                                for (intentData in accountIntents) {
+                                    val isChecked = MultiEventScreenIntents.checkedStates[intentData.id] ?: true
+                                    val type = intentData.type
 
-                                    if (rememberType != RememberType.NEVER && isChecked) {
-                                        val signRelay = if (localEvent.kind == 22242) {
-                                            if (relayAuthScope == RelayAuthScope.ALL) {
-                                                "*"
+                                    if (type == SignerType.SIGN_EVENT) {
+                                        val localEvent = intentData.event!!
+
+                                        if (rememberType != RememberType.NEVER && isChecked) {
+                                            val signRelay = if (localEvent.kind == 22242) {
+                                                if (relayAuthScope == RelayAuthScope.ALL) {
+                                                    "*"
+                                                } else {
+                                                    (
+                                                        AmberEvent.relay(localEvent)?.let { url ->
+                                                            try {
+                                                                java.net.URI(url).host ?: url
+                                                            } catch (e: Exception) {
+                                                                url
+                                                            }
+                                                        } ?: ""
+                                                        )
+                                                }
                                             } else {
-                                                (
-                                                    AmberEvent.relay(localEvent)?.let { url ->
-                                                        try {
-                                                            java.net.URI(url).host ?: url
-                                                        } catch (e: Exception) {
-                                                            url
-                                                        }
-                                                    } ?: ""
-                                                    )
+                                                ""
                                             }
-                                        } else {
-                                            ""
+                                            AmberUtils.updatePermission(
+                                                application,
+                                                localKey,
+                                                type,
+                                                localEvent.kind,
+                                                true,
+                                                rememberType,
+                                                relay = signRelay,
+                                                encryptedData = intentData.encryptedData,
+                                            )
+                                            permissionsChanged = true
                                         }
-                                        AmberUtils.acceptOrRejectPermission(
-                                            application,
-                                            localKey,
-                                            intentData.type,
-                                            localEvent.kind,
-                                            true,
-                                            rememberType,
-                                            thisAccount,
-                                            relay = signRelay,
-                                            encryptedData = intentData.encryptedData,
-                                        )
-                                    }
 
-                                    database.dao().insertApplicationWithPermissions(application)
-
-                                    historyDatabase.dao().addHistory(
-                                        HistoryEntity(
-                                            0,
-                                            localKey,
-                                            intentData.type.toString(),
-                                            localEvent.kind,
-                                            TimeUtils.now(),
-                                            isChecked,
-                                            content = localEvent.toJson(),
-                                        ),
-                                        thisAccount.npub,
-                                    )
-
-                                    if (isChecked) {
-                                        results.add(
-                                            Result(
-                                                null,
-                                                signature = if (localEvent is LnZapRequestEvent &&
-                                                    localEvent.tags.any { tag ->
-                                                        tag.any { t -> t == "anon" }
-                                                    }
-                                                ) {
-                                                    localEvent.toJson()
-                                                } else {
-                                                    localEvent.sig
-                                                },
-                                                result = if (localEvent is LnZapRequestEvent &&
-                                                    localEvent.tags.any { tag ->
-                                                        tag.any { t -> t == "anon" }
-                                                    }
-                                                ) {
-                                                    localEvent.toJson()
-                                                } else {
-                                                    localEvent.sig
-                                                },
-                                                id = intentData.id,
-                                                rejected = null,
+                                        historyList.add(
+                                            HistoryEntity(
+                                                0,
+                                                localKey,
+                                                type.toString(),
+                                                localEvent.kind,
+                                                TimeUtils.now(),
+                                                isChecked,
+                                                content = localEvent.toJson(),
                                             ),
                                         )
-                                    }
-                                } else if (intentData.type == SignerType.SIGN_MESSAGE) {
-                                    if (rememberType != RememberType.NEVER && isChecked) {
-                                        AmberUtils.acceptOrRejectPermission(
-                                            application,
-                                            localKey,
-                                            intentData.type,
-                                            null,
-                                            true,
-                                            rememberType,
-                                            thisAccount,
-                                            encryptedData = intentData.encryptedData,
-                                        )
-                                    }
 
-                                    database.dao().insertApplicationWithPermissions(application)
-                                    historyDatabase.dao().addHistory(
-                                        HistoryEntity(
-                                            0,
-                                            localKey,
-                                            intentData.type.toString(),
-                                            null,
-                                            TimeUtils.now(),
-                                            isChecked,
-                                            content = intentData.data,
-                                        ),
-                                        thisAccount.npub,
-                                    )
-
-                                    val signedMessage = thisAccount.signString(intentData.data)
-                                    if (isChecked) {
-                                        results.add(
-                                            Result(
-                                                null,
-                                                signature = signedMessage,
-                                                result = signedMessage,
-                                                id = intentData.id,
-                                                rejected = null,
-                                            ),
-                                        )
-                                    }
-                                } else {
-                                    if (rememberType != RememberType.NEVER && isChecked) {
-                                        AmberUtils.acceptOrRejectPermission(
-                                            application,
-                                            localKey,
-                                            intentData.type,
-                                            null,
-                                            true,
-                                            rememberType,
-                                            thisAccount,
-                                            encryptedData = intentData.encryptedData,
-                                        )
-                                    }
-
-                                    database.dao().insertApplicationWithPermissions(application)
-
-                                    historyDatabase.dao().addHistory(
-                                        HistoryEntity(
-                                            0,
-                                            localKey,
-                                            intentData.type.toString(),
-                                            null,
-                                            TimeUtils.now(),
-                                            isChecked,
-                                            content = if (intentData.type == SignerType.NIP04_DECRYPT || intentData.type == SignerType.NIP44_DECRYPT || intentData.type == SignerType.DECRYPT_ZAP_EVENT) {
-                                                intentData.encryptedData?.result ?: ""
+                                        if (isChecked) {
+                                            val signature = if (localEvent is LnZapRequestEvent &&
+                                                localEvent.tags.any { tag ->
+                                                    tag.any { t -> t == "anon" }
+                                                }
+                                            ) {
+                                                localEvent.toJson()
                                             } else {
-                                                intentData.data
-                                            },
-                                        ),
-                                        thisAccount.npub,
-                                    )
-
-                                    val signature = intentData.encryptedData?.result ?: continue
-                                    if (isChecked) {
-                                        results.add(
-                                            Result(
+                                                localEvent.sig
+                                            }
+                                            results.add(
+                                                Result(
+                                                    null,
+                                                    signature = signature,
+                                                    result = signature,
+                                                    id = intentData.id,
+                                                    rejected = null,
+                                                ),
+                                            )
+                                        }
+                                    } else if (type == SignerType.SIGN_MESSAGE) {
+                                        if (rememberType != RememberType.NEVER && isChecked) {
+                                            AmberUtils.updatePermission(
+                                                application,
+                                                localKey,
+                                                type,
                                                 null,
-                                                signature = signature,
-                                                result = signature,
-                                                id = intentData.id,
-                                                rejected = null,
+                                                true,
+                                                rememberType,
+                                                encryptedData = intentData.encryptedData,
+                                            )
+                                            permissionsChanged = true
+                                        }
+
+                                        historyList.add(
+                                            HistoryEntity(
+                                                0,
+                                                localKey,
+                                                type.toString(),
+                                                null,
+                                                TimeUtils.now(),
+                                                isChecked,
+                                                content = intentData.data,
                                             ),
                                         )
+
+                                        val signedMessage = thisAccount.signString(intentData.data)
+                                        if (isChecked) {
+                                            results.add(
+                                                Result(
+                                                    null,
+                                                    signature = signedMessage,
+                                                    result = signedMessage,
+                                                    id = intentData.id,
+                                                    rejected = null,
+                                                ),
+                                            )
+                                        }
+                                    } else {
+                                        if (rememberType != RememberType.NEVER && isChecked) {
+                                            AmberUtils.updatePermission(
+                                                application,
+                                                localKey,
+                                                type,
+                                                null,
+                                                true,
+                                                rememberType,
+                                                encryptedData = intentData.encryptedData,
+                                            )
+                                            permissionsChanged = true
+                                        }
+
+                                        historyList.add(
+                                            HistoryEntity(
+                                                0,
+                                                localKey,
+                                                type.toString(),
+                                                null,
+                                                TimeUtils.now(),
+                                                isChecked,
+                                                content = if (type == SignerType.NIP04_DECRYPT || type == SignerType.NIP44_DECRYPT || type == SignerType.DECRYPT_ZAP_EVENT) {
+                                                    intentData.encryptedData?.result ?: ""
+                                                } else {
+                                                    intentData.data
+                                                },
+                                            ),
+                                        )
+
+                                        val signature = intentData.encryptedData?.result
+                                        if (isChecked && signature != null) {
+                                            results.add(
+                                                Result(
+                                                    null,
+                                                    signature = signature,
+                                                    result = signature,
+                                                    id = intentData.id,
+                                                    rejected = null,
+                                                ),
+                                            )
+                                        }
                                     }
                                 }
+
+                                if (permissionsChanged || application.application.key.isBlank()) {
+                                    database.dao().insertApplicationWithPermissions(application)
+                                }
+                                historyDatabase.dao().addHistory(historyList, thisAccount.npub)
                             }
 
                             if (results.isNotEmpty()) {


### PR DESCRIPTION
- Grouped operations by local account to minimize database opening and data loading.
- Added AmberUtils.updatePermission for in-memory permission modifications.
- Implemented bulk history insertion in HistoryDao to reduce I/O overhead.
- Staged permission updates and performed a single database write per account.
- Fixed minor compilation issues and improved overall efficiency for large event batches.