### PR TITLE
Add activity statistics and filtering to Activities screen

### DIFF
--- a/app/src/main/java/com/greenart7c3/nostrsigner/database/HistoryDao.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/database/HistoryDao.kt
@@ -24,8 +24,14 @@ interface HistoryDao {
     @Query("SELECT * FROM history where (kind = :query OR LOWER(type) LIKE '%' || :query || '%' OR LOWER(translatedPermission) LIKE '%' || :query || '%' OR LOWER(content) LIKE '%' || :query || '%') AND pkKey = :pk ORDER BY time DESC")
     fun searchAllHistoryPaging(pk: String, query: String): PagingSource<Int, HistoryEntity>
 
-    @Query("SELECT * FROM history ORDER BY time DESC")
-    fun getAllHistoryPaging(): PagingSource<Int, HistoryEntity>
+    @Query(
+        """
+    SELECT * FROM history
+    WHERE (:acceptedFilter IS NULL OR accepted = :acceptedFilter)
+    ORDER BY time DESC
+    """,
+    )
+    fun getAllHistoryPaging(acceptedFilter: Boolean?): PagingSource<Int, HistoryEntity>
 
     @Query(
         """
@@ -33,13 +39,20 @@ interface HistoryDao {
     WHERE (kind = :query OR LOWER(type) LIKE '%' || :query || '%'
     OR LOWER(translatedPermission) LIKE '%' || :query || '%'
     OR LOWER(content) LIKE '%' || :query || '%')
+    AND (:acceptedFilter IS NULL OR accepted = :acceptedFilter)
     ORDER BY time DESC
     """,
     )
-    fun searchAllHistoryPaging(query: String): PagingSource<Int, HistoryEntity>
+    fun searchAllHistoryPaging(query: String, acceptedFilter: Boolean?): PagingSource<Int, HistoryEntity>
 
     @Query("DELETE FROM history where pkKey = :pk")
     suspend fun deleteHistory(pk: String)
+
+    @Query("SELECT COUNT(*) FROM history WHERE time >= :sinceSeconds AND accepted = 1")
+    suspend fun countAcceptedSince(sinceSeconds: Long): Long
+
+    @Query("SELECT COUNT(*) FROM history WHERE time >= :sinceSeconds AND accepted = 0")
+    suspend fun countRejectedSince(sinceSeconds: Long): Long
 
     @Query("SELECT COUNT(*) FROM history")
     suspend fun getCount(): Long

--- a/app/src/main/java/com/greenart7c3/nostrsigner/database/HistoryDao.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/database/HistoryDao.kt
@@ -18,11 +18,28 @@ private const val MAX_CONTENT_LENGTH = 500
 
 @Dao
 interface HistoryDao {
-    @Query("SELECT * FROM history where pkKey = :pk ORDER BY time DESC")
-    fun getAllHistoryPaging(pk: String): PagingSource<Int, HistoryEntity>
+    @Query(
+        """
+    SELECT * FROM history
+    WHERE pkKey = :pk
+    AND (:acceptedFilter IS NULL OR accepted = :acceptedFilter)
+    ORDER BY time DESC
+    """,
+    )
+    fun getAllHistoryPaging(pk: String, acceptedFilter: Boolean?): PagingSource<Int, HistoryEntity>
 
-    @Query("SELECT * FROM history where (kind = :query OR LOWER(type) LIKE '%' || :query || '%' OR LOWER(translatedPermission) LIKE '%' || :query || '%' OR LOWER(content) LIKE '%' || :query || '%') AND pkKey = :pk ORDER BY time DESC")
-    fun searchAllHistoryPaging(pk: String, query: String): PagingSource<Int, HistoryEntity>
+    @Query(
+        """
+    SELECT * FROM history
+    WHERE pkKey = :pk
+    AND (kind = :query OR LOWER(type) LIKE '%' || :query || '%'
+    OR LOWER(translatedPermission) LIKE '%' || :query || '%'
+    OR LOWER(content) LIKE '%' || :query || '%')
+    AND (:acceptedFilter IS NULL OR accepted = :acceptedFilter)
+    ORDER BY time DESC
+    """,
+    )
+    fun searchAllHistoryPaging(pk: String, query: String, acceptedFilter: Boolean?): PagingSource<Int, HistoryEntity>
 
     @Query(
         """
@@ -53,6 +70,12 @@ interface HistoryDao {
 
     @Query("SELECT COUNT(*) FROM history WHERE time >= :sinceSeconds AND accepted = 0")
     suspend fun countRejectedSince(sinceSeconds: Long): Long
+
+    @Query("SELECT COUNT(*) FROM history WHERE pkKey = :pk AND time >= :sinceSeconds AND accepted = 1")
+    suspend fun countAcceptedSince(pk: String, sinceSeconds: Long): Long
+
+    @Query("SELECT COUNT(*) FROM history WHERE pkKey = :pk AND time >= :sinceSeconds AND accepted = 0")
+    suspend fun countRejectedSince(pk: String, sinceSeconds: Long): Long
 
     @Query("SELECT COUNT(*) FROM history")
     suspend fun getCount(): Long

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/ActivitiesScreen.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/ActivitiesScreen.kt
@@ -11,11 +11,13 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -25,6 +27,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -53,12 +56,19 @@ import com.greenart7c3.nostrsigner.models.supportedKindNumbers
 import com.greenart7c3.nostrsigner.service.ApplicationNameCache
 import com.greenart7c3.nostrsigner.service.model.AmberEvent
 import com.greenart7c3.nostrsigner.service.toShortenHex
+import com.greenart7c3.nostrsigner.ui.components.ActivityStatsCard
 import com.greenart7c3.nostrsigner.ui.components.EventSection
 import com.greenart7c3.nostrsigner.ui.components.SimpleSearchBar
 import com.greenart7c3.nostrsigner.ui.components.TagsSection
 import com.greenart7c3.nostrsigner.ui.components.copyToClipboard
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+
+enum class ActivityFilter(val accepted: Boolean?) {
+    ALL(null),
+    ACCEPTED(true),
+    REJECTED(false),
+}
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -72,8 +82,9 @@ fun ActivitiesScreen(
 
     val context = LocalContext.current
     var searchQuery by remember { mutableStateOf("") }
+    var filter by rememberSaveable(account.npub) { mutableStateOf(ActivityFilter.ALL) }
 
-    val pager = remember(searchQuery) {
+    val pager = remember(searchQuery, filter) {
         Pager(
             PagingConfig(
                 pageSize = 20,
@@ -81,9 +92,9 @@ fun ActivitiesScreen(
             ),
         ) {
             if (searchQuery.isEmpty()) {
-                database.dao().getAllHistoryPaging()
+                database.dao().getAllHistoryPaging(filter.accepted)
             } else {
-                database.dao().searchAllHistoryPaging(searchQuery.lowercase())
+                database.dao().searchAllHistoryPaging(searchQuery.lowercase(), filter.accepted)
             }
         }
     }
@@ -96,6 +107,28 @@ fun ActivitiesScreen(
     Column(
         modifier = modifier.padding(top = topPadding),
     ) {
+        ActivityStatsCard(
+            account = account,
+            modifier = Modifier
+                .padding(
+                    start = paddingValues.calculateLeftPadding(LayoutDirection.Ltr),
+                    end = paddingValues.calculateRightPadding(LayoutDirection.Ltr),
+                    top = 8.dp,
+                    bottom = 4.dp,
+                )
+                .fillMaxWidth(),
+        )
+        ActivityFilterRow(
+            selected = filter,
+            onSelect = { filter = it },
+            modifier = Modifier
+                .padding(
+                    start = paddingValues.calculateLeftPadding(LayoutDirection.Ltr),
+                    end = paddingValues.calculateRightPadding(LayoutDirection.Ltr),
+                    bottom = 4.dp,
+                )
+                .fillMaxWidth(),
+        )
         SimpleSearchBar(
             modifier = Modifier
                 .padding(start = paddingValues.calculateLeftPadding(LayoutDirection.Ltr), end = paddingValues.calculateRightPadding(LayoutDirection.Ltr))
@@ -246,6 +279,41 @@ fun ActivityRow(activity: HistoryEntity, account: Account) {
             )
         }
         HorizontalDivider(color = MaterialTheme.colorScheme.primary)
+    }
+}
+
+@Composable
+fun ActivityFilterRow(
+    selected: ActivityFilter,
+    onSelect: (ActivityFilter) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    LazyRow(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        contentPadding = PaddingValues(horizontal = 4.dp),
+    ) {
+        item {
+            FilterChip(
+                selected = selected == ActivityFilter.ALL,
+                onClick = { onSelect(ActivityFilter.ALL) },
+                label = { Text(stringResource(R.string.filter_all)) },
+            )
+        }
+        item {
+            FilterChip(
+                selected = selected == ActivityFilter.ACCEPTED,
+                onClick = { onSelect(ActivityFilter.ACCEPTED) },
+                label = { Text(stringResource(R.string.filter_accepted)) },
+            )
+        }
+        item {
+            FilterChip(
+                selected = selected == ActivityFilter.REJECTED,
+                onClick = { onSelect(ActivityFilter.REJECTED) },
+                label = { Text(stringResource(R.string.filter_rejected)) },
+            )
+        }
     }
 }
 

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/actions/ActivityScreen.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/actions/ActivityScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -28,7 +29,10 @@ import androidx.paging.compose.itemKey
 import com.greenart7c3.nostrsigner.Amber
 import com.greenart7c3.nostrsigner.models.Account
 import com.greenart7c3.nostrsigner.models.supportedKindNumbers
+import com.greenart7c3.nostrsigner.ui.ActivityFilter
+import com.greenart7c3.nostrsigner.ui.ActivityFilterRow
 import com.greenart7c3.nostrsigner.ui.ActivityRow
+import com.greenart7c3.nostrsigner.ui.components.ActivityStatsCard
 import com.greenart7c3.nostrsigner.ui.components.SimpleSearchBar
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -44,8 +48,9 @@ fun ActivityScreen(
 
     val context = LocalContext.current
     var searchQuery by remember { mutableStateOf("") }
+    var filter by rememberSaveable(account.npub, key) { mutableStateOf(ActivityFilter.ALL) }
 
-    val pager = remember(searchQuery) {
+    val pager = remember(searchQuery, filter) {
         Pager(
             PagingConfig(
                 pageSize = 20,
@@ -53,9 +58,9 @@ fun ActivityScreen(
             ),
         ) {
             if (searchQuery.isEmpty()) {
-                database.dao().getAllHistoryPaging(key)
+                database.dao().getAllHistoryPaging(key, filter.accepted)
             } else {
-                database.dao().searchAllHistoryPaging(key, searchQuery.lowercase())
+                database.dao().searchAllHistoryPaging(key, searchQuery.lowercase(), filter.accepted)
             }
         }
     }
@@ -68,6 +73,29 @@ fun ActivityScreen(
     Column(
         modifier = modifier.padding(top = topPadding),
     ) {
+        ActivityStatsCard(
+            account = account,
+            pkKey = key,
+            modifier = Modifier
+                .padding(
+                    start = paddingValues.calculateLeftPadding(LayoutDirection.Ltr),
+                    end = paddingValues.calculateRightPadding(LayoutDirection.Ltr),
+                    top = 8.dp,
+                    bottom = 4.dp,
+                )
+                .fillMaxWidth(),
+        )
+        ActivityFilterRow(
+            selected = filter,
+            onSelect = { filter = it },
+            modifier = Modifier
+                .padding(
+                    start = paddingValues.calculateLeftPadding(LayoutDirection.Ltr),
+                    end = paddingValues.calculateRightPadding(LayoutDirection.Ltr),
+                    bottom = 4.dp,
+                )
+                .fillMaxWidth(),
+        )
         SimpleSearchBar(
             modifier = Modifier
                 .padding(start = paddingValues.calculateLeftPadding(LayoutDirection.Ltr), end = paddingValues.calculateRightPadding(LayoutDirection.Ltr))

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/ActivityStatsCard.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/ActivityStatsCard.kt
@@ -61,16 +61,17 @@ private data class WindowStats(
 fun ActivityStatsCard(
     account: Account,
     modifier: Modifier = Modifier,
+    pkKey: String? = null,
 ) {
     val dao = remember(account.npub) {
         Amber.instance.getHistoryDatabase(account.npub).dao()
     }
-    var expanded by rememberSaveable(account.npub) { mutableStateOf(false) }
-    var stats by remember(account.npub) { mutableStateOf<List<WindowStats>?>(null) }
+    var expanded by rememberSaveable(account.npub, pkKey) { mutableStateOf(false) }
+    var stats by remember(account.npub, pkKey) { mutableStateOf<List<WindowStats>?>(null) }
 
-    LaunchedEffect(account.npub, expanded) {
+    LaunchedEffect(account.npub, pkKey, expanded) {
         if (expanded && stats == null) {
-            stats = withContext(Dispatchers.IO) { loadStats(dao) }
+            stats = withContext(Dispatchers.IO) { loadStats(dao, pkKey) }
         }
     }
 
@@ -228,7 +229,7 @@ private fun ActivityStatsBar(stats: WindowStats, maxTotal: Long) {
     }
 }
 
-private suspend fun loadStats(dao: HistoryDao): List<WindowStats> {
+private suspend fun loadStats(dao: HistoryDao, pkKey: String?): List<WindowStats> {
     val now = TimeUtils.now()
     val day = 24L * 60 * 60
     val windows = listOf(
@@ -240,8 +241,8 @@ private suspend fun loadStats(dao: HistoryDao): List<WindowStats> {
         val since = now - windowSeconds
         WindowStats(
             labelRes = labelRes,
-            accepted = dao.countAcceptedSince(since),
-            rejected = dao.countRejectedSince(since),
+            accepted = if (pkKey == null) dao.countAcceptedSince(since) else dao.countAcceptedSince(pkKey, since),
+            rejected = if (pkKey == null) dao.countRejectedSince(since) else dao.countRejectedSince(pkKey, since),
         )
     }
 }

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/ActivityStatsCard.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/ActivityStatsCard.kt
@@ -1,0 +1,247 @@
+package com.greenart7c3.nostrsigner.ui.components
+
+import androidx.annotation.StringRes
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ExpandMore
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.greenart7c3.nostrsigner.Amber
+import com.greenart7c3.nostrsigner.R
+import com.greenart7c3.nostrsigner.database.HistoryDao
+import com.greenart7c3.nostrsigner.models.Account
+import com.vitorpamplona.quartz.utils.TimeUtils
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+private val AcceptedColor = Color(0xFF1D8802)
+private val RejectedColor = Color(0xFFFF6B00)
+
+private data class WindowStats(
+    @StringRes val labelRes: Int,
+    val accepted: Long,
+    val rejected: Long,
+) {
+    val total: Long get() = accepted + rejected
+}
+
+@Composable
+fun ActivityStatsCard(
+    account: Account,
+    modifier: Modifier = Modifier,
+) {
+    val dao = remember(account.npub) {
+        Amber.instance.getHistoryDatabase(account.npub).dao()
+    }
+    var expanded by rememberSaveable(account.npub) { mutableStateOf(false) }
+    var stats by remember(account.npub) { mutableStateOf<List<WindowStats>?>(null) }
+
+    LaunchedEffect(account.npub, expanded) {
+        if (expanded && stats == null) {
+            stats = withContext(Dispatchers.IO) { loadStats(dao) }
+        }
+    }
+
+    val chevronRotation by animateFloatAsState(
+        targetValue = if (expanded) 180f else 0f,
+        label = "chevron",
+    )
+
+    Card(
+        modifier = modifier,
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant,
+        ),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable { expanded = !expanded }
+                .padding(horizontal = 12.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = stringResource(R.string.statistics),
+                modifier = Modifier.weight(1f),
+                fontWeight = FontWeight.Bold,
+            )
+            Icon(
+                imageVector = Icons.Default.ExpandMore,
+                contentDescription = null,
+                modifier = Modifier.rotate(chevronRotation),
+            )
+        }
+
+        AnimatedVisibility(visible = expanded) {
+            Column(
+                modifier = Modifier.padding(horizontal = 12.dp, vertical = 4.dp),
+            ) {
+                Legend()
+                Spacer(Modifier.height(8.dp))
+                val current = stats
+                if (current == null) {
+                    Text(
+                        text = "…",
+                        modifier = Modifier.padding(vertical = 8.dp),
+                    )
+                } else {
+                    val maxTotal = current.maxOf { it.total }
+                    current.forEach { window ->
+                        ActivityStatsBar(window, maxTotal)
+                        Spacer(Modifier.height(6.dp))
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun Legend() {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        LegendSwatch(AcceptedColor)
+        Spacer(Modifier.width(4.dp))
+        Text(stringResource(R.string.filter_accepted), fontWeight = FontWeight.Medium)
+        Spacer(Modifier.width(12.dp))
+        LegendSwatch(RejectedColor)
+        Spacer(Modifier.width(4.dp))
+        Text(stringResource(R.string.filter_rejected), fontWeight = FontWeight.Medium)
+    }
+}
+
+@Composable
+private fun LegendSwatch(color: Color) {
+    Box(
+        modifier = Modifier
+            .size(10.dp)
+            .clip(RoundedCornerShape(2.dp))
+            .background(color),
+    )
+}
+
+@Composable
+private fun ActivityStatsBar(stats: WindowStats, maxTotal: Long) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = stringResource(stats.labelRes),
+            modifier = Modifier.weight(0.32f),
+        )
+        Box(
+            modifier = Modifier
+                .weight(0.55f)
+                .height(12.dp)
+                .clip(RoundedCornerShape(6.dp))
+                .background(MaterialTheme.colorScheme.surface),
+        ) {
+            if (maxTotal > 0 && stats.total > 0) {
+                val filledFraction = stats.total.toFloat() / maxTotal.toFloat()
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth(filledFraction)
+                        .height(12.dp),
+                ) {
+                    if (stats.accepted > 0) {
+                        Box(
+                            modifier = Modifier
+                                .weight(stats.accepted.toFloat())
+                                .fillMaxWidth()
+                                .background(AcceptedColor),
+                        )
+                    }
+                    if (stats.rejected > 0) {
+                        Box(
+                            modifier = Modifier
+                                .weight(stats.rejected.toFloat())
+                                .fillMaxWidth()
+                                .background(RejectedColor),
+                        )
+                    }
+                }
+            }
+        }
+        Text(
+            text = stats.total.toString(),
+            modifier = Modifier
+                .weight(0.13f)
+                .padding(start = 8.dp),
+            textAlign = androidx.compose.ui.text.style.TextAlign.End,
+            fontWeight = FontWeight.Medium,
+        )
+    }
+    if (stats.total > 0) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(start = 4.dp, top = 2.dp),
+            horizontalArrangement = Arrangement.End,
+        ) {
+            Text(
+                text = "${stats.accepted}",
+                color = AcceptedColor,
+                fontWeight = FontWeight.Medium,
+            )
+            Text(
+                text = " · ",
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Text(
+                text = "${stats.rejected}",
+                color = RejectedColor,
+                fontWeight = FontWeight.Medium,
+            )
+        }
+    }
+}
+
+private suspend fun loadStats(dao: HistoryDao): List<WindowStats> {
+    val now = TimeUtils.now()
+    val day = 24L * 60 * 60
+    val windows = listOf(
+        R.string.last_24_hours to day,
+        R.string.last_7_days to 7 * day,
+        R.string.last_30_days to 30 * day,
+    )
+    return windows.map { (labelRes, windowSeconds) ->
+        val since = now - windowSeconds
+        WindowStats(
+            labelRes = labelRes,
+            accepted = dao.countAcceptedSince(since),
+            rejected = dao.countRejectedSince(since),
+        )
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -775,4 +775,11 @@
     <string name="event_kind_37516">Geocache Listing</string>
     <string name="event_kind_36787">Music Track</string>
     <string name="event_kind_34139">Music Playlist</string>
+    <string name="statistics">Statistics</string>
+    <string name="last_24_hours">Last 24 hours</string>
+    <string name="last_7_days">Last 7 days</string>
+    <string name="last_30_days">Last 30 days</string>
+    <string name="filter_all">All</string>
+    <string name="filter_accepted">Accepted</string>
+    <string name="filter_rejected">Rejected</string>
 </resources>


### PR DESCRIPTION
## Summary
This PR adds activity statistics visualization and filtering capabilities to the Activities screen, allowing users to view acceptance/rejection rates across different time windows and filter activities by status.

## Key Changes
- **New ActivityStatsCard component**: Displays acceptance/rejection statistics for the last 24 hours, 7 days, and 30 days in an expandable card with visual bar charts
- **Activity filtering**: Added `ActivityFilter` enum with ALL, ACCEPTED, and REJECTED options, with filter chips in the Activities screen
- **Database queries**: Extended `HistoryDao` with new methods:
  - `countAcceptedSince()` and `countRejectedSince()` to retrieve statistics for time windows
  - Updated `getAllHistoryPaging()` and `searchAllHistoryPaging()` to support optional accepted/rejected filtering
- **UI updates**: 
  - Integrated `ActivityStatsCard` at the top of the Activities screen
  - Added `ActivityFilterRow` with filter chip selection
  - Filter state is persisted using `rememberSaveable`
- **String resources**: Added new localization strings for statistics labels and filter options

## Implementation Details
- Statistics are loaded asynchronously on-demand when the stats card is expanded to avoid unnecessary database queries
- The bar chart visualization uses proportional widths based on the maximum total across all time windows
- Filter state is tied to the account's npub to maintain separate filters per account
- The pager is recreated when search query or filter changes to reflect the updated data

https://claude.ai/code/session_01XzbB6rRQ7BY9AyUpTiGvpq