### PR TITLE
Fix ActivityStatsBar layout and text overflow issues

### DIFF
--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/ActivityStatsCard.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/ActivityStatsCard.kt
@@ -164,7 +164,7 @@ private fun ActivityStatsBar(stats: WindowStats, maxTotal: Long) {
         )
         Box(
             modifier = Modifier
-                .weight(0.55f)
+                .weight(1f)
                 .height(12.dp)
                 .clip(RoundedCornerShape(6.dp))
                 .background(MaterialTheme.colorScheme.surface),
@@ -197,11 +197,10 @@ private fun ActivityStatsBar(stats: WindowStats, maxTotal: Long) {
         }
         Text(
             text = stats.total.toString(),
-            modifier = Modifier
-                .weight(0.13f)
-                .padding(start = 8.dp),
+            modifier = Modifier.padding(start = 8.dp),
             textAlign = androidx.compose.ui.text.style.TextAlign.End,
             fontWeight = FontWeight.Medium,
+            maxLines = 1,
         )
     }
     if (stats.total > 0) {


### PR DESCRIPTION
## Summary
Adjusted the layout and text rendering of the ActivityStatsBar component to improve visual presentation and prevent text overflow.

## Key Changes
- Changed the stats bar container weight from `0.55f` to `1f` to allow it to take up more available space
- Removed the fixed weight constraint (`0.13f`) from the total stats text to allow it to size naturally
- Added `maxLines = 1` to the total stats text to prevent text wrapping and ensure single-line display

## Implementation Details
These changes improve the layout proportions of the ActivityStatsBar by giving the progress bar more horizontal space while allowing the total count text to display without artificial constraints. The `maxLines = 1` addition ensures the text remains compact and doesn't cause unexpected layout shifts.

https://claude.ai/code/session_01Ugc4LzrevMiUDnJnd5PHhY