### PR TITLE
Fix account selection logic using hexKey comparison

### DIFF
--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/BunkerConnectRequestScreen.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/BunkerConnectRequestScreen.kt
@@ -100,12 +100,19 @@ fun BunkerConnectRequestScreen(
             LocalPreferences.allCachedAccounts().forEach {
                 snapshot.add(it)
             }
+            if (snapshot.none { it.hexKey == account.hexKey }) {
+                snapshot.add(0, account)
+            }
         } else {
             snapshot.add(account)
         }
         snapshot
     }
-    var selectedAccountIndex by remember { mutableIntStateOf(accounts.indexOf(account)) }
+    var selectedAccountIndex by remember {
+        mutableIntStateOf(
+            accounts.indexOfFirst { it.hexKey == account.hexKey }.coerceAtLeast(0),
+        )
+    }
 
     // Trust scores for connection request relays
     val connectionRelays = remember { bunkerRequest.relays }

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/LoginWithPubKey.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/LoginWithPubKey.kt
@@ -119,9 +119,16 @@ fun LoginWithPubKey(
         LocalPreferences.allCachedAccounts().forEach {
             snapshot.add(it)
         }
+        if (snapshot.none { it.hexKey == account.hexKey }) {
+            snapshot.add(0, account)
+        }
         snapshot
     }
-    var selectedAccountIndex by remember { mutableIntStateOf(accounts.indexOf(account)) }
+    var selectedAccountIndex by remember {
+        mutableIntStateOf(
+            accounts.indexOfFirst { it.hexKey == account.hexKey }.coerceAtLeast(0),
+        )
+    }
     var showModal by remember { mutableStateOf(false) }
     val sheetState = rememberModalBottomSheetState(
         skipPartiallyExpanded = true,


### PR DESCRIPTION
## Summary
Fixed account selection logic in two screens to properly identify and select the current account by comparing hexKey values instead of relying on object equality.

## Key Changes
- **BunkerConnectRequestScreen.kt**: Updated account list initialization and selection logic
  - Added check to ensure current account is included in the snapshot if not already cached
  - Changed `selectedAccountIndex` calculation from `indexOf()` to `indexOfFirst()` with hexKey comparison
  - Added `coerceAtLeast(0)` to handle cases where account is not found

- **LoginWithPubKey.kt**: Applied identical fixes to maintain consistency
  - Added check to ensure current account is included in the snapshot if not already cached
  - Changed `selectedAccountIndex` calculation from `indexOf()` to `indexOfFirst()` with hexKey comparison
  - Added `coerceAtLeast(0)` to handle cases where account is not found

## Implementation Details
The changes address a potential issue where account selection could fail if the account object wasn't found in the list (returning -1 from `indexOf()`). By using `indexOfFirst()` with explicit hexKey comparison, the code now:
1. Properly identifies accounts by their unique identifier rather than object reference
2. Ensures the current account is always available in the selection list
3. Safely defaults to index 0 if the account cannot be found, preventing invalid state

https://claude.ai/code/session_01VjSAybDgE56zxqh8rkArbA