### PR TITLE
Display account name and npub separately in SigningAs

### DIFF
--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/SigningAs.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/SigningAs.kt
@@ -88,12 +88,27 @@ fun SigningAs(account: Account, modifier: Modifier = Modifier) {
             }
 
             val name by account.name.collectAsStateWithLifecycle()
-            Text(
+            Column(
                 modifier = Modifier.padding(start = 8.dp),
-                text = name.ifBlank { account.npub.toShortenHex() },
-                fontWeight = FontWeight.Bold,
-                style = MaterialTheme.typography.bodyMedium,
-            )
+            ) {
+                if (name.isNotBlank()) {
+                    Text(
+                        text = name,
+                        fontWeight = FontWeight.Bold,
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                }
+                Text(
+                    text = account.npub.toShortenHex(),
+                    fontWeight = if (name.isBlank()) FontWeight.Bold else FontWeight.Normal,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = if (name.isBlank()) {
+                        MaterialTheme.colorScheme.onSurface
+                    } else {
+                        MaterialTheme.colorScheme.onSurfaceVariant
+                    },
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
Updated the SigningAs component to display the account name and npub address as separate text elements instead of showing only one or the other.

## Key Changes
- Replaced single `Text` composable with a `Column` layout to display both name and npub
- Account name is now always displayed when available (non-blank)
- Npub address is always displayed below the name
- Applied conditional styling:
  - Name uses bold font weight when present
  - Npub uses bold font weight only when name is blank (fallback behavior)
  - Npub uses secondary color (`onSurfaceVariant`) when name is present, primary color (`onSurface`) when name is blank

## Implementation Details
- The layout now provides better visual hierarchy by showing both pieces of identifying information
- Maintains backward compatibility by using bold styling for npub when no name is available
- Uses Material Design color scheme for appropriate contrast based on context

https://claude.ai/code/session_017F9tWC8mYTGop7CVmaK6QV