### PR TITLE
Always close SignerActivity after handling requests

### DIFF
--- a/app/src/main/java/com/greenart7c3/nostrsigner/service/AmberUtils.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/service/AmberUtils.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.compose.ui.text.intl.Locale
 import androidx.compose.ui.text.toUpperCase
 import com.greenart7c3.nostrsigner.Amber
+import com.greenart7c3.nostrsigner.SignerActivity
 import com.greenart7c3.nostrsigner.database.ApplicationPermissionsEntity
 import com.greenart7c3.nostrsigner.database.ApplicationWithPermissions
 import com.greenart7c3.nostrsigner.models.Account
@@ -69,7 +70,7 @@ object AmberUtils {
                     EventNotificationConsumer(context).notificationManager().cancelAll()
                     val activity = Amber.instance.getMainActivity()
                     activity?.intent = null
-                    if (closeApplication) {
+                    if (closeApplication || activity is SignerActivity) {
                         activity?.finishAndRemoveTask()
                     }
                 }

--- a/app/src/main/java/com/greenart7c3/nostrsigner/service/BunkerRequestUtils.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/service/BunkerRequestUtils.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.util.Log
 import com.greenart7c3.nostrsigner.Amber
 import com.greenart7c3.nostrsigner.R
+import com.greenart7c3.nostrsigner.SignerActivity
 import com.greenart7c3.nostrsigner.database.ApplicationEntity
 import com.greenart7c3.nostrsigner.database.ApplicationPermissionsEntity
 import com.greenart7c3.nostrsigner.database.ApplicationWithPermissions
@@ -333,7 +334,7 @@ object BunkerRequestUtils {
 
             val activity = Amber.instance.getMainActivity()
             activity?.intent = null
-            if (application.application.closeApplication) {
+            if (application.application.closeApplication || activity is SignerActivity) {
                 activity?.finishAndRemoveTask()
             }
 
@@ -519,7 +520,7 @@ object BunkerRequestUtils {
             EventNotificationConsumer(Amber.instance).notificationManager().cancelAll()
             val activity = Amber.instance.getMainActivity()
             activity?.intent = null
-            if (application.application.closeApplication) {
+            if (application.application.closeApplication || activity is SignerActivity) {
                 activity?.finishAndRemoveTask()
             }
 


### PR DESCRIPTION
## Summary
Modified the application closing logic to always close `SignerActivity` instances after handling Bunker requests and Amber operations, regardless of the `closeApplication` setting.

## Key Changes
- Updated `BunkerRequestUtils.kt`: Modified two conditions (lines 337 and 523) to close the activity if it's a `SignerActivity` instance, in addition to checking the `closeApplication` flag
- Updated `AmberUtils.kt`: Modified the closing condition (line 73) to apply the same logic for `SignerActivity` instances
- Added `SignerActivity` import to both files

## Implementation Details
The changes ensure that `SignerActivity` is always finished and removed from the task stack after request handling completes, providing consistent behavior for this specific activity type. This is achieved by adding an `|| activity is SignerActivity` check to the existing `closeApplication` condition in three locations across the codebase.

https://claude.ai/code/session_018t8RRiJPuVobDHqKe7pyaf