### PR TITLE
Improve notification permission request handling and error resilience

### DIFF
--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/MainScreen.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/MainScreen.kt
@@ -88,6 +88,14 @@ import kotlinx.collections.immutable.ImmutableList
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
+private fun ManagedActivityResultLauncher<String, Boolean>.tryLaunchPostNotifications() {
+    try {
+        launch("android.permission.POST_NOTIFICATIONS")
+    } catch (_: IllegalStateException) {
+        // Launcher unregistered (composable left composition); skip silently.
+    }
+}
+
 private fun askNotificationPermission(
     context: Context,
     requestPermissionLauncher: ManagedActivityResultLauncher<String, Boolean>,
@@ -101,7 +109,7 @@ private fun askNotificationPermission(
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
         val shouldShowRationale = LocalPreferences.shouldShowRationale(context)
         if (shouldShowRationale == null) {
-            requestPermissionLauncher.launch("android.permission.POST_NOTIFICATIONS")
+            requestPermissionLauncher.tryLaunchPostNotifications()
             return
         }
 
@@ -111,7 +119,7 @@ private fun askNotificationPermission(
 
         onShouldShowRequestPermissionRationale()
     } else {
-        requestPermissionLauncher.launch("android.permission.POST_NOTIFICATIONS")
+        requestPermissionLauncher.tryLaunchPostNotifications()
     }
 }
 
@@ -171,15 +179,13 @@ fun MainScreen(
 
     if (!BuildFlavorChecker.isOfflineFlavor()) {
         LaunchedEffect(Unit) {
-            launch(Dispatchers.IO) {
-                askNotificationPermission(
-                    context = context,
-                    requestPermissionLauncher = requestPermissionLauncher,
-                    onShouldShowRequestPermissionRationale = {
-                        showDialog.value = true
-                    },
-                )
-            }
+            askNotificationPermission(
+                context = context,
+                requestPermissionLauncher = requestPermissionLauncher,
+                onShouldShowRequestPermissionRationale = {
+                    showDialog.value = true
+                },
+            )
         }
     }
 
@@ -198,7 +204,7 @@ fun MainScreen(
                 Button(
                     onClick = {
                         showDialog.value = false
-                        requestPermissionLauncher.launch("android.permission.POST_NOTIFICATIONS")
+                        requestPermissionLauncher.tryLaunchPostNotifications()
                     },
                 ) {
                     Text(text = stringResource(R.string.allow))


### PR DESCRIPTION
## Summary
This PR improves the notification permission request flow by adding error handling for edge cases and removing unnecessary dispatcher specification.

## Key Changes
- **Added `tryLaunchPostNotifications()` extension function**: Wraps the permission launcher call in a try-catch block to gracefully handle `IllegalStateException` that occurs when the launcher is unregistered (e.g., when the composable has left composition). This prevents crashes in edge cases.
- **Replaced all direct `launch()` calls**: Updated three locations where `requestPermissionLauncher.launch("android.permission.POST_NOTIFICATIONS")` was called to use the new `tryLaunchPostNotifications()` method for consistent error handling.
- **Removed unnecessary `Dispatchers.IO` specification**: The `askNotificationPermission()` call in `LaunchedEffect` no longer explicitly launches on `Dispatchers.IO`, as the function doesn't perform blocking I/O operations that would require it.

## Implementation Details
The new `tryLaunchPostNotifications()` extension function silently catches `IllegalStateException` exceptions, which can occur when attempting to launch a permission request after the associated composable has been removed from composition. This is a common edge case in Compose applications where timing issues can cause launcher invocations to fail.

https://claude.ai/code/session_01QYZugxbmNHLfeb8iiYfxaB