### PR TITLE
Display shortened npub in account selection supporting text

### DIFF
--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/BunkerConnectRequestScreen.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/BunkerConnectRequestScreen.kt
@@ -247,6 +247,12 @@ fun BunkerConnectRequestScreen(
                             fontSize = 16.sp,
                         )
                     },
+                    supportingContent = {
+                        val name by acc.name.collectAsStateWithLifecycle()
+                        if (name.isNotBlank()) {
+                            Text(acc.npub.toShortenHex())
+                        }
+                    },
                 )
             }
 

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/LoginWithPubKey.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/LoginWithPubKey.kt
@@ -207,6 +207,12 @@ fun LoginWithPubKey(
                             fontSize = 16.sp,
                         )
                     },
+                    supportingContent = {
+                        val name by acc.name.collectAsStateWithLifecycle()
+                        if (name.isNotBlank()) {
+                            Text(acc.npub.toShortenHex())
+                        }
+                    },
                 )
             }
 


### PR DESCRIPTION
## Summary
Added supporting text to account selection list items that displays the shortened npub (public key) when an account has a name assigned.

## Key Changes
- **BunkerConnectRequestScreen.kt**: Added `supportingContent` composable to the account list item that displays `acc.npub.toShortenHex()` when the account name is not blank
- **LoginWithPubKey.kt**: Added identical `supportingContent` composable to the account list item for consistency across the login flow

## Implementation Details
- The supporting text is conditionally displayed only when `acc.name` is not blank, using `collectAsStateWithLifecycle()` to observe the name state
- The shortened hex format of the npub provides a more compact identifier while maintaining uniqueness for user recognition
- This change improves account selection UX by showing both the account name and a shortened public key identifier

https://claude.ai/code/session_01FdoRXsBEEcikAFJB2NUp45