### PR TITLE
Add invalid intent error reporting UI and refactor report sending

### DIFF
--- a/app/src/main/java/com/greenart7c3/nostrsigner/SignerActivity.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/SignerActivity.kt
@@ -43,6 +43,7 @@ import com.greenart7c3.nostrsigner.ui.AccountScreen
 import com.greenart7c3.nostrsigner.ui.AccountStateViewModel
 import com.greenart7c3.nostrsigner.ui.CenterCircularProgressIndicator
 import com.greenart7c3.nostrsigner.ui.IntentWrapper
+import com.greenart7c3.nostrsigner.ui.InvalidIntentScreen
 import com.greenart7c3.nostrsigner.ui.NavHostControllerWrapper
 import com.greenart7c3.nostrsigner.ui.components.BiometricAuthScreen
 import com.greenart7c3.nostrsigner.ui.navigation.Route
@@ -107,6 +108,9 @@ class SignerActivity : AppCompatActivity() {
                         val context = LocalContext.current
                         var isAuthenticated by remember { mutableStateOf(false) }
 
+                        val invalidIntent by IntentUtils.invalidIntents
+                            .collectAsStateWithLifecycle(initialValue = null)
+
                         ModalBottomSheet(
                             sheetGesturesEnabled = false,
                             onDismissRequest = {
@@ -125,58 +129,70 @@ class SignerActivity : AppCompatActivity() {
                                 modifier = Modifier.fillMaxWidth(),
                                 color = MaterialTheme.colorScheme.background,
                             ) {
-                                BiometricAuthScreen(
-                                    onAuth = {
-                                        isAuthenticated = it
-                                    },
-                                )
-
-                                if (!isAuthenticated) {
-                                    Box(
+                                val err = invalidIntent
+                                if (err != null) {
+                                    InvalidIntentScreen(
                                         modifier = Modifier.fillMaxSize(),
-                                        contentAlignment = Alignment.Center,
-                                    ) {
-                                        CircularProgressIndicator()
-                                    }
+                                        info = err,
+                                        onClose = {
+                                            IntentUtils.clearInvalidIntents()
+                                            finishAndRemoveTask()
+                                        },
+                                    )
                                 } else {
-                                    val bunkerRequests = BunkerRequestUtils.state.collectAsStateWithLifecycle(persistentListOf())
-                                    val npub = remember { mainViewModel.getAccount(intent?.getStringExtra("current_user")) }
+                                    BiometricAuthScreen(
+                                        onAuth = {
+                                            isAuthenticated = it
+                                        },
+                                    )
 
-                                    val accountStateViewModel: AccountStateViewModel =
-                                        viewModel {
-                                            AccountStateViewModel(npub)
+                                    if (!isAuthenticated) {
+                                        Box(
+                                            modifier = Modifier.fillMaxSize(),
+                                            contentAlignment = Alignment.Center,
+                                        ) {
+                                            CircularProgressIndicator()
                                         }
+                                    } else {
+                                        val bunkerRequests = BunkerRequestUtils.state.collectAsStateWithLifecycle(persistentListOf())
+                                        val npub = remember { mainViewModel.getAccount(intent?.getStringExtra("current_user")) }
 
-                                    LaunchedEffect(Unit, bunkerRequests.value) {
-                                        launch(Dispatchers.IO) {
-                                            val localNpub = mainViewModel.getAccount(intent?.getStringExtra("current_user"))
-                                            val currentAccount = LocalPreferences.currentAccount(context)
-                                            if (currentAccount != null && localNpub != null && currentAccount != localNpub && localNpub.isNotBlank()) {
-                                                if (localNpub.startsWith("npub")) {
-                                                    Log.d(Amber.TAG, "Switching account to $localNpub")
-                                                    if (LocalPreferences.containsAccount(context, localNpub)) {
-                                                        accountStateViewModel.switchUser(localNpub, Route.IncomingRequest.route)
-                                                    }
-                                                } else {
-                                                    val localNpub2 = Hex.decode(localNpub).toNpub()
-                                                    Log.d(Amber.TAG, "Switching account to $localNpub2")
-                                                    if (LocalPreferences.containsAccount(context, localNpub2)) {
-                                                        accountStateViewModel.switchUser(localNpub2, Route.IncomingRequest.route)
+                                        val accountStateViewModel: AccountStateViewModel =
+                                            viewModel {
+                                                AccountStateViewModel(npub)
+                                            }
+
+                                        LaunchedEffect(Unit, bunkerRequests.value) {
+                                            launch(Dispatchers.IO) {
+                                                val localNpub = mainViewModel.getAccount(intent?.getStringExtra("current_user"))
+                                                val currentAccount = LocalPreferences.currentAccount(context)
+                                                if (currentAccount != null && localNpub != null && currentAccount != localNpub && localNpub.isNotBlank()) {
+                                                    if (localNpub.startsWith("npub")) {
+                                                        Log.d(Amber.TAG, "Switching account to $localNpub")
+                                                        if (LocalPreferences.containsAccount(context, localNpub)) {
+                                                            accountStateViewModel.switchUser(localNpub, Route.IncomingRequest.route)
+                                                        }
+                                                    } else {
+                                                        val localNpub2 = Hex.decode(localNpub).toNpub()
+                                                        Log.d(Amber.TAG, "Switching account to $localNpub2")
+                                                        if (LocalPreferences.containsAccount(context, localNpub2)) {
+                                                            accountStateViewModel.switchUser(localNpub2, Route.IncomingRequest.route)
+                                                        }
                                                     }
                                                 }
                                             }
                                         }
-                                    }
 
-                                    AccountScreen(
-                                        accountStateViewModel = accountStateViewModel,
-                                        intent = remember(intent) { IntentWrapper(intent) },
-                                        packageName = packageName,
-                                        appName = appName,
-                                        bunkerRequests = bunkerRequests.value,
-                                        navController = NavHostControllerWrapper(navController),
-                                        isExternalRequest = true,
-                                    )
+                                        AccountScreen(
+                                            accountStateViewModel = accountStateViewModel,
+                                            intent = remember(intent) { IntentWrapper(intent) },
+                                            packageName = packageName,
+                                            appName = appName,
+                                            bunkerRequests = bunkerRequests.value,
+                                            navController = NavHostControllerWrapper(navController),
+                                            isExternalRequest = true,
+                                        )
+                                    }
                                 }
                             }
                         }
@@ -225,6 +241,9 @@ class SignerActivity : AppCompatActivity() {
             if (toRemove.isNotEmpty()) {
                 IntentUtils.removeAll(toRemove)
             }
+        }
+        if (isFinishing) {
+            IntentUtils.clearInvalidIntents()
         }
         super.onDestroy()
     }

--- a/app/src/main/java/com/greenart7c3/nostrsigner/service/IntentUtils.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/service/IntentUtils.kt
@@ -54,7 +54,10 @@ import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -63,6 +66,45 @@ import kotlinx.coroutines.withContext
 object IntentUtils {
     private val _intents = MutableStateFlow<ImmutableList<IntentData>>(persistentListOf())
     val intents = _intents.asStateFlow()
+
+    data class InvalidIntentInfo(
+        val id: String,
+        val dataString: String?,
+        val callingPackage: String?,
+        val typeExtra: String?,
+        val message: String,
+        val stackTrace: String?,
+        val timestampMs: Long = System.currentTimeMillis(),
+    )
+
+    private val _invalidIntents = MutableSharedFlow<InvalidIntentInfo>(
+        replay = 1,
+        extraBufferCapacity = 4,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST,
+    )
+    val invalidIntents = _invalidIntents.asSharedFlow()
+
+    fun clearInvalidIntents() {
+        _invalidIntents.resetReplayCache()
+    }
+
+    private fun emitInvalid(
+        intent: Intent,
+        packageName: String?,
+        message: String,
+        t: Throwable? = null,
+    ) {
+        _invalidIntents.tryEmit(
+            InvalidIntentInfo(
+                id = UUID.randomUUID().toString(),
+                dataString = intent.dataString,
+                callingPackage = packageName,
+                typeExtra = intent.extras?.getString("type"),
+                message = message,
+                stackTrace = t?.stackTraceToString(),
+            ),
+        )
+    }
 
     fun addAll(list: List<IntentData>) {
         _intents.update { current ->
@@ -162,6 +204,7 @@ object IntentUtils {
             }
 
             if (type == SignerType.INVALID) {
+                emitInvalid(intent, packageName, "Unknown signer type in URL: ${intent.dataString}")
                 return null
             }
 
@@ -291,6 +334,7 @@ object IntentUtils {
         val type = parseSignerType(intent.extras?.getString("type"))
 
         if (type == SignerType.INVALID) {
+            emitInvalid(intent, packageName, "Unknown signer type: ${intent.extras?.getString("type")}")
             return null
         }
 
@@ -609,6 +653,7 @@ object IntentUtils {
             }
         } catch (e: Exception) {
             Log.e(Amber.TAG, "Error parsing intent: ${e.message}", e)
+            emitInvalid(intent, packageName, "Error parsing intent: ${e.message}", e)
             Amber.instance.applicationIOScope.launch {
                 LocalPreferences.allSavedAccounts(Amber.instance).forEach {
                     Amber.instance.getLogDatabase(it.npub).dao().insertLog(

--- a/app/src/main/java/com/greenart7c3/nostrsigner/service/ReportSender.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/service/ReportSender.kt
@@ -1,0 +1,116 @@
+/**
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.greenart7c3.nostrsigner.service
+
+import android.content.ClipData
+import android.content.Intent
+import androidx.compose.ui.platform.ClipEntry
+import androidx.compose.ui.platform.Clipboard
+import androidx.core.net.toUri
+import com.greenart7c3.nostrsigner.Amber
+import com.greenart7c3.nostrsigner.BuildFlavorChecker
+import com.greenart7c3.nostrsigner.models.Account
+import com.vitorpamplona.quartz.nip01Core.relay.client.NostrClient
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
+import com.vitorpamplona.quartz.nip01Core.tags.people.PTag
+import com.vitorpamplona.quartz.nip17Dm.messages.ChatMessageEvent
+import com.vitorpamplona.quartz.nip19Bech32.toNpub
+import com.vitorpamplona.quartz.nip40Expiration.expiration
+import com.vitorpamplona.quartz.utils.Hex
+import com.vitorpamplona.quartz.utils.TimeUtils
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+object ReportSender {
+    fun send(
+        account: Account?,
+        report: String,
+        clipboard: Clipboard,
+        onDone: () -> Unit,
+    ) {
+        if (report.isBlank()) {
+            onDone()
+            return
+        }
+        val useOffline = BuildFlavorChecker.isOfflineFlavor() || account == null
+        if (useOffline) {
+            sendOffline(report, clipboard, onDone)
+        } else {
+            sendOnline(account, report, onDone)
+        }
+    }
+
+    private fun sendOffline(
+        report: String,
+        clipboard: Clipboard,
+        onDone: () -> Unit,
+    ) {
+        Amber.instance.applicationIOScope.launch(Dispatchers.Main) {
+            try {
+                clipboard.setClipEntry(
+                    ClipEntry(ClipData.newPlainText("", report)),
+                )
+                val intent = Intent(Intent.ACTION_VIEW)
+                val npub = Hex.decode(Amber.DEVELOPER_HEX_KEY).toNpub()
+                intent.data = "nostr:$npub".toUri()
+                intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
+                Amber.instance.startActivity(intent)
+                onDone()
+            } catch (_: Exception) {
+                onDone()
+            }
+        }
+    }
+
+    private fun sendOnline(
+        account: Account,
+        report: String,
+        onDone: () -> Unit,
+    ) {
+        Amber.instance.applicationIOScope.launch {
+            val client = NostrClient(Amber.instance.factory, Amber.instance.applicationIOScope)
+            client.connect()
+
+            val template = ChatMessageEvent.build(
+                msg = report,
+                to = listOf(PTag(Amber.DEVELOPER_HEX_KEY)),
+                createdAt = System.currentTimeMillis() / 1000,
+            ) {
+                val thirtyDaysInSeconds = 30L * 86_400
+                expiration(TimeUtils.now() + thirtyDaysInSeconds)
+            }
+            val signedEvents = account.createMessageNIP17(template)
+            signedEvents.wraps.forEach { wrap ->
+                client.publish(
+                    event = wrap,
+                    relayList = setOf(
+                        NormalizedRelayUrl(url = "wss://inbox.nostr.wine"),
+                        NormalizedRelayUrl(url = "wss://nostr.land"),
+                    ),
+                )
+            }
+            onDone()
+            delay(10000)
+            client.disconnect()
+        }
+    }
+}

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/InvalidIntentScreen.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/InvalidIntentScreen.kt
@@ -45,24 +45,42 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalClipboard
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import com.greenart7c3.nostrsigner.Amber
-import com.greenart7c3.nostrsigner.BuildFlavorChecker
+import com.greenart7c3.nostrsigner.BuildConfig
+import com.greenart7c3.nostrsigner.LocalPreferences
 import com.greenart7c3.nostrsigner.R
-import com.greenart7c3.nostrsigner.models.Account
+import com.greenart7c3.nostrsigner.service.IntentUtils
 import com.greenart7c3.nostrsigner.service.ReportSender
+import kotlinx.coroutines.launch
 
 @Composable
-fun CrashReportScreen(
+fun InvalidIntentScreen(
     modifier: Modifier = Modifier,
-    account: Account,
-    onDismiss: () -> Unit,
+    info: IntentUtils.InvalidIntentInfo,
+    onClose: () -> Unit,
 ) {
-    val initialStack = remember { Amber.instance.pendingCrashReport ?: "" }
-    var editedStack by remember { mutableStateOf(initialStack) }
+    val context = LocalContext.current
     val clipboardManager = LocalClipboard.current
+
+    val initialReport = remember(info.id) {
+        buildString {
+            appendLine("Reason: ${info.message}")
+            appendLine("Caller: ${info.callingPackage ?: "unknown"}")
+            appendLine("Type extra: ${info.typeExtra ?: "(none)"}")
+            appendLine("Data: ${info.dataString ?: "(none)"}")
+            appendLine("Amber: ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})")
+            appendLine("Time: ${info.timestampMs}")
+            info.stackTrace?.let {
+                appendLine()
+                append(it)
+            }
+        }
+    }
+    var editedReport by remember { mutableStateOf(initialReport) }
 
     Column(
         modifier = modifier
@@ -77,18 +95,19 @@ fun CrashReportScreen(
             verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
             Text(
-                text = if (BuildFlavorChecker.isOfflineFlavor()) {
-                    stringResource(R.string.copy_crash_report_to_clipboard)
-                } else {
-                    stringResource(R.string.would_you_like_to_send_the_recent_crash_report_to_amber_in_a_dm_no_personal_information_will_be_shared)
-                },
+                text = stringResource(R.string.invalid_intent_title),
+                style = MaterialTheme.typography.headlineSmall,
+            )
+
+            Text(
+                text = stringResource(R.string.invalid_intent_body),
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
 
             OutlinedTextField(
-                value = editedStack,
-                onValueChange = { editedStack = it },
+                value = editedReport,
+                onValueChange = { editedReport = it },
                 modifier = Modifier
                     .weight(1f)
                     .fillMaxWidth(),
@@ -104,26 +123,24 @@ fun CrashReportScreen(
         ) {
             OutlinedButton(
                 modifier = Modifier.weight(1f),
-                onClick = {
-                    Amber.instance.pendingCrashReport = null
-                    onDismiss()
-                },
+                onClick = onClose,
             ) {
-                Text(stringResource(R.string.cancel))
+                Text(stringResource(R.string.invalid_intent_close_app))
             }
 
             Button(
                 modifier = Modifier.weight(1f),
                 onClick = {
-                    ReportSender.send(
-                        account = account,
-                        report = editedStack,
-                        clipboard = clipboardManager,
-                        onDone = {
-                            Amber.instance.pendingCrashReport = null
-                            onDismiss()
-                        },
-                    )
+                    val report = editedReport
+                    Amber.instance.applicationIOScope.launch {
+                        val account = LocalPreferences.loadFromEncryptedStorage(context)
+                        ReportSender.send(
+                            account = account,
+                            report = report,
+                            clipboard = clipboardManager,
+                            onDone = onClose,
+                        )
+                    }
                 },
             ) {
                 Row(
@@ -132,10 +149,10 @@ fun CrashReportScreen(
                     Icon(
                         imageVector = Icons.Outlined.Done,
                         tint = Color.Black,
-                        contentDescription = stringResource(R.string.crashreport_found_send),
+                        contentDescription = stringResource(R.string.invalid_intent_send_report),
                     )
                     Spacer(Modifier.size(4.dp))
-                    Text(stringResource(R.string.crashreport_found_send), color = Color.Black)
+                    Text(stringResource(R.string.invalid_intent_send_report), color = Color.Black)
                 }
             }
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -678,6 +678,10 @@
     <string name="would_you_like_to_send_the_recent_crash_report_to_amber_in_a_dm_no_personal_information_will_be_shared">Would you like to send the recent crash report to Amber in a DM? No personal information will be shared</string>
     <string name="copy_crash_report_to_clipboard">Would you like to copy the crash report to your clipboard and open a Client to send it to Amber?</string>
     <string name="crashreport_found_send">Send it</string>
+    <string name="invalid_intent_title">Invalid request</string>
+    <string name="invalid_intent_body">Amber received a malformed nostrsigner request and cannot process it. You can close the app or send the details to the developer to help fix the issue.</string>
+    <string name="invalid_intent_close_app">Close app</string>
+    <string name="invalid_intent_send_report">Send report to developer</string>
     <string name="event_content">Event content</string>
     <string name="event_kind_14">Direct Message</string>
     <string name="wants_to_encrypt_with">" wants to encrypt %1$s with %2$s"</string>


### PR DESCRIPTION
## Summary
This PR adds a new UI screen for displaying and reporting invalid intents, and refactors the report sending logic into a reusable service to eliminate code duplication.

## Key Changes

- **New `InvalidIntentScreen` Composable**: Displays invalid intent errors with editable report details including reason, caller package, intent type, data, app version, and stack trace. Users can either close the app or send the report.

- **New `ReportSender` Service**: Extracted common report sending logic into a reusable object that handles both offline (clipboard + intent) and online (Nostr NIP-17 DM) report delivery. Supports sending to the Amber developer via encrypted messages.

- **Invalid Intent Tracking**: Added `InvalidIntentInfo` data class and `invalidIntents` SharedFlow to `IntentUtils` for tracking and emitting invalid intent events. Invalid intents are now captured at three key points:
  - Unknown signer type in URL
  - Unknown signer type in extras
  - Exception during intent parsing

- **Updated `SignerActivity`**: Integrated `InvalidIntentScreen` to display when an invalid intent is detected, preventing the normal authentication flow from proceeding.

- **Refactored `CrashReportScreen`**: Replaced inline report sending logic with calls to `ReportSender.send()`, reducing code duplication and improving maintainability.

- **String Resources**: Added new localized strings for invalid intent UI (`invalid_intent_title`, `invalid_intent_body`, `invalid_intent_close_app`, `invalid_intent_send_report`).

## Implementation Details

- Invalid intents are emitted via a `MutableSharedFlow` with replay=1 to ensure the latest error is always available
- Report sending supports both online (with Nostr relay) and offline (clipboard + intent) modes
- Stack traces are captured and included in reports for debugging
- Reports are sent as encrypted NIP-17 DMs to the developer with 30-day expiration

https://claude.ai/code/session_014dca1nciVs7F7MhCKUR38E