### PR TITLE
Add translation report dialog with offline and online support

### DIFF
--- a/app/src/main/java/com/greenart7c3/nostrsigner/Amber.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/Amber.kt
@@ -89,6 +89,7 @@ class Amber :
     private var mainActivityRef: WeakReference<AppCompatActivity?>? = null
     val crashReportCache: CrashReportCache by lazy { CrashReportCache(this.applicationContext) }
     var pendingCrashReport: String? = null
+    val pendingTranslationReport = MutableStateFlow<String?>(null)
 
     fun setMainActivity(activity: AppCompatActivity?) {
         Log.d(TAG, "Setting main activity ref to $activity")

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/MainScreen.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/MainScreen.kt
@@ -988,6 +988,26 @@ fun MainScreen(
                     )
 
                     composable(
+                        Route.TranslationReport.route,
+                        content = {
+                            TranslationReportScreen(
+                                modifier = Modifier
+                                    .fillMaxSize()
+                                    .padding(padding)
+                                    .consumeWindowInsets(padding)
+                                    .padding(horizontal = verticalPadding)
+                                    .padding(top = verticalPadding * 1.5f),
+                                account = account,
+                                onDismiss = {
+                                    Amber.instance.applicationIOScope.launch(Dispatchers.Main) {
+                                        navController.navController.navigateUp()
+                                    }
+                                },
+                            )
+                        },
+                    )
+
+                    composable(
                         Route.AuthWhitelist.route,
                         content = {
                             val scrollState = rememberScrollState()
@@ -1038,6 +1058,14 @@ fun MainScreen(
             }
 
             DisplayCrashMessages(account, navController)
+
+            LaunchedEffect(account) {
+                Amber.instance.pendingTranslationReport.collect { message ->
+                    if (message != null && navController.navController.currentDestination?.route != Route.TranslationReport.route) {
+                        navController.navController.navigate(Route.TranslationReport.route)
+                    }
+                }
+            }
         }
         if (isLoading) {
             CenterCircularProgressIndicator(

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/TranslationReportScreen.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/TranslationReportScreen.kt
@@ -1,0 +1,195 @@
+/**
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.greenart7c3.nostrsigner.ui
+
+import android.content.ClipData
+import android.content.Intent
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Done
+import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.ClipEntry
+import androidx.compose.ui.platform.LocalClipboard
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.core.net.toUri
+import com.greenart7c3.nostrsigner.Amber
+import com.greenart7c3.nostrsigner.BuildFlavorChecker
+import com.greenart7c3.nostrsigner.R
+import com.greenart7c3.nostrsigner.models.Account
+import com.vitorpamplona.quartz.nip01Core.relay.client.NostrClient
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
+import com.vitorpamplona.quartz.nip01Core.tags.people.PTag
+import com.vitorpamplona.quartz.nip17Dm.messages.ChatMessageEvent
+import com.vitorpamplona.quartz.nip19Bech32.toNpub
+import com.vitorpamplona.quartz.nip40Expiration.expiration
+import com.vitorpamplona.quartz.utils.Hex
+import com.vitorpamplona.quartz.utils.TimeUtils
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+@Composable
+fun TranslationReportScreen(
+    modifier: Modifier = Modifier,
+    account: Account,
+    onDismiss: () -> Unit,
+) {
+    val initialMessage = remember { Amber.instance.pendingTranslationReport.value ?: "" }
+    var editedMessage by remember { mutableStateOf(initialMessage) }
+    val clipboardManager = LocalClipboard.current
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        verticalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Column(
+            modifier = Modifier
+                .weight(1f)
+                .padding(bottom = 8.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Text(
+                text = if (BuildFlavorChecker.isOfflineFlavor()) {
+                    stringResource(R.string.copy_translation_report_to_clipboard)
+                } else {
+                    stringResource(R.string.would_you_like_to_send_the_translation_report_to_amber_in_a_dm)
+                },
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+
+            OutlinedTextField(
+                value = editedMessage,
+                onValueChange = { editedMessage = it },
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxWidth(),
+                textStyle = MaterialTheme.typography.bodyMedium,
+            )
+        }
+
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 8.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            OutlinedButton(
+                modifier = Modifier.weight(1f),
+                onClick = {
+                    Amber.instance.pendingTranslationReport.value = null
+                    onDismiss()
+                },
+            ) {
+                Text(stringResource(R.string.cancel))
+            }
+
+            Button(
+                modifier = Modifier.weight(1f),
+                onClick = {
+                    val report = editedMessage.ifBlank { return@Button }
+                    if (BuildFlavorChecker.isOfflineFlavor()) {
+                        Amber.instance.applicationIOScope.launch(Dispatchers.Main) {
+                            try {
+                                clipboardManager.setClipEntry(
+                                    ClipEntry(ClipData.newPlainText("", report)),
+                                )
+                                val intent = Intent(Intent.ACTION_VIEW)
+                                val npub = Hex.decode(Amber.DEVELOPER_HEX_KEY).toNpub()
+                                intent.data = "nostr:$npub".toUri()
+                                intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
+                                Amber.instance.startActivity(intent)
+                                Amber.instance.pendingTranslationReport.value = null
+                                onDismiss()
+                            } catch (_: Exception) {
+                                Amber.instance.pendingTranslationReport.value = null
+                                onDismiss()
+                            }
+                        }
+                    } else {
+                        Amber.instance.applicationIOScope.launch {
+                            val client = NostrClient(Amber.instance.factory, Amber.instance.applicationIOScope)
+                            client.connect()
+
+                            val template = ChatMessageEvent.build(
+                                msg = report,
+                                to = listOf(PTag(Amber.DEVELOPER_HEX_KEY)),
+                                createdAt = System.currentTimeMillis() / 1000,
+                            ) {
+                                val tenDaysInSeconds = 10L * 86_400
+                                expiration(TimeUtils.now() + tenDaysInSeconds)
+                            }
+                            val signedEvents = account.createMessageNIP17(template)
+                            signedEvents.wraps.forEach { wrap ->
+                                client.publish(
+                                    event = wrap,
+                                    relayList = setOf(
+                                        NormalizedRelayUrl(url = "wss://inbox.nostr.wine"),
+                                        NormalizedRelayUrl(url = "wss://nostr.land"),
+                                    ),
+                                )
+                            }
+                            Amber.instance.pendingTranslationReport.value = null
+                            onDismiss()
+                            delay(10000)
+                            client.disconnect()
+                        }
+                    }
+                },
+            ) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Icon(
+                        imageVector = Icons.Outlined.Done,
+                        tint = Color.Black,
+                        contentDescription = stringResource(R.string.translation_report_send),
+                    )
+                    Spacer(Modifier.size(4.dp))
+                    Text(stringResource(R.string.translation_report_send), color = Color.Black)
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/EventData.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/EventData.kt
@@ -1,7 +1,5 @@
 package com.greenart7c3.nostrsigner.ui.components
 
-import android.content.ClipData
-import android.content.Intent
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -18,8 +16,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.ClipEntry
-import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.SpanStyle
@@ -31,25 +27,12 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.core.net.toUri
 import com.greenart7c3.nostrsigner.Amber
-import com.greenart7c3.nostrsigner.BuildFlavorChecker
 import com.greenart7c3.nostrsigner.R
 import com.greenart7c3.nostrsigner.models.Account
 import com.greenart7c3.nostrsigner.models.Permission
 import com.greenart7c3.nostrsigner.ui.RememberType
 import com.vitorpamplona.quartz.nip01Core.core.Event
-import com.vitorpamplona.quartz.nip01Core.relay.client.NostrClient
-import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
-import com.vitorpamplona.quartz.nip01Core.tags.people.PTag
-import com.vitorpamplona.quartz.nip17Dm.messages.ChatMessageEvent
-import com.vitorpamplona.quartz.nip19Bech32.toNpub
-import com.vitorpamplona.quartz.nip40Expiration.expiration
-import com.vitorpamplona.quartz.utils.Hex
-import com.vitorpamplona.quartz.utils.TimeUtils
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -90,7 +73,7 @@ fun EventData(
         )
         if (kindTranslation == unknownKindString && altTag == null) {
             val appInfo = packageName?.let { rememberAppDisplayInfo(it) }
-            ReportMissingEventKindButton(account, event.kind, appInfo?.name)
+            ReportMissingEventKindButton(event.kind, appInfo?.name)
         }
         Spacer(Modifier.size(4.dp))
 
@@ -178,7 +161,7 @@ fun BunkerEventData(
             modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
         )
         if (kindTranslation == unknownKindString && altTag == null) {
-            ReportMissingEventKindButton(account, event.kind, appName)
+            ReportMissingEventKindButton(event.kind, appName)
         }
         Spacer(Modifier.size(4.dp))
 
@@ -241,8 +224,7 @@ fun ContactListDetail(title: String, text: String) {
 }
 
 @Composable
-fun ReportMissingEventKindButton(account: Account, kind: Int, appName: String? = null) {
-    val clipboardManager = LocalClipboard.current
+fun ReportMissingEventKindButton(kind: Int, appName: String? = null) {
     AmberButton(
         onClick = {
             val text = if (!appName.isNullOrBlank()) {
@@ -250,45 +232,7 @@ fun ReportMissingEventKindButton(account: Account, kind: Int, appName: String? =
             } else {
                 "Missing event kind translation: $kind"
             }
-            if (BuildFlavorChecker.isOfflineFlavor()) {
-                Amber.instance.applicationIOScope.launch(Dispatchers.Main) {
-                    clipboardManager.setClipEntry(
-                        ClipEntry(
-                            ClipData.newPlainText("", text),
-                        ),
-                    )
-                    val intent = Intent(Intent.ACTION_VIEW)
-                    val npub = Hex.decode(Amber.DEVELOPER_HEX_KEY).toNpub()
-                    intent.data = "nostr:$npub".toUri()
-                    intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
-                    Amber.instance.startActivity(intent)
-                }
-            } else {
-                Amber.instance.applicationIOScope.launch {
-                    val client = NostrClient(Amber.instance.factory, Amber.instance.applicationIOScope)
-                    client.connect()
-                    val template = ChatMessageEvent.build(
-                        msg = text,
-                        to = listOf(PTag(Amber.DEVELOPER_HEX_KEY)),
-                        createdAt = System.currentTimeMillis() / 1000,
-                    ) {
-                        val tenDaysInSeconds = 10L * 86_400
-                        expiration(TimeUtils.now() + tenDaysInSeconds)
-                    }
-                    val signedEvents = account.createMessageNIP17(template)
-                    signedEvents.wraps.forEach { wrap ->
-                        client.publish(
-                            event = wrap,
-                            relayList = setOf(
-                                NormalizedRelayUrl(url = "wss://inbox.nostr.wine"),
-                                NormalizedRelayUrl(url = "wss://nostr.land"),
-                            ),
-                        )
-                    }
-                    delay(10000)
-                    client.disconnect()
-                }
-            }
+            Amber.instance.pendingTranslationReport.value = text
         },
         text = stringResource(R.string.report_missing_event_kind_translation),
     )

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/navigation/Route.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/navigation/Route.kt
@@ -197,6 +197,12 @@ sealed class Route(
         icon = R.drawable.settings,
     )
 
+    data object TranslationReport : Route(
+        title = Amber.instance.getString(R.string.translation_report_title),
+        route = "TranslationReport",
+        icon = R.drawable.settings,
+    )
+
     data object AuthWhitelist : Route(
         title = Amber.instance.getString(R.string.auth_whitelist),
         route = "AuthWhitelist",
@@ -252,6 +258,7 @@ val routes = listOf(
     Route.Feedback,
     Route.Activities,
     Route.CrashReport,
+    Route.TranslationReport,
     Route.UpdateSettings,
     Route.CloudBackup,
     Route.ServiceSettings,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -729,6 +729,10 @@
     <string name="status_detail">Status Detail</string>
     <string name="amber_is_a_free_and_open_source_project">Amber is a free and open source project\n</string>
     <string name="report_missing_event_kind_translation">Report missing event kind translation</string>
+    <string name="translation_report_title">Missing translation report</string>
+    <string name="translation_report_send">Send it</string>
+    <string name="would_you_like_to_send_the_translation_report_to_amber_in_a_dm">Would you like to send this missing translation report to Amber in a DM? You can edit the message before sending.</string>
+    <string name="copy_translation_report_to_clipboard">Would you like to copy this missing translation report to your clipboard and open a Client to send it to Amber? You can edit the message before sending.</string>
     <string name="account_picture">Account picture</string>
     <string name="encrypt_and_copy_to_clipboard">Encrypt and copy to clipboard</string>
     <string name="encrypt_and_show_qr_code">Encrypt and show QR Code</string>


### PR DESCRIPTION
## Summary
This PR introduces a dedicated translation report screen that allows users to report missing event kind translations. The implementation supports both offline and online flavors of the app, with different behaviors for each.

## Key Changes
- **New `TranslationReportScreen` composable**: A modal dialog that displays a text field for users to edit and submit translation reports
  - For offline flavor: Copies the report to clipboard and opens the developer's Nostr profile
  - For online flavor: Sends the report as an encrypted NIP-17 DM to the developer with a 10-day expiration
  
- **Refactored `ReportMissingEventKindButton`**: Simplified the button logic by removing direct report submission code
  - Now sets `pendingTranslationReport` state instead of handling submission directly
  - Removed `Account` parameter as it's no longer needed for the button itself
  
- **Added navigation support**: 
  - New `Route.TranslationReport` route for the translation report screen
  - Added `LaunchedEffect` in `MainScreen` to navigate to the report screen when `pendingTranslationReport` is set
  
- **State management**: Added `pendingTranslationReport` observable to `Amber` singleton to track pending reports
  
- **UI strings**: Added new string resources for the translation report dialog

## Implementation Details
- The report submission logic is now centralized in `TranslationReportScreen`, making it easier to maintain
- Uses `NostrClient` for online submissions with proper relay configuration (inbox.nostr.wine, nostr.land)
- Implements proper cleanup with `onDismiss` callback and state clearing
- Supports editing the auto-generated report message before submission

https://claude.ai/code/session_016xf7j2Dff9bnDX3hytoUFm