### PR TITLE
Add select/deselect all functionality to permissions list

### DIFF
--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/EnabledPermissions.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/EnabledPermissions.kt
@@ -3,6 +3,7 @@ package com.greenart7c3.nostrsigner.ui.components
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -13,6 +14,7 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.TriStateCheckbox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -20,7 +22,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.state.ToggleableState
 import androidx.compose.ui.unit.dp
+import com.greenart7c3.nostrsigner.R
 import com.greenart7c3.nostrsigner.models.Permission
 
 @Composable
@@ -31,41 +36,73 @@ fun EnabledPermissions(
     val enabledPermissions = localPermissions.map {
         remember { mutableStateOf(it.checked) }
     }
-    LazyColumn(
+
+    val allCheckedState = when {
+        enabledPermissions.all { it.value } -> ToggleableState.On
+        enabledPermissions.none { it.value } -> ToggleableState.Off
+        else -> ToggleableState.Indeterminate
+    }
+
+    val toggleAll = {
+        val newValue = allCheckedState != ToggleableState.On
+        localPermissions.forEachIndexed { index, item ->
+            item.checked = newValue
+            enabledPermissions[index].value = newValue
+        }
+    }
+
+    Column(
         modifier
             .fillMaxWidth()
             .padding(8.dp),
     ) {
-        itemsIndexed(localPermissions) { index, item ->
-            Card(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(vertical = 4.dp),
-                border = BorderStroke(1.dp, Color.LightGray),
-                colors = CardDefaults.cardColors().copy(
-                    containerColor = MaterialTheme.colorScheme.background,
-                ),
-            ) {
-                Row(
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                    verticalAlignment = Alignment.CenterVertically,
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable { toggleAll() },
+        ) {
+            TriStateCheckbox(
+                state = allCheckedState,
+                onClick = { toggleAll() },
+            )
+            Text(stringResource(R.string.select_deselect_all))
+        }
+
+        LazyColumn(
+            Modifier.fillMaxWidth(),
+        ) {
+            itemsIndexed(localPermissions) { index, item ->
+                Card(
                     modifier = Modifier
-                        .clickable {
-                            item.checked = !item.checked
-                            enabledPermissions[index].value = item.checked
-                        },
+                        .fillMaxWidth()
+                        .padding(vertical = 4.dp),
+                    border = BorderStroke(1.dp, Color.LightGray),
+                    colors = CardDefaults.cardColors().copy(
+                        containerColor = MaterialTheme.colorScheme.background,
+                    ),
                 ) {
-                    Checkbox(
-                        checked = enabledPermissions[index].value,
-                        onCheckedChange = { _ ->
-                            item.checked = !item.checked
-                            enabledPermissions[index].value = item.checked
-                        },
-                    )
-                    Text(
-                        modifier = Modifier.weight(1f),
-                        text = item.toLocalizedString(LocalContext.current),
-                    )
+                    Row(
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier
+                            .clickable {
+                                item.checked = !item.checked
+                                enabledPermissions[index].value = item.checked
+                            },
+                    ) {
+                        Checkbox(
+                            checked = enabledPermissions[index].value,
+                            onCheckedChange = { _ ->
+                                item.checked = !item.checked
+                                enabledPermissions[index].value = item.checked
+                            },
+                        )
+                        Text(
+                            modifier = Modifier.weight(1f),
+                            text = item.toLocalizedString(LocalContext.current),
+                        )
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
Added a "Select/Deselect All" feature to the EnabledPermissions component, allowing users to toggle all permissions at once using a tri-state checkbox.

## Key Changes
- Added `TriStateCheckbox` import and `ToggleableState` for managing three-state checkbox logic
- Implemented tri-state checkbox logic that displays:
  - **On** state when all permissions are checked
  - **Off** state when no permissions are checked
  - **Indeterminate** state when some permissions are checked
- Added a new header row with "Select/Deselect All" functionality that appears above the permissions list
- Wrapped the permissions list in a `Column` to accommodate the new header row
- Moved the `LazyColumn` inside the `Column` to maintain proper layout hierarchy
- Added string resource reference for the "Select/Deselect All" label

## Implementation Details
- The `toggleAll()` function updates both the model state (`item.checked`) and the UI state (`enabledPermissions[index].value`) to keep them in sync
- The tri-state checkbox automatically reflects the current selection state of all permissions
- The header row is clickable and toggles all permissions when clicked, matching the checkbox behavior

https://claude.ai/code/session_01NWZhLwgq1Vk8LW6cXUW7Vs