### PR TITLE
Include app name in missing event kind report

### DIFF
--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/EventData.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/EventData.kt
@@ -89,7 +89,8 @@ fun EventData(
             modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
         )
         if (kindTranslation == unknownKindString && altTag == null) {
-            ReportMissingEventKindButton(account, event.kind)
+            val appInfo = packageName?.let { rememberAppDisplayInfo(it) }
+            ReportMissingEventKindButton(account, event.kind, appInfo?.name)
         }
         Spacer(Modifier.size(4.dp))
 
@@ -177,7 +178,7 @@ fun BunkerEventData(
             modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
         )
         if (kindTranslation == unknownKindString && altTag == null) {
-            ReportMissingEventKindButton(account, event.kind)
+            ReportMissingEventKindButton(account, event.kind, appName)
         }
         Spacer(Modifier.size(4.dp))
 
@@ -240,11 +241,15 @@ fun ContactListDetail(title: String, text: String) {
 }
 
 @Composable
-fun ReportMissingEventKindButton(account: Account, kind: Int) {
+fun ReportMissingEventKindButton(account: Account, kind: Int, appName: String? = null) {
     val clipboardManager = LocalClipboard.current
     AmberButton(
         onClick = {
-            val text = "Missing event kind translation: $kind"
+            val text = if (!appName.isNullOrBlank()) {
+                "Missing event kind translation: $kind (app: $appName)"
+            } else {
+                "Missing event kind translation: $kind"
+            }
             if (BuildFlavorChecker.isOfflineFlavor()) {
                 Amber.instance.applicationIOScope.launch(Dispatchers.Main) {
                     clipboardManager.setClipEntry(


### PR DESCRIPTION
## Summary
Enhanced the missing event kind reporting feature to include the app name when available, providing more context for debugging and issue tracking.

## Key Changes
- Modified `ReportMissingEventKindButton` to accept an optional `appName` parameter
- Updated the report message to include the app name when available: `"Missing event kind translation: $kind (app: $appName)"`
- In `EventData` composable: retrieve app display info from package name and pass it to the report button
- In `BunkerEventData` composable: pass the existing `appName` parameter to the report button

## Implementation Details
- The `appName` parameter is optional (defaults to `null`) to maintain backward compatibility
- App name is only included in the report message when it's not null or blank
- The app display info is retrieved using `rememberAppDisplayInfo()` in the `EventData` composable, which handles the package name lookup

https://claude.ai/code/session_017v4MvTB2yEVccGNJyggKxx