### PR TITLE
Add NIP-46 bunker proxy support for remote signing

### DIFF
--- a/app/src/main/java/com/greenart7c3/nostrsigner/Amber.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/Amber.kt
@@ -47,6 +47,7 @@ import com.greenart7c3.nostrsigner.service.ClearLogsWorker
 import com.greenart7c3.nostrsigner.service.ConnectivityService
 import com.greenart7c3.nostrsigner.service.NotificationSubscription
 import com.greenart7c3.nostrsigner.service.ProfileSubscription
+import com.greenart7c3.nostrsigner.service.ProxyResponseSubscription
 import com.greenart7c3.nostrsigner.service.TorManager
 import com.greenart7c3.nostrsigner.service.UpdateCheckWorker
 import com.greenart7c3.nostrsigner.service.ZapstoreUpdater
@@ -133,6 +134,9 @@ class Amber :
     val relayStats = RelayStats(client)
 
     val notificationSubscription = NotificationSubscription(client, this)
+
+    // Listens for NIP-46 responses from remote bunkers we're acting as a proxy for.
+    val proxyResponseSubscription = ProxyResponseSubscription(client, this)
 
     // This runs on the foreground only
     val profileSubscription = ProfileSubscription(client, this, applicationIOScope)
@@ -449,6 +453,7 @@ class Amber :
                 profileSubscription.updateFilter()
             }
             notificationSubscription.updateFilter()
+            proxyResponseSubscription.updateFilter()
         }
         Log.d(TAG, "checkForNewRelaysAndUpdateAllFilters wasActive: $wasActive")
         if (!wasActive) {

--- a/app/src/main/java/com/greenart7c3/nostrsigner/Amber.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/Amber.kt
@@ -52,6 +52,7 @@ import com.greenart7c3.nostrsigner.service.ClearLogsWorker
 import com.greenart7c3.nostrsigner.service.ConnectivityService
 import com.greenart7c3.nostrsigner.service.NotificationSubscription
 import com.greenart7c3.nostrsigner.service.ProfileSubscription
+import com.greenart7c3.nostrsigner.service.ProxyResponseSubscription
 import com.greenart7c3.nostrsigner.service.TorManager
 import com.greenart7c3.nostrsigner.service.UpdateCheckWorker
 import com.greenart7c3.nostrsigner.service.ZapstoreUpdater
@@ -138,6 +139,9 @@ class Amber :
     val relayStats = RelayStats(client)
 
     val notificationSubscription = NotificationSubscription(client, this)
+
+    // Listens for NIP-46 responses from remote bunkers we're acting as a proxy for.
+    val proxyResponseSubscription = ProxyResponseSubscription(client, this)
 
     // Per-account profile metadata fetch, started/stopped by the composables that display
     // each account (see ProfileSubscriptionEffect) rather than app-wide.
@@ -542,6 +546,7 @@ class Amber :
                 profileSubscription.updateFilters()
             }
             notificationSubscription.updateFilter()
+            proxyResponseSubscription.updateFilter()
         }
         AmberLog.d(TAG, "checkForNewRelaysAndUpdateAllFilters wasActive: $wasActive")
         if (!wasActive) {

--- a/app/src/main/java/com/greenart7c3/nostrsigner/Amber.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/Amber.kt
@@ -66,6 +66,7 @@ import com.vitorpamplona.quartz.nip01Core.relay.client.auth.RelayAuthenticator
 import com.vitorpamplona.quartz.nip01Core.relay.client.stats.RelayStats
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.RelayUrlNormalizer
+import com.vitorpamplona.quartz.nip01Core.signers.NostrSignerInternal
 import com.vitorpamplona.quartz.nip01Core.tags.people.PTag
 import com.vitorpamplona.quartz.nip34Git.issue.GitIssueEvent
 import com.vitorpamplona.quartz.nip34Git.repository.GitRepositoryEvent
@@ -129,11 +130,36 @@ class Amber :
         client.addConnectionListener(it)
     }
 
+    /**
+     * Signers registered transiently for relay AUTH only. Used while pairing
+     * with a remote bunker over a relay that requires NIP-42 auth, before the
+     * proxy account is created. Also covers any other "pre-login" relay
+     * publish that needs to auth.
+     */
+    val transientAuthSigners: MutableSet<NostrSignerInternal> = java.util.concurrent.ConcurrentHashMap.newKeySet()
+
+    fun registerTransientAuthSigner(signer: NostrSignerInternal) {
+        transientAuthSigners.add(signer)
+    }
+
+    fun unregisterTransientAuthSigner(signer: NostrSignerInternal) {
+        transientAuthSigners.remove(signer)
+    }
+
     // Authenticates with relays.
     val authCoordinator = RelayAuthenticator(client, applicationIOScope) { event ->
-        LocalPreferences.allAccounts(this).map { account ->
-            account.sign(event)
+        // Proxy accounts MUST sign auth events with their local keypair, not the
+        // remote bunker — the bunker lives behind these very relays, so forwarding
+        // would deadlock. For non-proxy accounts the usual path is fine.
+        val saved = LocalPreferences.allAccounts(this).map { account ->
+            if (account.isProxy) {
+                account.signer.sign(event)
+            } else {
+                account.sign(event)
+            }
         }
+        val transient = transientAuthSigners.map { it.sign(event) }
+        saved + transient
     }
 
     val relayStats = RelayStats(client)

--- a/app/src/main/java/com/greenart7c3/nostrsigner/LocalPreferences.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/LocalPreferences.kt
@@ -10,6 +10,7 @@ import androidx.core.os.LocaleListCompat
 import com.greenart7c3.nostrsigner.models.Account
 import com.greenart7c3.nostrsigner.models.AmberSettings
 import com.greenart7c3.nostrsigner.models.ProfileFetchInterval
+import com.greenart7c3.nostrsigner.models.ProxyAccountMetadata
 import com.greenart7c3.nostrsigner.models.TorMode
 import com.greenart7c3.nostrsigner.models.UpdateChannel
 import com.greenart7c3.nostrsigner.models.UpdateCheckFrequency
@@ -42,6 +43,10 @@ private enum class PrefKeys(val key: String) {
     USER_RELAYS_CREATED_AT("user_relays_created_at"),
     DID_BACKUP("did_backup"),
     BACKUP_APPLICATIONS("backup_applications"),
+    PROXY_REMOTE_PUBKEY("proxy_remote_pubkey"),
+    PROXY_RELAYS("proxy_relays"),
+    PROXY_BUNKER_NAME("proxy_bunker_name"),
+    PROXY_NOSTR_CONNECT_SECRET("proxy_nostr_connect_secret"),
 }
 
 private enum class SettingsKeys(val key: String) {
@@ -480,6 +485,17 @@ object LocalPreferences {
                 putString(PrefKeys.PROFILE_URL.key, account.picture.value)
                 putInt(PrefKeys.SIGN_POLICY.key, account.signPolicy)
                 putBoolean(PrefKeys.DID_BACKUP.key, account.didBackup)
+                account.proxy?.let { proxy ->
+                    putString(PrefKeys.PROXY_REMOTE_PUBKEY.key, proxy.remotePubkey)
+                    putString(PrefKeys.PROXY_RELAYS.key, proxy.relays.joinToString(separator = COMMA) { it.url })
+                    putString(PrefKeys.PROXY_BUNKER_NAME.key, proxy.bunkerName)
+                    putString(PrefKeys.PROXY_NOSTR_CONNECT_SECRET.key, proxy.nostrConnectSecret)
+                } ?: run {
+                    remove(PrefKeys.PROXY_REMOTE_PUBKEY.key)
+                    remove(PrefKeys.PROXY_RELAYS.key)
+                    remove(PrefKeys.PROXY_BUNKER_NAME.key)
+                    remove(PrefKeys.PROXY_NOSTR_CONNECT_SECRET.key)
+                }
             }
         }
 
@@ -727,6 +743,22 @@ object LocalPreferences {
             val signPolicy = getInt(PrefKeys.SIGN_POLICY.key, 1)
             val didBackup = getBoolean(PrefKeys.DID_BACKUP.key, true)
 
+            val proxyRemote = getString(PrefKeys.PROXY_REMOTE_PUBKEY.key, null)
+            val proxy = if (!proxyRemote.isNullOrBlank()) {
+                val relayCsv = getString(PrefKeys.PROXY_RELAYS.key, "") ?: ""
+                val relays = relayCsv.split(COMMA)
+                    .mapNotNull { it.trim().takeIf(String::isNotEmpty) }
+                    .mapNotNull { RelayUrlNormalizer.normalizeOrNull(it) }
+                ProxyAccountMetadata(
+                    remotePubkey = proxyRemote,
+                    relays = relays,
+                    bunkerName = getString(PrefKeys.PROXY_BUNKER_NAME.key, "") ?: "",
+                    nostrConnectSecret = getString(PrefKeys.PROXY_NOSTR_CONNECT_SECRET.key, "") ?: "",
+                )
+            } else {
+                null
+            }
+
             val account =
                 Account(
                     signer = NostrSignerInternal(KeyPair(privKey.hexToByteArray())),
@@ -736,6 +768,7 @@ object LocalPreferences {
                     picture = MutableStateFlow(picture),
                     signPolicy = signPolicy,
                     didBackup = didBackup,
+                    proxy = proxy,
                 )
             accountCache.put(npub, account)
             return account

--- a/app/src/main/java/com/greenart7c3/nostrsigner/LocalPreferences.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/LocalPreferences.kt
@@ -10,6 +10,7 @@ import androidx.core.content.edit
 import androidx.core.os.LocaleListCompat
 import com.greenart7c3.nostrsigner.models.Account
 import com.greenart7c3.nostrsigner.models.AmberSettings
+import com.greenart7c3.nostrsigner.models.ProxyAccountMetadata
 import com.greenart7c3.nostrsigner.models.TorMode
 import com.greenart7c3.nostrsigner.models.UpdateCheckFrequency
 import com.greenart7c3.nostrsigner.models.defaultAppRelays
@@ -37,6 +38,10 @@ private enum class PrefKeys(val key: String) {
     LAST_METADATA_UPDATE("last_metadata_update"),
     LAST_CHECK("last_check"),
     DID_BACKUP("did_backup"),
+    PROXY_REMOTE_PUBKEY("proxy_remote_pubkey"),
+    PROXY_RELAYS("proxy_relays"),
+    PROXY_BUNKER_NAME("proxy_bunker_name"),
+    PROXY_NOSTR_CONNECT_SECRET("proxy_nostr_connect_secret"),
 }
 
 private enum class SettingsKeys(val key: String) {
@@ -422,6 +427,17 @@ object LocalPreferences {
                 putString(PrefKeys.PROFILE_URL.key, account.picture.value)
                 putInt(PrefKeys.SIGN_POLICY.key, account.signPolicy)
                 putBoolean(PrefKeys.DID_BACKUP.key, account.didBackup)
+                account.proxy?.let { proxy ->
+                    putString(PrefKeys.PROXY_REMOTE_PUBKEY.key, proxy.remotePubkey)
+                    putString(PrefKeys.PROXY_RELAYS.key, proxy.relays.joinToString(separator = COMMA) { it.url })
+                    putString(PrefKeys.PROXY_BUNKER_NAME.key, proxy.bunkerName)
+                    putString(PrefKeys.PROXY_NOSTR_CONNECT_SECRET.key, proxy.nostrConnectSecret)
+                } ?: run {
+                    remove(PrefKeys.PROXY_REMOTE_PUBKEY.key)
+                    remove(PrefKeys.PROXY_RELAYS.key)
+                    remove(PrefKeys.PROXY_BUNKER_NAME.key)
+                    remove(PrefKeys.PROXY_NOSTR_CONNECT_SECRET.key)
+                }
             }
         }
 
@@ -621,6 +637,22 @@ object LocalPreferences {
             val signPolicy = getInt(PrefKeys.SIGN_POLICY.key, 1)
             val didBackup = getBoolean(PrefKeys.DID_BACKUP.key, true)
 
+            val proxyRemote = getString(PrefKeys.PROXY_REMOTE_PUBKEY.key, null)
+            val proxy = if (!proxyRemote.isNullOrBlank()) {
+                val relayCsv = getString(PrefKeys.PROXY_RELAYS.key, "") ?: ""
+                val relays = relayCsv.split(COMMA)
+                    .mapNotNull { it.trim().takeIf(String::isNotEmpty) }
+                    .mapNotNull { RelayUrlNormalizer.normalizeOrNull(it) }
+                ProxyAccountMetadata(
+                    remotePubkey = proxyRemote,
+                    relays = relays,
+                    bunkerName = getString(PrefKeys.PROXY_BUNKER_NAME.key, "") ?: "",
+                    nostrConnectSecret = getString(PrefKeys.PROXY_NOSTR_CONNECT_SECRET.key, "") ?: "",
+                )
+            } else {
+                null
+            }
+
             val account =
                 Account(
                     signer = NostrSignerInternal(KeyPair(privKey.hexToByteArray())),
@@ -630,6 +662,7 @@ object LocalPreferences {
                     picture = MutableStateFlow(picture),
                     signPolicy = signPolicy,
                     didBackup = didBackup,
+                    proxy = proxy,
                 )
             accountCache.put(npub, account)
             return account

--- a/app/src/main/java/com/greenart7c3/nostrsigner/MainViewModel.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/MainViewModel.kt
@@ -131,6 +131,12 @@ class MainViewModel(val context: Context) : ViewModel() {
             account?.let { acc ->
                 val intentData = IntentUtils.getIntentData(context, intent, callingPackage, intent.getStringExtra("route"), acc)
                 if (intentData != null) {
+                    if (acc.isProxy) {
+                        // Bunker proxy: forward the request silently. Never enqueue
+                        // it for the approval UI.
+                        val handled = IntentUtils.handleProxyIntent(context, acc, intentData, callingPackage)
+                        if (handled) return@let
+                    }
                     IntentUtils.addAll(listOf(intentData))
                     addedIntentIds.add(intentData.id)
                     // The calling app is visible to us now; capture its icon/name.

--- a/app/src/main/java/com/greenart7c3/nostrsigner/MainViewModel.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/MainViewModel.kt
@@ -132,6 +132,14 @@ class MainViewModel(val context: Context) : ViewModel() {
             account?.let { acc ->
                 val intentData = IntentUtils.getIntentData(context, intent, callingPackage, intent.getStringExtra("route"), acc)
                 if (intentData != null) {
+                    if (acc.isProxy) {
+                        // Bunker proxy: forward the request silently. Never enqueue
+                        // it for the approval UI.
+                        val handled = IntentUtils.handleProxyIntent(context, acc, intentData, callingPackage)
+                        if (handled) {
+                            return@let
+                        }
+                    }
                     IntentUtils.addAll(listOf(intentData))
                     addedIntentIds.add(intentData.id)
                 }

--- a/app/src/main/java/com/greenart7c3/nostrsigner/SignerActivity.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/SignerActivity.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Density
+import androidx.core.graphics.drawable.toDrawable
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.compose.rememberNavController
@@ -70,14 +71,17 @@ class SignerActivity : AppCompatActivity() {
         mainViewModel = MainViewModel(applicationContext)
 
         // If the request will be served by a bunker proxy account, the proxy
-        // forwards it transparently and finishes the activity itself. Render
-        // nothing so the user does not see the approval bottom sheet flash.
+        // forwards it transparently and finishes the activity itself. Make the
+        // activity completely invisible — no focus, no dim, no animation, no
+        // window content — so the user never sees Amber come up at all.
         val isProxyHandled = isProxyHandledIntent(intent)
+        if (isProxyHandled) {
+            makeWindowInvisible()
+        }
 
         intent?.let { mainViewModel.onNewIntent(it, callingPackage) }
 
         if (isProxyHandled) {
-            window.setBackgroundDrawable(android.graphics.drawable.ColorDrawable(android.graphics.Color.TRANSPARENT))
             setContent { }
             return
         }
@@ -237,9 +241,37 @@ class SignerActivity : AppCompatActivity() {
             // Mirror the onCreate gate: if a proxy account will silently
             // forward this intent, we never want to surface the approval UI.
             if (isProxyHandledIntent(intent)) {
-                window.setBackgroundDrawable(android.graphics.drawable.ColorDrawable(android.graphics.Color.TRANSPARENT))
+                makeWindowInvisible()
             }
             mainViewModel.onNewIntent(intent, callingPackage)
+        }
+    }
+
+    /**
+     * Makes the activity's window completely invisible and non-interactive. Used for
+     * bunker proxy accounts so the source app never loses focus and the user never
+     * sees Amber come to the foreground while the proxy forwards the request to the
+     * remote bunker.
+     */
+    private fun makeWindowInvisible() {
+        overridePendingTransition(0, 0)
+        window.setBackgroundDrawable(android.graphics.Color.TRANSPARENT.toDrawable())
+        window.clearFlags(android.view.WindowManager.LayoutParams.FLAG_DIM_BEHIND)
+        window.addFlags(
+            android.view.WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE or
+                android.view.WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE or
+                android.view.WindowManager.LayoutParams.FLAG_NOT_TOUCH_MODAL,
+        )
+        // Shrink the window to a single off-screen pixel so it cannot draw anything
+        // even briefly. The activity is still alive in the background to receive the
+        // proxy's setResult / finishAndRemoveTask call.
+        window.attributes = window.attributes.apply {
+            width = 1
+            height = 1
+            gravity = android.view.Gravity.TOP or android.view.Gravity.START
+            x = 0
+            y = 0
+            dimAmount = 0f
         }
     }
 

--- a/app/src/main/java/com/greenart7c3/nostrsigner/SignerActivity.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/SignerActivity.kt
@@ -68,7 +68,20 @@ class SignerActivity : AppCompatActivity() {
 
         Amber.instance.setMainActivity(this)
         mainViewModel = MainViewModel(applicationContext)
+
+        // If the request will be served by a bunker proxy account, the proxy
+        // forwards it transparently and finishes the activity itself. Render
+        // nothing so the user does not see the approval bottom sheet flash.
+        val isProxyHandled = isProxyHandledIntent(intent)
+
         intent?.let { mainViewModel.onNewIntent(it, callingPackage) }
+
+        if (isProxyHandled) {
+            window.setBackgroundDrawable(android.graphics.drawable.ColorDrawable(android.graphics.Color.TRANSPARENT))
+            setContent { }
+            return
+        }
+
         setContent {
             NostrSignerTheme {
                 HttpClientManager.setDefaultUserAgent("Amber/${BuildConfig.VERSION_NAME}")
@@ -221,6 +234,11 @@ class SignerActivity : AppCompatActivity() {
         super.onNewIntent(intent)
         setIntent(intent)
         if (::mainViewModel.isInitialized) {
+            // Mirror the onCreate gate: if a proxy account will silently
+            // forward this intent, we never want to surface the approval UI.
+            if (isProxyHandledIntent(intent)) {
+                window.setBackgroundDrawable(android.graphics.drawable.ColorDrawable(android.graphics.Color.TRANSPARENT))
+            }
             mainViewModel.onNewIntent(intent, callingPackage)
         }
     }
@@ -237,6 +255,21 @@ class SignerActivity : AppCompatActivity() {
             IntentUtils.clearInvalidIntents()
         }
         super.onDestroy()
+    }
+
+    /**
+     * Returns true if the current intent will be handled silently by the bunker
+     * proxy. In that case the activity should not render its approval UI — the
+     * proxy forwards the request to the remote bunker and calls
+     * [finishAndRemoveTask] from [IntentUtils.handleProxyIntent].
+     */
+    private fun isProxyHandledIntent(intent: Intent?): Boolean {
+        if (intent == null) return false
+        if (intent.action != Intent.ACTION_VIEW && intent.data == null) return false
+        val userFromIntent = intent.getStringExtra("current_user")
+        val npub = mainViewModel.getAccount(userFromIntent) ?: return false
+        val account = LocalPreferences.loadFromEncryptedStorageSync(applicationContext, npub) ?: return false
+        return account.isProxy
     }
 
     private fun rejectIfRateLimited(intent: Intent?): Boolean {

--- a/app/src/main/java/com/greenart7c3/nostrsigner/SignerProvider.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/SignerProvider.kt
@@ -92,7 +92,7 @@ class SignerProvider : ContentProvider() {
                                 "SIGN_MESSAGE",
                             )
                     val signPolicy = database.dao().getSignPolicy(packageName)
-                    val isRemembered = IntentUtils.isRemembered(signPolicy, permission) ?: return null
+                    val isRemembered = if (account.isProxy) true else IntentUtils.isRemembered(signPolicy, permission) ?: return null
                     if (!isRemembered) {
                         scope.launch {
                             historyDatabase.dao().addHistory(
@@ -240,7 +240,7 @@ class SignerProvider : ContentProvider() {
                         }
                     }
                     val signPolicy = database.dao().getSignPolicy(packageName)
-                    val isRemembered = whitelistAutoAccept || IntentUtils.isRemembered(signPolicy, permission) ?: return null
+                    val isRemembered = if (account.isProxy) true else whitelistAutoAccept || IntentUtils.isRemembered(signPolicy, permission) ?: return null
                     if (!isRemembered) {
                         scope.launch {
                             historyDatabase.dao().addHistory(
@@ -391,7 +391,7 @@ class SignerProvider : ContentProvider() {
                         }
                     }
                     val signPolicy = database.dao().getSignPolicy(packageName)
-                    val isRemembered = IntentUtils.isRemembered(signPolicy, permission) ?: return null
+                    val isRemembered = if (account.isProxy) true else IntentUtils.isRemembered(signPolicy, permission) ?: return null
                     if (!isRemembered) {
                         scope.launch {
                             historyDatabase.dao().addHistory(
@@ -495,7 +495,7 @@ class SignerProvider : ContentProvider() {
                             )
 
                     val signPolicy = database.dao().getSignPolicy(packageName)
-                    val isRemembered = IntentUtils.isRemembered(signPolicy, permission) ?: return null
+                    val isRemembered = if (account.isProxy) true else IntentUtils.isRemembered(signPolicy, permission) ?: return null
                     if (!isRemembered) {
                         scope.launch {
                             historyDatabase.dao().addHistory(

--- a/app/src/main/java/com/greenart7c3/nostrsigner/SignerProviderQuery.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/SignerProviderQuery.kt
@@ -172,7 +172,7 @@ object SignerProviderQuery {
                         }
                     }
                     val signPolicy = permDao.getSignPolicy(requesterId)
-                    val isRemembered = whitelistAutoAccept || IntentUtils.isRemembered(signPolicy, permission) ?: return null
+                    val isRemembered = if (account.isProxy) true else whitelistAutoAccept || IntentUtils.isRemembered(signPolicy, permission) ?: return null
                     if (!isRemembered) {
                         scope.launch {
                             historyDatabase.dao().addHistory(
@@ -358,7 +358,7 @@ object SignerProviderQuery {
                         }
                     }
                     val signPolicy = permDao.getSignPolicy(requesterId)
-                    val isRemembered = IntentUtils.isRemembered(signPolicy, permission) ?: return null
+                    val isRemembered = if (account.isProxy && !isV3) true else IntentUtils.isRemembered(signPolicy, permission) ?: return null
                     if (!isRemembered) {
                         // A rejected encrypt request was never performed, so no
                         // ciphertext exists — store nothing rather than leaking the
@@ -475,7 +475,7 @@ object SignerProviderQuery {
                                 "SIGN_PSBT",
                             )
                     val signPolicy = permDao.getSignPolicy(requesterId)
-                    val isRemembered = IntentUtils.isRemembered(signPolicy, permission) ?: return null
+                    val isRemembered = if (account.isProxy) true else IntentUtils.isRemembered(signPolicy, permission) ?: return null
                     if (!isRemembered) {
                         scope.launch {
                             historyDatabase.dao().addHistory(

--- a/app/src/main/java/com/greenart7c3/nostrsigner/models/Account.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/models/Account.kt
@@ -9,9 +9,11 @@ import androidx.compose.ui.platform.Clipboard
 import com.greenart7c3.nostrsigner.Amber
 import com.greenart7c3.nostrsigner.DataStoreAccess
 import com.greenart7c3.nostrsigner.R
+import com.greenart7c3.nostrsigner.service.RemoteBunkerClient
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import com.vitorpamplona.quartz.nip01Core.core.toHexKey
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
 import com.vitorpamplona.quartz.nip01Core.signers.EventTemplate
 import com.vitorpamplona.quartz.nip01Core.signers.NostrSignerInternal
 import com.vitorpamplona.quartz.nip17Dm.NIP17Factory
@@ -28,6 +30,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 
 @Stable
 class Account(
@@ -38,6 +41,7 @@ class Account(
     val picture: MutableStateFlow<String>,
     signPolicy: Int,
     didBackup: Boolean,
+    val proxy: ProxyAccountMetadata? = null,
 ) {
     var signPolicy: Int = signPolicy
         set(value) {
@@ -55,6 +59,8 @@ class Account(
             }
         }
 
+    val isProxy: Boolean get() = proxy != null
+
     private val _saveable = MutableStateFlow(AccountState(this))
     val saveable = _saveable.asStateFlow()
 
@@ -66,34 +72,81 @@ class Account(
         }
     }
 
-    suspend fun <T : Event> sign(eventTemplate: EventTemplate<T>): T = signer.sign(eventTemplate)
+    suspend fun <T : Event> sign(eventTemplate: EventTemplate<T>): T = if (isProxy) {
+        @Suppress("UNCHECKED_CAST")
+        RemoteBunkerClient.remoteSignEvent(this, eventTemplate) as T
+    } else {
+        signer.sign(eventTemplate)
+    }
 
     fun <T : Event> signSync(
         createdAt: Long,
         kind: Int,
         tags: Array<Array<String>>,
         content: String,
-    ): T = signer.signerSync.sign(createdAt, kind, tags, content)
+    ): T = if (isProxy) {
+        @Suppress("UNCHECKED_CAST")
+        runBlocking {
+            RemoteBunkerClient.remoteSignEventSync(this@Account, createdAt, kind, tags, content)
+        } as T
+    } else {
+        signer.signerSync.sign(createdAt, kind, tags, content)
+    }
 
-    fun signString(message: String): String = signString(message, signer.keyPair.privKey!!).toHexKey()
+    fun signString(message: String): String = if (isProxy) {
+        runBlocking { RemoteBunkerClient.remoteSignString(this@Account, message) }
+    } else {
+        signString(message, signer.keyPair.privKey!!).toHexKey()
+    }
 
-    fun nip49Encrypt(password: String): String = Nip49().encrypt(signer.keyPair.privKey!!.toHexKey(), password)
+    fun nip49Encrypt(password: String): String {
+        check(!isProxy) { "Bunker proxy accounts have no local key to export" }
+        return Nip49().encrypt(signer.keyPair.privKey!!.toHexKey(), password)
+    }
 
-    suspend fun nip44Encrypt(plainText: String, toPublicKey: String): String = signer.nip44Encrypt(plainText, toPublicKey)
+    suspend fun nip44Encrypt(plainText: String, toPublicKey: String): String = if (isProxy) {
+        RemoteBunkerClient.remoteEncrypt(this, plainText, toPublicKey, useNip44 = true)
+    } else {
+        signer.nip44Encrypt(plainText, toPublicKey)
+    }
 
-    suspend fun nip04Encrypt(plainText: String, toPublicKey: String): String = signer.nip04Encrypt(plainText, toPublicKey)
+    suspend fun nip04Encrypt(plainText: String, toPublicKey: String): String = if (isProxy) {
+        RemoteBunkerClient.remoteEncrypt(this, plainText, toPublicKey, useNip44 = false)
+    } else {
+        signer.nip04Encrypt(plainText, toPublicKey)
+    }
 
-    suspend fun nip44Decrypt(cipherText: String, fromPublicKey: String): String = signer.nip44Decrypt(cipherText, fromPublicKey)
+    suspend fun nip44Decrypt(cipherText: String, fromPublicKey: String): String = if (isProxy) {
+        RemoteBunkerClient.remoteDecrypt(this, cipherText, fromPublicKey, useNip44 = true)
+    } else {
+        signer.nip44Decrypt(cipherText, fromPublicKey)
+    }
 
-    suspend fun nip04Decrypt(cipherText: String, fromPublicKey: String): String = signer.nip04Decrypt(cipherText, fromPublicKey)
+    suspend fun nip04Decrypt(cipherText: String, fromPublicKey: String): String = if (isProxy) {
+        RemoteBunkerClient.remoteDecrypt(this, cipherText, fromPublicKey, useNip44 = false)
+    } else {
+        signer.nip04Decrypt(cipherText, fromPublicKey)
+    }
 
-    suspend fun decrypt(encryptedContent: String, fromPublicKey: String): String = signer.decrypt(encryptedContent, fromPublicKey)
+    suspend fun decrypt(encryptedContent: String, fromPublicKey: String): String = if (isProxy) {
+        RemoteBunkerClient.remoteDecryptAuto(this, encryptedContent, fromPublicKey)
+    } else {
+        signer.decrypt(encryptedContent, fromPublicKey)
+    }
 
-    suspend fun seedWords() = runCatching { DataStoreAccess.getEncryptedKey(Amber.instance, npub, DataStoreAccess.SEED_WORDS) }.getOrNull() ?: ""
+    suspend fun seedWords(): String {
+        if (isProxy) return ""
+        return runCatching { DataStoreAccess.getEncryptedKey(Amber.instance, npub, DataStoreAccess.SEED_WORDS) }.getOrNull() ?: ""
+    }
 
     fun decryptZapEvent(
         data: String,
     ): String? {
+        if (isProxy) {
+            return runCatching {
+                runBlocking { RemoteBunkerClient.remoteDecryptZapEvent(this@Account, data) }
+            }.getOrNull()
+        }
         val event = Event.fromJson(data) as LnZapRequestEvent
         return try {
             PrivateZapRequestBuilder().decryptZapEvent(
@@ -106,11 +159,27 @@ class Account(
         }
     }
 
-    suspend fun createMessageNIP17(template: EventTemplate<ChatMessageEvent>): NIP17Factory.Result = NIP17Factory().createMessageNIP17(template, signer)
+    suspend fun createMessageNIP17(template: EventTemplate<ChatMessageEvent>): NIP17Factory.Result {
+        check(!isProxy) { "Bunker proxy accounts cannot build NIP-17 messages locally" }
+        return NIP17Factory().createMessageNIP17(template, signer)
+    }
 
-    suspend fun getNsec(): String = signer.keyPair.privKey!!.toNsec()
+    suspend fun getNsec(): String {
+        check(!isProxy) { "Bunker proxy accounts have no local nsec" }
+        return signer.keyPair.privKey!!.toNsec()
+    }
 
     fun copyToClipboard(clipboardManager: Clipboard) {
+        if (isProxy) {
+            Amber.instance.applicationIOScope.launch(Dispatchers.Main) {
+                Toast.makeText(
+                    Amber.instance,
+                    Amber.instance.getString(R.string.app_name),
+                    Toast.LENGTH_SHORT,
+                ).show()
+            }
+            return
+        }
         Amber.instance.applicationIOScope.launch {
             didBackup = true
             val nsec = getNsec()
@@ -130,6 +199,14 @@ class Account(
         }
     }
 }
+
+@Immutable
+data class ProxyAccountMetadata(
+    val remotePubkey: String,
+    val relays: List<NormalizedRelayUrl>,
+    val bunkerName: String,
+    val nostrConnectSecret: String,
+)
 
 @Immutable
 class AccountState(val account: Account)

--- a/app/src/main/java/com/greenart7c3/nostrsigner/models/Account.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/models/Account.kt
@@ -7,12 +7,14 @@ import androidx.compose.ui.platform.Clipboard
 import com.greenart7c3.nostrsigner.Amber
 import com.greenart7c3.nostrsigner.DataStoreAccess
 import com.greenart7c3.nostrsigner.R
+import com.greenart7c3.nostrsigner.service.RemoteBunkerClient
 import com.greenart7c3.nostrsigner.service.nip44v3.Nip44v3
 import com.greenart7c3.nostrsigner.ui.setSensitiveClip
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import com.vitorpamplona.quartz.nip01Core.core.hexToByteArray
 import com.vitorpamplona.quartz.nip01Core.core.toHexKey
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
 import com.vitorpamplona.quartz.nip01Core.signers.EventTemplate
 import com.vitorpamplona.quartz.nip01Core.signers.NostrSignerInternal
 import com.vitorpamplona.quartz.nip17Dm.NIP17Factory
@@ -28,6 +30,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 
 @Stable
 class Account(
@@ -38,6 +41,7 @@ class Account(
     val picture: MutableStateFlow<String>,
     signPolicy: Int,
     didBackup: Boolean,
+    val proxy: ProxyAccountMetadata? = null,
 ) {
     var signPolicy: Int = signPolicy
         set(value) {
@@ -55,6 +59,8 @@ class Account(
             }
         }
 
+    val isProxy: Boolean get() = proxy != null
+
     private val _saveable = MutableStateFlow(AccountState(this))
     val saveable = _saveable.asStateFlow()
 
@@ -66,38 +72,91 @@ class Account(
         }
     }
 
-    suspend fun <T : Event> sign(eventTemplate: EventTemplate<T>): T = signer.sign(eventTemplate)
+    suspend fun <T : Event> sign(eventTemplate: EventTemplate<T>): T = if (isProxy) {
+        @Suppress("UNCHECKED_CAST")
+        RemoteBunkerClient.remoteSignEvent(this, eventTemplate) as T
+    } else {
+        signer.sign(eventTemplate)
+    }
 
     fun <T : Event> signSync(
         createdAt: Long,
         kind: Int,
         tags: Array<Array<String>>,
         content: String,
-    ): T = signer.signerSync.sign(createdAt, kind, tags, content)
+    ): T = if (isProxy) {
+        @Suppress("UNCHECKED_CAST")
+        runBlocking {
+            RemoteBunkerClient.remoteSignEventSync(this@Account, createdAt, kind, tags, content)
+        } as T
+    } else {
+        signer.signerSync.sign(createdAt, kind, tags, content)
+    }
 
-    fun nip49Encrypt(password: String): String = Nip49().encrypt(signer.keyPair.privKey!!.toHexKey(), password)
+    fun nip49Encrypt(password: String): String {
+        check(!isProxy) { "Bunker proxy accounts have no local key to export" }
+        return Nip49().encrypt(signer.keyPair.privKey!!.toHexKey(), password)
+    }
 
-    suspend fun nip44Encrypt(plainText: String, toPublicKey: String): String = signer.nip44Encrypt(plainText, toPublicKey)
+    suspend fun nip44Encrypt(plainText: String, toPublicKey: String): String = if (isProxy) {
+        RemoteBunkerClient.remoteEncrypt(this, plainText, toPublicKey, useNip44 = true)
+    } else {
+        signer.nip44Encrypt(plainText, toPublicKey)
+    }
 
-    suspend fun nip04Encrypt(plainText: String, toPublicKey: String): String = signer.nip04Encrypt(plainText, toPublicKey)
+    suspend fun nip04Encrypt(plainText: String, toPublicKey: String): String = if (isProxy) {
+        RemoteBunkerClient.remoteEncrypt(this, plainText, toPublicKey, useNip44 = false)
+    } else {
+        signer.nip04Encrypt(plainText, toPublicKey)
+    }
 
-    suspend fun nip44Decrypt(cipherText: String, fromPublicKey: String): String = signer.nip44Decrypt(cipherText, fromPublicKey)
+    suspend fun nip44Decrypt(cipherText: String, fromPublicKey: String): String = if (isProxy) {
+        RemoteBunkerClient.remoteDecrypt(this, cipherText, fromPublicKey, useNip44 = true)
+    } else {
+        signer.nip44Decrypt(cipherText, fromPublicKey)
+    }
 
-    suspend fun nip04Decrypt(cipherText: String, fromPublicKey: String): String = signer.nip04Decrypt(cipherText, fromPublicKey)
+    suspend fun nip04Decrypt(cipherText: String, fromPublicKey: String): String = if (isProxy) {
+        RemoteBunkerClient.remoteDecrypt(this, cipherText, fromPublicKey, useNip44 = false)
+    } else {
+        signer.nip04Decrypt(cipherText, fromPublicKey)
+    }
 
-    fun nip44v3Encrypt(plainText: ByteArray, toPublicKey: String, kind: Int, scope: String): String = Nip44v3.encrypt(plainText, signer.keyPair.privKey!!, toPublicKey.hexToByteArray(), kind, scope)
+    fun nip44v3Encrypt(plainText: ByteArray, toPublicKey: String, kind: Int, scope: String): String {
+        check(!isProxy) { "Bunker proxy accounts cannot perform NIP-44v3 encryption locally" }
+        return Nip44v3.encrypt(plainText, signer.keyPair.privKey!!, toPublicKey.hexToByteArray(), kind, scope)
+    }
 
-    fun nip44v3Decrypt(cipherText: String, fromPublicKey: String, kind: Int, scope: String): ByteArray = Nip44v3.decrypt(cipherText, signer.keyPair.privKey!!, fromPublicKey.hexToByteArray(), kind, scope)
+    fun nip44v3Decrypt(cipherText: String, fromPublicKey: String, kind: Int, scope: String): ByteArray {
+        check(!isProxy) { "Bunker proxy accounts cannot perform NIP-44v3 decryption locally" }
+        return Nip44v3.decrypt(cipherText, signer.keyPair.privKey!!, fromPublicKey.hexToByteArray(), kind, scope)
+    }
 
-    suspend fun decrypt(encryptedContent: String, fromPublicKey: String): String = signer.decrypt(encryptedContent, fromPublicKey)
+    suspend fun decrypt(encryptedContent: String, fromPublicKey: String): String = if (isProxy) {
+        RemoteBunkerClient.remoteDecryptAuto(this, encryptedContent, fromPublicKey)
+    } else {
+        signer.decrypt(encryptedContent, fromPublicKey)
+    }
 
-    suspend fun signPsbt(psbtHex: String): String = signer.signPsbt(psbtHex)
+    suspend fun signPsbt(psbtHex: String): String = if (isProxy) {
+        RemoteBunkerClient.remoteSignPsbt(this, psbtHex)
+    } else {
+        signer.signPsbt(psbtHex)
+    }
 
-    suspend fun seedWords() = runCatching { DataStoreAccess.getEncryptedKey(Amber.instance, npub, DataStoreAccess.SEED_WORDS) }.getOrNull() ?: ""
+    suspend fun seedWords(): String {
+        if (isProxy) return ""
+        return runCatching { DataStoreAccess.getEncryptedKey(Amber.instance, npub, DataStoreAccess.SEED_WORDS) }.getOrNull() ?: ""
+    }
 
     fun decryptZapEvent(
         data: String,
     ): String? {
+        if (isProxy) {
+            return runCatching {
+                runBlocking { RemoteBunkerClient.remoteDecryptZapEvent(this@Account, data) }
+            }.getOrNull()
+        }
         val event = Event.fromJson(data) as LnZapRequestEvent
         return try {
             PrivateZapRequestBuilder().decryptZapEvent(
@@ -110,11 +169,27 @@ class Account(
         }
     }
 
-    suspend fun createMessageNIP17(template: EventTemplate<ChatMessageEvent>): NIP17Factory.Result = NIP17Factory().createMessageNIP17(template, signer)
+    suspend fun createMessageNIP17(template: EventTemplate<ChatMessageEvent>): NIP17Factory.Result {
+        check(!isProxy) { "Bunker proxy accounts cannot build NIP-17 messages locally" }
+        return NIP17Factory().createMessageNIP17(template, signer)
+    }
 
-    suspend fun getNsec(): String = signer.keyPair.privKey!!.toNsec()
+    suspend fun getNsec(): String {
+        check(!isProxy) { "Bunker proxy accounts have no local nsec" }
+        return signer.keyPair.privKey!!.toNsec()
+    }
 
     fun copyToClipboard(clipboardManager: Clipboard) {
+        if (isProxy) {
+            Amber.instance.applicationIOScope.launch(Dispatchers.Main) {
+                Toast.makeText(
+                    Amber.instance,
+                    Amber.instance.getString(R.string.app_name),
+                    Toast.LENGTH_SHORT,
+                ).show()
+            }
+            return
+        }
         Amber.instance.applicationIOScope.launch {
             didBackup = true
             val nsec = getNsec()
@@ -130,6 +205,14 @@ class Account(
         }
     }
 }
+
+@Immutable
+data class ProxyAccountMetadata(
+    val remotePubkey: String,
+    val relays: List<NormalizedRelayUrl>,
+    val bunkerName: String,
+    val nostrConnectSecret: String,
+)
 
 @Immutable
 class AccountState(val account: Account)

--- a/app/src/main/java/com/greenart7c3/nostrsigner/service/EventNotificationConsumer.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/service/EventNotificationConsumer.kt
@@ -229,6 +229,13 @@ class EventNotificationConsumer(private val applicationContext: Context) {
 
         val bunkerRequest = JacksonMapper.mapper.readValue(requestStr, BunkerRequest::class.java)
 
+        // Bunker proxy accounts forward every request to the remote bunker
+        // without showing UI or consulting per-app permissions.
+        if (acc.isProxy) {
+            forwardProxyRequest(event, acc, bunkerRequest, responseRelay, encryptionType, connectionPrivKey)
+            return
+        }
+
         val signedEvent = if (bunkerRequest is BunkerRequestSign) {
             acc.sign(bunkerRequest.event)
         } else {
@@ -533,6 +540,62 @@ class EventNotificationConsumer(private val applicationContext: Context) {
                 }
             }
         }
+    }
+
+    /**
+     * Bunker-proxy short-circuit: forward the inbound NIP-46 request straight to the
+     * remote bunker, then relay the bunker's response back to the requester. No UI
+     * is shown and per-app permissions are bypassed.
+     */
+    private suspend fun forwardProxyRequest(
+        event: Event,
+        acc: Account,
+        bunkerRequest: BunkerRequest,
+        responseRelay: List<NormalizedRelayUrl>,
+        encryptionType: EncryptionType,
+        connectionPrivKey: String,
+    ) {
+        saveLog("Proxy forwarding bunker request method=${bunkerRequest.method}", responseRelay.firstOrNull()?.url ?: "", acc.npub)
+
+        val remoteResponse = try {
+            RemoteBunkerClient.request(
+                account = acc,
+                method = bunkerRequest.method,
+                params = bunkerRequest.params.toList(),
+            )
+        } catch (e: Exception) {
+            saveLog("Proxy forward failed: ${e.message}", responseRelay.firstOrNull()?.url ?: "", acc.npub)
+            null
+        }
+
+        val (result, error) = if (remoteResponse == null) {
+            Pair("", "bunker timeout")
+        } else {
+            Pair(remoteResponse.result ?: "", remoteResponse.error)
+        }
+
+        BunkerRequestUtils.sendBunkerResponse(
+            context = applicationContext,
+            account = acc,
+            bunkerRequest = AmberBunkerRequest(
+                request = bunkerRequest,
+                localKey = event.pubKey,
+                relays = responseRelay,
+                currentAccount = acc.npub,
+                nostrConnectSecret = "",
+                closeApplication = true,
+                name = "",
+                signedEvent = null,
+                encryptedData = null,
+                encryptionType = encryptionType,
+                isNostrConnectUri = false,
+                signerPrivKey = connectionPrivKey,
+            ),
+            bunkerResponse = BunkerResponse(bunkerRequest.id, result, error),
+            relays = responseRelay,
+            onLoading = { },
+            onDone = { },
+        )
     }
 
     private fun generateMessage(

--- a/app/src/main/java/com/greenart7c3/nostrsigner/service/EventNotificationConsumer.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/service/EventNotificationConsumer.kt
@@ -229,11 +229,17 @@ class EventNotificationConsumer(private val applicationContext: Context) {
 
         val bunkerRequest = JacksonMapper.mapper.readValue(requestStr, BunkerRequest::class.java)
 
-        // Bunker proxy accounts forward every request to the remote bunker
-        // without showing UI or consulting per-app permissions.
+        // Bunker proxy accounts forward most requests silently. The exception is
+        // CONNECT and GET_PUBLIC_KEY: when more than one account is logged in we
+        // surface the connect screen so the user can pick which account to expose
+        // to the requesting app.
         if (acc.isProxy) {
-            forwardProxyRequest(event, acc, bunkerRequest, responseRelay, encryptionType, connectionPrivKey)
-            return
+            val isPairing = bunkerRequest.method == "connect" || bunkerRequest.method == "get_public_key"
+            val multipleAccounts = LocalPreferences.allSavedAccounts(applicationContext).size > 1
+            if (!(isPairing && multipleAccounts)) {
+                forwardProxyRequest(event, acc, bunkerRequest, responseRelay, encryptionType, connectionPrivKey)
+                return
+            }
         }
 
         val signedEvent = if (bunkerRequest is BunkerRequestSign) {

--- a/app/src/main/java/com/greenart7c3/nostrsigner/service/EventNotificationConsumer.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/service/EventNotificationConsumer.kt
@@ -226,6 +226,19 @@ class EventNotificationConsumer(private val applicationContext: Context) {
         // is already logged above; here we record only non-sensitive metadata.
         saveLog("Decrypted request ${bunkerRequest.id} method ${bunkerRequest.method}", relay.url, acc.npub)
 
+        // Bunker proxy accounts forward most requests silently. The exception is
+        // CONNECT and GET_PUBLIC_KEY: when more than one account is logged in we
+        // surface the connect screen so the user can pick which account to expose
+        // to the requesting app.
+        if (acc.isProxy) {
+            val isPairing = bunkerRequest.method == "connect" || bunkerRequest.method == "get_public_key"
+            val multipleAccounts = LocalPreferences.allSavedAccounts(applicationContext).size > 1
+            if (!(isPairing && multipleAccounts)) {
+                forwardProxyRequest(event, acc, bunkerRequest, listOf(relay), encryptionType, connectionPrivKey)
+                return
+            }
+        }
+
         val signedEvent = if (bunkerRequest is BunkerRequestSign) {
             acc.sign(bunkerRequest.event)
         } else {
@@ -602,6 +615,63 @@ class EventNotificationConsumer(private val applicationContext: Context) {
                 }
             }
         }
+    }
+
+    /**
+     * Bunker-proxy short-circuit: forward the inbound NIP-46 request straight to the
+     * remote bunker, then relay the bunker's response back to the requester. No UI
+     * is shown and per-app permissions are bypassed.
+     */
+    private suspend fun forwardProxyRequest(
+        event: Event,
+        acc: Account,
+        bunkerRequest: BunkerRequest,
+        responseRelay: List<NormalizedRelayUrl>,
+        encryptionType: EncryptionType,
+        connectionPrivKey: String,
+    ) {
+        saveLog("Proxy forwarding bunker request method=${bunkerRequest.method}", responseRelay.firstOrNull()?.url ?: "", acc.npub)
+
+        val remoteResponse = try {
+            RemoteBunkerClient.request(
+                account = acc,
+                method = bunkerRequest.method,
+                params = bunkerRequest.params.toList(),
+            )
+        } catch (e: Exception) {
+            saveLog("Proxy forward failed: ${e.message}", responseRelay.firstOrNull()?.url ?: "", acc.npub)
+            null
+        }
+
+        val (result, error) = if (remoteResponse == null) {
+            Pair("", "bunker timeout")
+        } else {
+            Pair(remoteResponse.result ?: "", remoteResponse.error)
+        }
+
+        BunkerRequestUtils.sendBunkerResponse(
+            context = applicationContext,
+            account = acc,
+            bunkerRequest = AmberBunkerRequest(
+                request = bunkerRequest,
+                localKey = event.pubKey,
+                relays = responseRelay,
+                currentAccount = acc.npub,
+                nostrConnectSecret = "",
+                closeApplication = true,
+                name = "",
+                clientMetadata = null,
+                signedEvent = null,
+                encryptedData = null,
+                encryptionType = encryptionType,
+                isNostrConnectUri = false,
+                signerPrivKey = connectionPrivKey,
+            ),
+            bunkerResponse = BunkerResponse(bunkerRequest.id, result, error),
+            relays = responseRelay,
+            onLoading = { },
+            onDone = { },
+        )
     }
 
     private fun generateMessage(

--- a/app/src/main/java/com/greenart7c3/nostrsigner/service/IntentUtils.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/service/IntentUtils.kt
@@ -153,6 +153,151 @@ object IntentUtils {
         }
     }
 
+    /**
+     * Bunker-proxy short-circuit for `nostrsigner://` intents. Forwards the request
+     * to the remote bunker (or computes the result locally for trivial methods) and
+     * delivers the result back to the caller via [Activity.setResult] or the
+     * provided callback URL. Per-app permissions and approval UI are skipped.
+     *
+     * Returns true if the intent was handled (so the caller should not enqueue it
+     * for the approval UI).
+     */
+    suspend fun handleProxyIntent(
+        context: Context,
+        account: Account,
+        intentData: IntentData,
+        packageName: String?,
+    ): Boolean {
+        if (!account.isProxy) return false
+
+        // GET_PUBLIC_KEY with more than one account: fall through to the existing
+        // approval UI so the user can pick which account to expose.
+        if (intentData.type == SignerType.GET_PUBLIC_KEY &&
+            LocalPreferences.allSavedAccounts(context).size > 1
+        ) {
+            return false
+        }
+
+        try {
+            val (event, value) = when (intentData.type) {
+                SignerType.GET_PUBLIC_KEY -> Pair("", account.hexKey)
+                SignerType.PING -> Pair("", "pong")
+                SignerType.SIGN_EVENT -> {
+                    val unsigned = intentData.event ?: return false
+                    val signed = RemoteBunkerClient.remoteSignEventSync(
+                        account = account,
+                        createdAt = unsigned.createdAt,
+                        kind = unsigned.kind,
+                        tags = unsigned.tags,
+                        content = unsigned.content,
+                    )
+                    Pair(signed.toJson(), signed.sig)
+                }
+                SignerType.NIP04_ENCRYPT -> {
+                    val cipher = RemoteBunkerClient.remoteEncrypt(account, intentData.data, intentData.pubKey, useNip44 = false)
+                    Pair(cipher, cipher)
+                }
+                SignerType.NIP44_ENCRYPT -> {
+                    val cipher = RemoteBunkerClient.remoteEncrypt(account, intentData.data, intentData.pubKey, useNip44 = true)
+                    Pair(cipher, cipher)
+                }
+                SignerType.NIP04_DECRYPT -> {
+                    val plain = RemoteBunkerClient.remoteDecrypt(account, intentData.data, intentData.pubKey, useNip44 = false)
+                    Pair(plain, plain)
+                }
+                SignerType.NIP44_DECRYPT -> {
+                    val plain = RemoteBunkerClient.remoteDecrypt(account, intentData.data, intentData.pubKey, useNip44 = true)
+                    Pair(plain, plain)
+                }
+                SignerType.DECRYPT_ZAP_EVENT -> {
+                    val plain = RemoteBunkerClient.remoteDecryptZapEvent(account, intentData.data)
+                    Pair(plain, plain)
+                }
+                SignerType.SIGN_PSBT -> {
+                    val signed = RemoteBunkerClient.remoteSignPsbt(account, intentData.data)
+                    Pair(signed, signed)
+                }
+                else -> return false
+            }
+
+            deliverProxyResult(context, packageName, account, intentData, event, value)
+            return true
+        } catch (e: Exception) {
+            AmberLog.e(Amber.TAG, "Bunker proxy intent forwarding failed", e)
+            Amber.instance.applicationIOScope.launch {
+                Amber.instance.getLogDatabase(account.npub).dao().insertLog(
+                    LogEntity(
+                        0,
+                        packageName ?: "intent",
+                        "bunker proxy intent",
+                        e.message ?: "unknown error",
+                        System.currentTimeMillis(),
+                    ),
+                )
+            }
+            deliverProxyRejection()
+            return true
+        }
+    }
+
+    private fun deliverProxyResult(
+        context: Context,
+        packageName: String?,
+        account: Account,
+        intentData: IntentData,
+        event: String,
+        value: String,
+    ) {
+        if (packageName != null) {
+            val intent = Intent()
+            intent.putExtra("signature", value)
+            intent.putExtra("result", value)
+            intent.putExtra("id", intentData.id)
+            intent.putExtra("event", event)
+            if (intentData.type == SignerType.GET_PUBLIC_KEY) {
+                intent.putExtra("package", BuildConfig.APPLICATION_ID)
+            }
+            Amber.instance.getMainActivity()?.setResult(RESULT_OK, intent)
+        } else if (!intentData.callBackUrl.isNullOrBlank()) {
+            if (intentData.returnType == ReturnType.SIGNATURE) {
+                val ai = Intent(Intent.ACTION_VIEW)
+                ai.data = (intentData.callBackUrl + Uri.encode(value)).toUri()
+                context.startActivity(ai)
+            } else {
+                val ai = Intent(Intent.ACTION_VIEW)
+                ai.data = (intentData.callBackUrl + Uri.encode(event)).toUri()
+                context.startActivity(ai)
+            }
+        }
+        Amber.instance.applicationIOScope.launch {
+            Amber.instance.getHistoryDatabase(account.npub).dao().addHistory(
+                listOf(
+                    HistoryEntity(
+                        0,
+                        packageName ?: "",
+                        intentData.type.toString(),
+                        intentData.event?.kind,
+                        TimeUtils.now(),
+                        true,
+                        content = if (event.isNotEmpty()) event else value,
+                    ),
+                ),
+                account.npub,
+            )
+        }
+        Amber.instance.getMainActivity()?.let {
+            it.intent = null
+            it.finishAndRemoveTask()
+        }
+    }
+
+    private fun deliverProxyRejection() {
+        Amber.instance.getMainActivity()?.let {
+            it.intent = null
+            it.finishAndRemoveTask()
+        }
+    }
+
     fun removeAll(list: List<IntentData>) {
         _intents.update { current -> (current - list.toSet()).toPersistentList() }
     }

--- a/app/src/main/java/com/greenart7c3/nostrsigner/service/IntentUtils.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/service/IntentUtils.kt
@@ -131,6 +131,14 @@ object IntentUtils {
     ): Boolean {
         if (!account.isProxy) return false
 
+        // GET_PUBLIC_KEY with more than one account: fall through to the existing
+        // approval UI so the user can pick which account to expose.
+        if (intentData.type == SignerType.GET_PUBLIC_KEY &&
+            LocalPreferences.allSavedAccounts(context).size > 1
+        ) {
+            return false
+        }
+
         try {
             val (event, value) = when (intentData.type) {
                 SignerType.GET_PUBLIC_KEY -> Pair("", account.hexKey)

--- a/app/src/main/java/com/greenart7c3/nostrsigner/service/IntentUtils.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/service/IntentUtils.kt
@@ -114,6 +114,143 @@ object IntentUtils {
         }
     }
 
+    /**
+     * Bunker-proxy short-circuit for `nostrsigner://` intents. Forwards the request
+     * to the remote bunker (or computes the result locally for trivial methods) and
+     * delivers the result back to the caller via [Activity.setResult] or the
+     * provided callback URL. Per-app permissions and approval UI are skipped.
+     *
+     * Returns true if the intent was handled (so the caller should not enqueue it
+     * for the approval UI).
+     */
+    suspend fun handleProxyIntent(
+        context: Context,
+        account: Account,
+        intentData: IntentData,
+        packageName: String?,
+    ): Boolean {
+        if (!account.isProxy) return false
+
+        try {
+            val (event, value) = when (intentData.type) {
+                SignerType.GET_PUBLIC_KEY -> Pair("", account.hexKey)
+                SignerType.PING -> Pair("", "pong")
+                SignerType.SIGN_MESSAGE -> {
+                    val sig = RemoteBunkerClient.remoteSignString(account, intentData.data)
+                    Pair(sig, sig)
+                }
+                SignerType.SIGN_EVENT -> {
+                    val unsigned = intentData.event ?: return false
+                    val signed = RemoteBunkerClient.remoteSignEventSync(
+                        account = account,
+                        createdAt = unsigned.createdAt,
+                        kind = unsigned.kind,
+                        tags = unsigned.tags,
+                        content = unsigned.content,
+                    )
+                    Pair(signed.toJson(), signed.sig)
+                }
+                SignerType.NIP04_ENCRYPT -> {
+                    val cipher = RemoteBunkerClient.remoteEncrypt(account, intentData.data, intentData.pubKey, useNip44 = false)
+                    Pair(cipher, cipher)
+                }
+                SignerType.NIP44_ENCRYPT -> {
+                    val cipher = RemoteBunkerClient.remoteEncrypt(account, intentData.data, intentData.pubKey, useNip44 = true)
+                    Pair(cipher, cipher)
+                }
+                SignerType.NIP04_DECRYPT -> {
+                    val plain = RemoteBunkerClient.remoteDecrypt(account, intentData.data, intentData.pubKey, useNip44 = false)
+                    Pair(plain, plain)
+                }
+                SignerType.NIP44_DECRYPT -> {
+                    val plain = RemoteBunkerClient.remoteDecrypt(account, intentData.data, intentData.pubKey, useNip44 = true)
+                    Pair(plain, plain)
+                }
+                SignerType.DECRYPT_ZAP_EVENT -> {
+                    val plain = RemoteBunkerClient.remoteDecryptZapEvent(account, intentData.data)
+                    Pair(plain, plain)
+                }
+                else -> return false
+            }
+
+            deliverProxyResult(context, packageName, account, intentData, event, value)
+            return true
+        } catch (e: Exception) {
+            Log.e(Amber.TAG, "Bunker proxy intent forwarding failed", e)
+            Amber.instance.applicationIOScope.launch {
+                Amber.instance.getLogDatabase(account.npub).dao().insertLog(
+                    LogEntity(
+                        0,
+                        packageName ?: "intent",
+                        "bunker proxy intent",
+                        e.message ?: "unknown error",
+                        System.currentTimeMillis(),
+                    ),
+                )
+            }
+            deliverProxyRejection()
+            return true
+        }
+    }
+
+    private fun deliverProxyResult(
+        context: Context,
+        packageName: String?,
+        account: Account,
+        intentData: IntentData,
+        event: String,
+        value: String,
+    ) {
+        if (packageName != null) {
+            val intent = Intent()
+            intent.putExtra("signature", value)
+            intent.putExtra("result", value)
+            intent.putExtra("id", intentData.id)
+            intent.putExtra("event", event)
+            if (intentData.type == SignerType.GET_PUBLIC_KEY) {
+                intent.putExtra("package", BuildConfig.APPLICATION_ID)
+            }
+            Amber.instance.getMainActivity()?.setResult(RESULT_OK, intent)
+        } else if (!intentData.callBackUrl.isNullOrBlank()) {
+            if (intentData.returnType == ReturnType.SIGNATURE) {
+                val ai = Intent(Intent.ACTION_VIEW)
+                ai.data = (intentData.callBackUrl + Uri.encode(value)).toUri()
+                context.startActivity(ai)
+            } else {
+                val ai = Intent(Intent.ACTION_VIEW)
+                ai.data = (intentData.callBackUrl + Uri.encode(event)).toUri()
+                context.startActivity(ai)
+            }
+        }
+        Amber.instance.applicationIOScope.launch {
+            Amber.instance.getHistoryDatabase(account.npub).dao().addHistory(
+                listOf(
+                    HistoryEntity(
+                        0,
+                        packageName ?: "",
+                        intentData.type.toString(),
+                        intentData.event?.kind,
+                        TimeUtils.now(),
+                        true,
+                        content = if (event.isNotEmpty()) event else value,
+                    ),
+                ),
+                account.npub,
+            )
+        }
+        Amber.instance.getMainActivity()?.let {
+            it.intent = null
+            it.finishAndRemoveTask()
+        }
+    }
+
+    private fun deliverProxyRejection() {
+        Amber.instance.getMainActivity()?.let {
+            it.intent = null
+            it.finishAndRemoveTask()
+        }
+    }
+
     fun removeAll(list: List<IntentData>) {
         _intents.update { current -> (current - list.toSet()).toPersistentList() }
     }

--- a/app/src/main/java/com/greenart7c3/nostrsigner/service/ProxyResponseSubscription.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/service/ProxyResponseSubscription.kt
@@ -1,0 +1,243 @@
+package com.greenart7c3.nostrsigner.service
+
+import android.content.Context
+import android.util.Log
+import com.greenart7c3.nostrsigner.Amber
+import com.greenart7c3.nostrsigner.BuildFlavorChecker
+import com.greenart7c3.nostrsigner.LocalPreferences
+import com.vitorpamplona.quartz.nip01Core.core.Event
+import com.vitorpamplona.quartz.nip01Core.core.toHexKey
+import com.vitorpamplona.quartz.nip01Core.crypto.KeyPair
+import com.vitorpamplona.quartz.nip01Core.crypto.verify
+import com.vitorpamplona.quartz.nip01Core.jackson.JacksonMapper
+import com.vitorpamplona.quartz.nip01Core.relay.client.NostrClient
+import com.vitorpamplona.quartz.nip01Core.relay.client.listeners.RelayConnectionListener
+import com.vitorpamplona.quartz.nip01Core.relay.client.single.IRelayClient
+import com.vitorpamplona.quartz.nip01Core.relay.commands.toClient.EventMessage
+import com.vitorpamplona.quartz.nip01Core.relay.commands.toClient.Message
+import com.vitorpamplona.quartz.nip01Core.relay.filters.Filter
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
+import com.vitorpamplona.quartz.nip01Core.signers.NostrSignerInternal
+import com.vitorpamplona.quartz.nip01Core.tags.people.taggedUsers
+import com.vitorpamplona.quartz.nip04Dm.crypto.EncryptedInfo
+import com.vitorpamplona.quartz.nip19Bech32.toNpub
+import com.vitorpamplona.quartz.nip46RemoteSigner.BunkerResponse
+import com.vitorpamplona.quartz.nip46RemoteSigner.NostrConnectEvent
+import com.vitorpamplona.quartz.utils.TimeUtils
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
+
+/**
+ * Subscribes to NIP-46 response events sent by remote bunkers to any of our
+ * proxy accounts. Each proxy account's local proxy pubkey gets a filter
+ * `kinds=[24133], #p=[localProxyPub], authors=[remoteBunkerPub]` on the configured
+ * relays. Incoming events are decrypted with the local proxy keypair and routed
+ * to [RemoteBunkerClient.deliverResponse].
+ *
+ * Also supports transient subscriptions used during login (before an account
+ * exists), see [subscribeForLocalKey] and [awaitInitialConnect].
+ */
+class ProxyResponseSubscription(
+    val client: NostrClient,
+    val appContext: Context,
+) : RelayConnectionListener {
+    private val subIds = mutableMapOf<String, String>()
+
+    private val transientLogins = ConcurrentHashMap<String, TransientLogin>()
+    private val pendingInitialConnect = ConcurrentHashMap<String, CompletableDeferred<String>>()
+
+    private data class TransientLogin(
+        val localPrivKey: ByteArray,
+        val remotePubkey: String,
+        val secret: String,
+    )
+
+    init {
+        client.addConnectionListener(this)
+    }
+
+    override fun onIncomingMessage(relay: IRelayClient, msgStr: String, msg: Message) {
+        if (msg is EventMessage) {
+            if (subIds.containsValue(msg.subId)) {
+                handleEvent(msg.event, relay.url.url)
+            }
+        }
+        super.onIncomingMessage(relay, msgStr, msg)
+    }
+
+    private fun handleEvent(event: Event, relayUrl: String) {
+        if (event.kind != NostrConnectEvent.KIND) return
+        if (!event.verify()) return
+
+        val taggedKey = event.taggedUsers().firstOrNull() ?: return
+        val taggedNpub = taggedKey.toNPub()
+
+        Amber.instance.applicationIOScope.launch {
+            transientLogins.values.firstOrNull { tl ->
+                NostrSignerInternal(KeyPair(privKey = tl.localPrivKey)).keyPair.pubKey.toNpub() == taggedNpub
+            }?.let { tl ->
+                handleViaSigner(event, NostrSignerInternal(KeyPair(privKey = tl.localPrivKey)), tl.remotePubkey, tl.secret, relayUrl)
+                return@launch
+            }
+
+            val accounts = LocalPreferences.allSavedAccounts(appContext)
+            for (info in accounts) {
+                val account = LocalPreferences.loadFromEncryptedStorage(appContext, info.npub) ?: continue
+                val proxy = account.proxy ?: continue
+                val localPub = account.signer.keyPair.pubKey.toNpub()
+                if (localPub != taggedNpub) continue
+                if (event.pubKey != proxy.remotePubkey) continue
+                handleViaSigner(event, account.signer, proxy.remotePubkey, "", relayUrl)
+                return@launch
+            }
+        }
+    }
+
+    private suspend fun handleViaSigner(
+        event: Event,
+        signer: NostrSignerInternal,
+        remotePubkey: String,
+        secret: String,
+        relayUrl: String,
+    ) {
+        val decrypted = try {
+            val isNip04 = EncryptedInfo.isNIP04(event.content)
+            if (isNip04) {
+                signer.nip04Decrypt(event.content, event.pubKey)
+            } else {
+                signer.nip44Decrypt(event.content, event.pubKey)
+            }
+        } catch (e: Exception) {
+            Log.w(Amber.TAG, "Proxy response decrypt failed on $relayUrl: ${e.message}", e)
+            return
+        }
+
+        val response = try {
+            JacksonMapper.mapper.readValue(decrypted, BunkerResponse::class.java)
+        } catch (_: Exception) {
+            null
+        }
+
+        if (response != null) {
+            RemoteBunkerClient.deliverResponse(response)
+            val localPub = signer.keyPair.pubKey.toHexKey()
+            pendingInitialConnect[localPub]?.let { deferred ->
+                val result = response.result
+                if (response.error.isNullOrBlank() && (secret.isEmpty() || result == secret || result == "ack")) {
+                    deferred.complete(event.pubKey)
+                    pendingInitialConnect.remove(localPub)
+                }
+            }
+            return
+        }
+
+        // Bunker-initiated `connect` request (nostrconnect:// generate flow).
+        try {
+            val node = JacksonMapper.mapper.readTree(decrypted)
+            val method = node.get("method")?.asText() ?: return
+            if (method == "connect") {
+                val localPub = signer.keyPair.pubKey.toHexKey()
+                pendingInitialConnect[localPub]?.let { deferred ->
+                    deferred.complete(event.pubKey)
+                    pendingInitialConnect.remove(localPub)
+                }
+            }
+        } catch (_: Exception) {
+            // ignored
+        }
+    }
+
+    suspend fun subscribeForLocalKey(localPubHex: String, remotePubkey: String, relays: List<NormalizedRelayUrl>) {
+        if (BuildFlavorChecker.isOfflineFlavor() || relays.isEmpty()) return
+        val subKey = "transient_$localPubHex"
+        if (!subIds.containsKey(subKey)) {
+            subIds[subKey] = UUID.randomUUID().toString()
+        }
+        client.subscribe(
+            subIds[subKey]!!,
+            relays.associateWith {
+                listOf(
+                    Filter(
+                        kinds = listOf(NostrConnectEvent.KIND),
+                        tags = mapOf("p" to listOf(localPubHex)),
+                        since = TimeUtils.now() - 60,
+                    ),
+                )
+            },
+        )
+    }
+
+    suspend fun awaitInitialConnect(
+        localKeyPair: KeyPair,
+        relays: List<NormalizedRelayUrl>,
+        secret: String,
+        timeoutMs: Long,
+    ): String? {
+        val localPub = localKeyPair.pubKey.toHexKey()
+        val deferred = CompletableDeferred<String>()
+        pendingInitialConnect[localPub] = deferred
+        transientLogins[localPub] = TransientLogin(
+            localPrivKey = localKeyPair.privKey!!,
+            remotePubkey = "",
+            secret = secret,
+        )
+        subscribeForLocalKey(localPub, "", relays)
+        return withTimeoutOrNull(timeoutMs) { deferred.await() }
+    }
+
+    fun registerTransientLogin(localPrivKey: ByteArray, remotePubkey: String) {
+        val signer = NostrSignerInternal(KeyPair(privKey = localPrivKey))
+        transientLogins[signer.keyPair.pubKey.toHexKey()] = TransientLogin(
+            localPrivKey = localPrivKey,
+            remotePubkey = remotePubkey,
+            secret = "",
+        )
+    }
+
+    fun clearTransient(localPubHex: String) {
+        transientLogins.remove(localPubHex)
+        pendingInitialConnect.remove(localPubHex)
+        val subKey = "transient_$localPubHex"
+        subIds.remove(subKey)?.let { client.unsubscribe(it) }
+    }
+
+    suspend fun updateFilter() {
+        if (BuildFlavorChecker.isOfflineFlavor()) return
+        val activeSubKeys = mutableSetOf<String>()
+        activeSubKeys += subIds.keys.filter { it.startsWith("transient_") }
+        val since = TimeUtils.now()
+
+        LocalPreferences.allAccounts(appContext).forEach { account ->
+            val proxy = account.proxy ?: return@forEach
+            if (proxy.relays.isEmpty()) return@forEach
+
+            val localPub = account.signer.keyPair.pubKey.toHexKey()
+            val subKey = "proxy_${account.npub}"
+            activeSubKeys.add(subKey)
+            if (!subIds.containsKey(subKey)) {
+                subIds[subKey] = UUID.randomUUID().toString()
+            }
+            client.subscribe(
+                subIds[subKey]!!,
+                proxy.relays.associateWith {
+                    listOf(
+                        Filter(
+                            kinds = listOf(NostrConnectEvent.KIND),
+                            tags = mapOf("p" to listOf(localPub)),
+                            authors = listOf(proxy.remotePubkey),
+                            since = since,
+                        ),
+                    )
+                },
+            )
+        }
+
+        val stale = subIds.keys.filter { it !in activeSubKeys }
+        for (subKey in stale) {
+            subIds.remove(subKey)?.let { client.unsubscribe(it) }
+        }
+    }
+}

--- a/app/src/main/java/com/greenart7c3/nostrsigner/service/ProxyResponseSubscription.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/service/ProxyResponseSubscription.kt
@@ -1,0 +1,281 @@
+package com.greenart7c3.nostrsigner.service
+
+import android.content.Context
+import android.util.Log
+import com.greenart7c3.nostrsigner.Amber
+import com.greenart7c3.nostrsigner.BuildFlavorChecker
+import com.greenart7c3.nostrsigner.LocalPreferences
+import com.vitorpamplona.quartz.nip01Core.core.Event
+import com.vitorpamplona.quartz.nip01Core.core.toHexKey
+import com.vitorpamplona.quartz.nip01Core.crypto.KeyPair
+import com.vitorpamplona.quartz.nip01Core.crypto.verify
+import com.vitorpamplona.quartz.nip01Core.jackson.JacksonMapper
+import com.vitorpamplona.quartz.nip01Core.relay.client.NostrClient
+import com.vitorpamplona.quartz.nip01Core.relay.client.listeners.RelayConnectionListener
+import com.vitorpamplona.quartz.nip01Core.relay.client.single.IRelayClient
+import com.vitorpamplona.quartz.nip01Core.relay.commands.toClient.EventMessage
+import com.vitorpamplona.quartz.nip01Core.relay.commands.toClient.Message
+import com.vitorpamplona.quartz.nip01Core.relay.filters.Filter
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
+import com.vitorpamplona.quartz.nip01Core.signers.NostrSignerInternal
+import com.vitorpamplona.quartz.nip01Core.tags.people.taggedUsers
+import com.vitorpamplona.quartz.nip04Dm.crypto.EncryptedInfo
+import com.vitorpamplona.quartz.nip19Bech32.toNpub
+import com.vitorpamplona.quartz.nip46RemoteSigner.BunkerResponse
+import com.vitorpamplona.quartz.nip46RemoteSigner.NostrConnectEvent
+import com.vitorpamplona.quartz.utils.TimeUtils
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
+
+/**
+ * Subscribes to NIP-46 response events sent by remote bunkers to any of our
+ * proxy accounts. Each proxy account's local proxy pubkey gets a filter
+ * `kinds=[24133], #p=[localProxyPub], authors=[remoteBunkerPub]` on the configured
+ * relays. Incoming events are decrypted with the local proxy keypair and routed
+ * to [RemoteBunkerClient.deliverResponse].
+ *
+ * Also supports transient subscriptions used during login (before an account
+ * exists), see [subscribeForLocalKey] and [awaitInitialConnect].
+ */
+class ProxyResponseSubscription(
+    val client: NostrClient,
+    val appContext: Context,
+) : RelayConnectionListener {
+    private val subIds = mutableMapOf<String, String>()
+
+    /**
+     * Transient login-time subscriptions: maps local proxy pubkey hex to the
+     * private key + remote bunker pubkey we expect responses from.
+     */
+    private val transientLogins = ConcurrentHashMap<String, TransientLogin>()
+
+    /**
+     * Pending awaiters for the nostrconnect:// generate flow — keyed by local
+     * proxy pubkey hex.
+     */
+    private val pendingInitialConnect = ConcurrentHashMap<String, CompletableDeferred<String>>()
+
+    private data class TransientLogin(
+        val localPrivKey: ByteArray,
+        val remotePubkey: String,
+        val secret: String,
+    )
+
+    init {
+        client.addConnectionListener(this)
+    }
+
+    override fun onIncomingMessage(relay: IRelayClient, msgStr: String, msg: Message) {
+        if (msg is EventMessage) {
+            if (subIds.containsValue(msg.subId)) {
+                handleEvent(msg.event, relay.url.url)
+            }
+        }
+        super.onIncomingMessage(relay, msgStr, msg)
+    }
+
+    private fun handleEvent(event: Event, relayUrl: String) {
+        if (event.kind != NostrConnectEvent.KIND) return
+        if (!event.verify()) return
+
+        val taggedKey = event.taggedUsers().firstOrNull() ?: return
+        val taggedNpub = taggedKey.toNPub()
+
+        Amber.instance.applicationIOScope.launch {
+            // First: check transient (login-time) subscriptions.
+            transientLogins.values.firstOrNull { tl ->
+                NostrSignerInternal(KeyPair(privKey = tl.localPrivKey)).keyPair.pubKey.toNpub() == taggedNpub
+            }?.let { tl ->
+                handleViaSigner(event, NostrSignerInternal(KeyPair(privKey = tl.localPrivKey)), tl.remotePubkey, tl.secret, relayUrl)
+                return@launch
+            }
+
+            // Then: check stored proxy accounts.
+            val accounts = LocalPreferences.allSavedAccounts(appContext)
+            for (info in accounts) {
+                val account = LocalPreferences.loadFromEncryptedStorage(appContext, info.npub) ?: continue
+                val proxy = account.proxy ?: continue
+                val localPub = account.signer.keyPair.pubKey.toNpub()
+                if (localPub != taggedNpub) continue
+                if (event.pubKey != proxy.remotePubkey) continue
+                handleViaSigner(event, account.signer, proxy.remotePubkey, "", relayUrl)
+                return@launch
+            }
+        }
+    }
+
+    private suspend fun handleViaSigner(
+        event: Event,
+        signer: NostrSignerInternal,
+        remotePubkey: String,
+        secret: String,
+        relayUrl: String,
+    ) {
+        val decrypted = try {
+            val isNip04 = EncryptedInfo.isNIP04(event.content)
+            if (isNip04) {
+                signer.nip04Decrypt(event.content, event.pubKey)
+            } else {
+                signer.nip44Decrypt(event.content, event.pubKey)
+            }
+        } catch (e: Exception) {
+            Log.w(Amber.TAG, "Proxy response decrypt failed on $relayUrl: ${e.message}", e)
+            return
+        }
+
+        // Try the response shape first.
+        val response = try {
+            JacksonMapper.mapper.readValue(decrypted, BunkerResponse::class.java)
+        } catch (_: Exception) {
+            null
+        }
+
+        if (response != null) {
+            RemoteBunkerClient.deliverResponse(response)
+            // Some bunkers respond to a nostrconnect URI with `connect` + secret as the
+            // "result". Handle that for the initial-connect awaiter.
+            val localPub = signer.keyPair.pubKey.toHexKey()
+            pendingInitialConnect[localPub]?.let { deferred ->
+                val result = response.result
+                if (response.error.isNullOrBlank() && (secret.isEmpty() || result == secret || result == "ack")) {
+                    deferred.complete(event.pubKey)
+                    pendingInitialConnect.remove(localPub)
+                }
+            }
+            return
+        }
+
+        // Otherwise it might be a `connect` request from the bunker initiated by
+        // the user pasting our nostrconnect:// URI on the bunker side.
+        try {
+            val node = JacksonMapper.mapper.readTree(decrypted)
+            val method = node.get("method")?.asText() ?: return
+            if (method == "connect") {
+                val localPub = signer.keyPair.pubKey.toHexKey()
+                pendingInitialConnect[localPub]?.let { deferred ->
+                    deferred.complete(event.pubKey)
+                    pendingInitialConnect.remove(localPub)
+                }
+            }
+        } catch (_: Exception) {
+            // ignored
+        }
+    }
+
+    /**
+     * Adds a transient login-time subscription. Used while pairing with a remote
+     * bunker, before the account is fully created.
+     */
+    suspend fun subscribeForLocalKey(localPubHex: String, remotePubkey: String, relays: List<NormalizedRelayUrl>) {
+        if (BuildFlavorChecker.isOfflineFlavor() || relays.isEmpty()) return
+        val subKey = "transient_$localPubHex"
+        if (!subIds.containsKey(subKey)) {
+            subIds[subKey] = UUID.randomUUID().toString()
+        }
+        client.subscribe(
+            subIds[subKey]!!,
+            relays.associateWith {
+                listOf(
+                    Filter(
+                        kinds = listOf(NostrConnectEvent.KIND),
+                        tags = mapOf("p" to listOf(localPubHex)),
+                        since = TimeUtils.now() - 60,
+                    ),
+                )
+            },
+        )
+    }
+
+    /**
+     * Used by the nostrconnect:// generate login flow. Returns the bunker's
+     * pubkey when the bunker first reaches out, or null on timeout.
+     */
+    suspend fun awaitInitialConnect(
+        localKeyPair: KeyPair,
+        relays: List<NormalizedRelayUrl>,
+        secret: String,
+        timeoutMs: Long,
+    ): String? {
+        val localPub = localKeyPair.pubKey.toHexKey()
+        val deferred = CompletableDeferred<String>()
+        pendingInitialConnect[localPub] = deferred
+        transientLogins[localPub] = TransientLogin(
+            localPrivKey = localKeyPair.privKey!!,
+            remotePubkey = "",
+            secret = secret,
+        )
+        try {
+            subscribeForLocalKey(localPub, "", relays)
+            return withTimeoutOrNull(timeoutMs) { deferred.await() }
+        } finally {
+            // Keep the transient login until the caller finishes the get_public_key
+            // round trip that follows.
+        }
+    }
+
+    /**
+     * Promotes a transient login (used for the bunker:// flow during initial
+     * connect / get_public_key) so that subsequent responses still decrypt
+     * correctly until the account is saved.
+     */
+    fun registerTransientLogin(localPrivKey: ByteArray, remotePubkey: String) {
+        val signer = NostrSignerInternal(KeyPair(privKey = localPrivKey))
+        transientLogins[signer.keyPair.pubKey.toHexKey()] = TransientLogin(
+            localPrivKey = localPrivKey,
+            remotePubkey = remotePubkey,
+            secret = "",
+        )
+    }
+
+    fun clearTransient(localPubHex: String) {
+        transientLogins.remove(localPubHex)
+        pendingInitialConnect.remove(localPubHex)
+        val subKey = "transient_$localPubHex"
+        subIds.remove(subKey)?.let { client.unsubscribe(it) }
+    }
+
+    /**
+     * Refresh per-proxy-account subscriptions. Call after login / logout /
+     * relay changes — same lifecycle as [NotificationSubscription.updateFilter].
+     */
+    suspend fun updateFilter() {
+        if (BuildFlavorChecker.isOfflineFlavor()) return
+        val activeSubKeys = mutableSetOf<String>()
+        // Keep transient subscriptions alive across refreshes.
+        activeSubKeys += subIds.keys.filter { it.startsWith("transient_") }
+        val since = TimeUtils.now()
+
+        LocalPreferences.allAccounts(appContext).forEach { account ->
+            val proxy = account.proxy ?: return@forEach
+            if (proxy.relays.isEmpty()) return@forEach
+
+            val localPub = account.signer.keyPair.pubKey.toHexKey()
+            val subKey = "proxy_${account.npub}"
+            activeSubKeys.add(subKey)
+            if (!subIds.containsKey(subKey)) {
+                subIds[subKey] = UUID.randomUUID().toString()
+            }
+            client.subscribe(
+                subIds[subKey]!!,
+                proxy.relays.associateWith {
+                    listOf(
+                        Filter(
+                            kinds = listOf(NostrConnectEvent.KIND),
+                            tags = mapOf("p" to listOf(localPub)),
+                            authors = listOf(proxy.remotePubkey),
+                            since = since,
+                        ),
+                    )
+                },
+            )
+        }
+
+        val stale = subIds.keys.filter { it !in activeSubKeys }
+        for (subKey in stale) {
+            subIds.remove(subKey)?.let { client.unsubscribe(it) }
+        }
+    }
+}

--- a/app/src/main/java/com/greenart7c3/nostrsigner/service/RemoteBunkerClient.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/service/RemoteBunkerClient.kt
@@ -1,0 +1,309 @@
+package com.greenart7c3.nostrsigner.service
+
+import android.util.Log
+import com.greenart7c3.nostrsigner.Amber
+import com.greenart7c3.nostrsigner.database.LogEntity
+import com.greenart7c3.nostrsigner.models.Account
+import com.vitorpamplona.quartz.nip01Core.core.Event
+import com.vitorpamplona.quartz.nip01Core.jackson.JacksonMapper
+import com.vitorpamplona.quartz.nip01Core.relay.client.accessories.publishAndConfirm
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
+import com.vitorpamplona.quartz.nip01Core.signers.EventTemplate
+import com.vitorpamplona.quartz.nip01Core.signers.NostrSignerInternal
+import com.vitorpamplona.quartz.nip04Dm.crypto.EncryptedInfo
+import com.vitorpamplona.quartz.nip46RemoteSigner.BunkerResponse
+import com.vitorpamplona.quartz.nip46RemoteSigner.NostrConnectEvent
+import com.vitorpamplona.quartz.utils.TimeUtils
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.withTimeoutOrNull
+
+/**
+ * Outbound NIP-46 client. When an [Account] is configured as a bunker proxy, every
+ * sign / encrypt / decrypt call is forwarded to the remote bunker through this object.
+ *
+ * The local proxy keypair lives inside [Account.signer]. The remote user pubkey is
+ * stored in [Account.proxy].remotePubkey; that's what apps see as `account.hexKey`.
+ */
+object RemoteBunkerClient {
+    private const val TIMEOUT_MS = 30_000L
+
+    private val pending = ConcurrentHashMap<String, CompletableDeferred<BunkerResponse>>()
+
+    /**
+     * Called by [ProxyResponseSubscription] (or by tests) when a response from the
+     * remote bunker arrives.
+     */
+    fun deliverResponse(response: BunkerResponse) {
+        val deferred = pending.remove(response.id) ?: return
+        deferred.complete(response)
+    }
+
+    /**
+     * Returns the response or null on timeout / network failure.
+     */
+    suspend fun request(
+        account: Account,
+        method: String,
+        params: List<String>,
+        timeoutMs: Long = TIMEOUT_MS,
+    ): BunkerResponse? {
+        val proxy = account.proxy ?: error("request() called on a non-proxy account")
+        if (proxy.relays.isEmpty()) return null
+
+        val id = UUID.randomUUID().toString()
+        val deferred = CompletableDeferred<BunkerResponse>()
+        pending[id] = deferred
+
+        try {
+            val payload = JacksonMapper.mapper.writeValueAsString(
+                mapOf(
+                    "id" to id,
+                    "method" to method,
+                    "params" to params,
+                ),
+            )
+
+            val encrypted = try {
+                account.signer.nip44Encrypt(payload, proxy.remotePubkey)
+            } catch (e: Exception) {
+                Log.w(Amber.TAG, "NIP-44 encrypt to bunker failed; falling back to NIP-04", e)
+                account.signer.nip04Encrypt(payload, proxy.remotePubkey)
+            }
+
+            val event = account.signer.signerSync.sign<Event>(
+                createdAt = TimeUtils.now(),
+                kind = NostrConnectEvent.KIND,
+                tags = arrayOf(arrayOf("p", proxy.remotePubkey)),
+                content = encrypted,
+            )
+
+            Amber.instance.getLogDatabase(account.npub).dao().insertLog(
+                LogEntity(
+                    id = 0,
+                    url = proxy.remotePubkey,
+                    type = "bunker proxy request",
+                    message = "method=$method id=$id",
+                    time = System.currentTimeMillis(),
+                ),
+            )
+
+            val published = Amber.instance.client.publishAndConfirm(
+                event = event,
+                relayList = proxy.relays.toSet(),
+                timeoutInSeconds = 5,
+            )
+
+            if (!published) {
+                Log.w(Amber.TAG, "Failed to publish bunker proxy request id=$id")
+                Amber.instance.getLogDatabase(account.npub).dao().insertLog(
+                    LogEntity(
+                        id = 0,
+                        url = proxy.remotePubkey,
+                        type = "bunker proxy request",
+                        message = "publish failed for $method id=$id",
+                        time = System.currentTimeMillis(),
+                    ),
+                )
+                return null
+            }
+
+            val response = withTimeoutOrNull(timeoutMs) { deferred.await() }
+            if (response == null) {
+                Log.w(Amber.TAG, "Bunker proxy request timed out id=$id method=$method")
+                Amber.instance.getLogDatabase(account.npub).dao().insertLog(
+                    LogEntity(
+                        id = 0,
+                        url = proxy.remotePubkey,
+                        type = "bunker proxy request",
+                        message = "timeout for $method id=$id",
+                        time = System.currentTimeMillis(),
+                    ),
+                )
+            }
+            return response
+        } finally {
+            pending.remove(id)
+        }
+    }
+
+    private fun BunkerResponse.requireResult(method: String): String {
+        if (!error.isNullOrBlank()) {
+            throw RemoteBunkerException("bunker error for $method: $error")
+        }
+        return result ?: throw RemoteBunkerException("bunker returned null result for $method")
+    }
+
+    suspend fun <T : Event> remoteSignEvent(account: Account, template: EventTemplate<T>): Event {
+        val proxy = account.proxy ?: error("remoteSignEvent on non-proxy account")
+        val unsignedJson = JacksonMapper.mapper.writeValueAsString(
+            mapOf(
+                "kind" to template.kind,
+                "content" to template.content,
+                "tags" to template.tags,
+                "created_at" to template.createdAt,
+                "pubkey" to proxy.remotePubkey,
+            ),
+        )
+        val response = request(account, "sign_event", listOf(unsignedJson))
+            ?: throw RemoteBunkerException("bunker timeout: sign_event")
+        val signedJson = response.requireResult("sign_event")
+        return Event.fromJson(signedJson)
+    }
+
+    suspend fun remoteSignEventSync(
+        account: Account,
+        createdAt: Long,
+        kind: Int,
+        tags: Array<Array<String>>,
+        content: String,
+    ): Event {
+        val proxy = account.proxy ?: error("remoteSignEventSync on non-proxy account")
+        val unsignedJson = JacksonMapper.mapper.writeValueAsString(
+            mapOf(
+                "kind" to kind,
+                "content" to content,
+                "tags" to tags,
+                "created_at" to createdAt,
+                "pubkey" to proxy.remotePubkey,
+            ),
+        )
+        val response = request(account, "sign_event", listOf(unsignedJson))
+            ?: throw RemoteBunkerException("bunker timeout: sign_event")
+        val signedJson = response.requireResult("sign_event")
+        return Event.fromJson(signedJson)
+    }
+
+    suspend fun remoteSignString(account: Account, message: String): String {
+        val response = request(account, "sign_message", listOf(message))
+            ?: throw RemoteBunkerException("bunker timeout: sign_message")
+        return response.requireResult("sign_message")
+    }
+
+    suspend fun remoteEncrypt(
+        account: Account,
+        plainText: String,
+        toPublicKey: String,
+        useNip44: Boolean,
+    ): String {
+        val method = if (useNip44) "nip44_encrypt" else "nip04_encrypt"
+        val response = request(account, method, listOf(toPublicKey, plainText))
+            ?: throw RemoteBunkerException("bunker timeout: $method")
+        return response.requireResult(method)
+    }
+
+    suspend fun remoteDecrypt(
+        account: Account,
+        cipherText: String,
+        fromPublicKey: String,
+        useNip44: Boolean,
+    ): String {
+        val method = if (useNip44) "nip44_decrypt" else "nip04_decrypt"
+        val response = request(account, method, listOf(fromPublicKey, cipherText))
+            ?: throw RemoteBunkerException("bunker timeout: $method")
+        return response.requireResult(method)
+    }
+
+    suspend fun remoteDecryptAuto(account: Account, cipherText: String, fromPublicKey: String): String {
+        val useNip44 = !EncryptedInfo.isNIP04(cipherText)
+        return remoteDecrypt(account, cipherText, fromPublicKey, useNip44)
+    }
+
+    suspend fun remoteDecryptZapEvent(account: Account, eventJson: String): String {
+        val response = request(account, "decrypt_zap_event", listOf(account.proxy!!.remotePubkey, eventJson))
+            ?: throw RemoteBunkerException("bunker timeout: decrypt_zap_event")
+        return response.requireResult("decrypt_zap_event")
+    }
+
+    suspend fun remoteSignPsbt(account: Account, psbtHex: String): String {
+        val response = request(account, "sign_psbt", listOf(psbtHex))
+            ?: throw RemoteBunkerException("bunker timeout: sign_psbt")
+        return response.requireResult("sign_psbt")
+    }
+
+    suspend fun remoteGetPublicKey(account: Account): String {
+        val response = request(account, "get_public_key", emptyList())
+            ?: throw RemoteBunkerException("bunker timeout: get_public_key")
+        return response.requireResult("get_public_key")
+    }
+
+    /**
+     * Sends a `connect` request without using the [Account] (used during login,
+     * before the account is created).
+     */
+    suspend fun connect(
+        localSigner: NostrSignerInternal,
+        remotePubkey: String,
+        relays: List<NormalizedRelayUrl>,
+        secret: String,
+        permissions: String,
+        timeoutMs: Long = TIMEOUT_MS,
+    ): BunkerResponse? {
+        val params = buildList {
+            add(remotePubkey)
+            if (secret.isNotEmpty() || permissions.isNotEmpty()) add(secret)
+            if (permissions.isNotEmpty()) add(permissions)
+        }
+        return rawRequest(localSigner, remotePubkey, relays, "connect", params, timeoutMs)
+    }
+
+    /**
+     * Sends a `get_public_key` request without using an [Account].
+     */
+    suspend fun getPublicKey(
+        localSigner: NostrSignerInternal,
+        remotePubkey: String,
+        relays: List<NormalizedRelayUrl>,
+        timeoutMs: Long = TIMEOUT_MS,
+    ): BunkerResponse? = rawRequest(localSigner, remotePubkey, relays, "get_public_key", emptyList(), timeoutMs)
+
+    /**
+     * Low-level helper used during login. Identical to [request] but does not require an [Account].
+     */
+    suspend fun rawRequest(
+        localSigner: NostrSignerInternal,
+        remotePubkey: String,
+        relays: List<NormalizedRelayUrl>,
+        method: String,
+        params: List<String>,
+        timeoutMs: Long = TIMEOUT_MS,
+    ): BunkerResponse? {
+        if (relays.isEmpty()) return null
+        val id = UUID.randomUUID().toString()
+        val deferred = CompletableDeferred<BunkerResponse>()
+        pending[id] = deferred
+        try {
+            val payload = JacksonMapper.mapper.writeValueAsString(
+                mapOf(
+                    "id" to id,
+                    "method" to method,
+                    "params" to params,
+                ),
+            )
+            val encrypted = try {
+                localSigner.nip44Encrypt(payload, remotePubkey)
+            } catch (e: Exception) {
+                Log.w(Amber.TAG, "NIP-44 encrypt to bunker failed (raw); falling back to NIP-04", e)
+                localSigner.nip04Encrypt(payload, remotePubkey)
+            }
+            val event = localSigner.signerSync.sign<Event>(
+                createdAt = TimeUtils.now(),
+                kind = NostrConnectEvent.KIND,
+                tags = arrayOf(arrayOf("p", remotePubkey)),
+                content = encrypted,
+            )
+            val published = Amber.instance.client.publishAndConfirm(
+                event = event,
+                relayList = relays.toSet(),
+                timeoutInSeconds = 5,
+            )
+            if (!published) return null
+            return withTimeoutOrNull(timeoutMs) { deferred.await() }
+        } finally {
+            pending.remove(id)
+        }
+    }
+}
+
+class RemoteBunkerException(message: String) : RuntimeException(message)

--- a/app/src/main/java/com/greenart7c3/nostrsigner/service/RemoteBunkerClient.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/service/RemoteBunkerClient.kt
@@ -17,6 +17,7 @@ import com.vitorpamplona.quartz.utils.TimeUtils
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.withTimeoutOrNull
 
 /**
@@ -89,11 +90,11 @@ object RemoteBunkerClient {
                 ),
             )
 
-            val published = Amber.instance.client.publishAndConfirm(
-                event = event,
-                relayList = proxy.relays.toSet(),
-                timeoutInSeconds = 5,
-            )
+            // Publish with retry/backoff. The first attempt may be rejected if the
+            // relay is still negotiating NIP-42 AUTH; the auth coordinator answers
+            // the challenge in the background and subsequent retries succeed once
+            // the relay accepts our AUTH event.
+            val published = publishWithAuthRetry(event, proxy.relays.toSet())
 
             if (!published) {
                 Log.w(Amber.TAG, "Failed to publish bunker proxy request id=$id")
@@ -293,16 +294,48 @@ object RemoteBunkerClient {
                 tags = arrayOf(arrayOf("p", remotePubkey)),
                 content = encrypted,
             )
-            val published = Amber.instance.client.publishAndConfirm(
-                event = event,
-                relayList = relays.toSet(),
-                timeoutInSeconds = 5,
-            )
+            // Retry-with-backoff so the relay's NIP-42 AUTH challenge has time to
+            // be answered by the auth coordinator before the bunker request itself
+            // is published — without this, the very first bunker `connect` attempt
+            // races the AUTH and is rejected.
+            val published = publishWithAuthRetry(event, relays.toSet())
             if (!published) return null
             return withTimeoutOrNull(timeoutMs) { deferred.await() }
         } finally {
             pending.remove(id)
         }
+    }
+
+    /**
+     * Publishes [event] to [relays] using the same retry/backoff strategy as
+     * [BunkerRequestUtils.retryWithBackoff]. Inlined here so we don't pull a
+     * `Context` parameter through the client just for logging. The retry covers
+     * the case where a relay (e.g. wss://auth.nostr1.com) demands NIP-42 AUTH
+     * before accepting writes: the first attempt may fail with auth-required,
+     * the [com.vitorpamplona.quartz.nip01Core.relay.client.auth.RelayAuthenticator]
+     * answers the challenge in the background, and the next attempt succeeds.
+     */
+    private suspend fun publishWithAuthRetry(
+        event: Event,
+        relays: Set<com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl>,
+        maxRetries: Int = 5,
+        initialDelayMs: Long = 200L,
+        maxDelayMs: Long = 3_200L,
+    ): Boolean {
+        var currentDelay = initialDelayMs
+        repeat(maxRetries) { attempt ->
+            if (attempt > 0) delay(currentDelay)
+            val ok = Amber.instance.client.publishAndConfirm(
+                event = event,
+                relayList = relays,
+                timeoutInSeconds = 5,
+            )
+            if (ok) return true
+            if (attempt < maxRetries - 1) {
+                currentDelay = (currentDelay * 2).coerceAtMost(maxDelayMs)
+            }
+        }
+        return false
     }
 }
 

--- a/app/src/main/java/com/greenart7c3/nostrsigner/service/RemoteBunkerClient.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/service/RemoteBunkerClient.kt
@@ -1,0 +1,309 @@
+package com.greenart7c3.nostrsigner.service
+
+import android.util.Log
+import com.greenart7c3.nostrsigner.Amber
+import com.greenart7c3.nostrsigner.database.LogEntity
+import com.greenart7c3.nostrsigner.models.Account
+import com.vitorpamplona.quartz.nip01Core.core.Event
+import com.vitorpamplona.quartz.nip01Core.jackson.JacksonMapper
+import com.vitorpamplona.quartz.nip01Core.relay.client.accessories.publishAndConfirm
+import com.vitorpamplona.quartz.nip01Core.signers.EventTemplate
+import com.vitorpamplona.quartz.nip04Dm.crypto.EncryptedInfo
+import com.vitorpamplona.quartz.nip46RemoteSigner.BunkerResponse
+import com.vitorpamplona.quartz.nip46RemoteSigner.NostrConnectEvent
+import com.vitorpamplona.quartz.utils.TimeUtils
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.withTimeoutOrNull
+
+/**
+ * Outbound NIP-46 client. When an [Account] is configured as a bunker proxy, every
+ * sign / encrypt / decrypt call is forwarded to the remote bunker through this object.
+ *
+ * The local proxy keypair lives inside [Account.signer]. The remote user pubkey is
+ * stored in [Account.proxy].remotePubkey; that's what apps see as `account.hexKey`.
+ */
+object RemoteBunkerClient {
+    private const val TIMEOUT_MS = 30_000L
+
+    private val pending = ConcurrentHashMap<String, CompletableDeferred<BunkerResponse>>()
+
+    /**
+     * Called by [ProxyResponseSubscription] (or by tests) when a response from the
+     * remote bunker arrives.
+     */
+    fun deliverResponse(response: BunkerResponse) {
+        val deferred = pending.remove(response.id) ?: return
+        deferred.complete(response)
+    }
+
+    /**
+     * Returns the response or null on timeout / network failure.
+     */
+    suspend fun request(
+        account: Account,
+        method: String,
+        params: List<String>,
+        timeoutMs: Long = TIMEOUT_MS,
+    ): BunkerResponse? {
+        val proxy = account.proxy ?: error("request() called on a non-proxy account")
+        if (proxy.relays.isEmpty()) return null
+
+        val id = UUID.randomUUID().toString()
+        val deferred = CompletableDeferred<BunkerResponse>()
+        pending[id] = deferred
+
+        try {
+            val payload = JacksonMapper.mapper.writeValueAsString(
+                mapOf(
+                    "id" to id,
+                    "method" to method,
+                    "params" to params,
+                ),
+            )
+
+            val encrypted = try {
+                account.signer.nip44Encrypt(payload, proxy.remotePubkey)
+            } catch (e: Exception) {
+                Log.w(Amber.TAG, "NIP-44 encrypt to bunker failed; falling back to NIP-04", e)
+                account.signer.nip04Encrypt(payload, proxy.remotePubkey)
+            }
+
+            val event = account.signer.signerSync.sign<Event>(
+                createdAt = TimeUtils.now(),
+                kind = NostrConnectEvent.KIND,
+                tags = arrayOf(arrayOf("p", proxy.remotePubkey)),
+                content = encrypted,
+            )
+
+            Amber.instance.applicationIOScope.let {
+                Amber.instance.getLogDatabase(account.npub).dao().insertLog(
+                    LogEntity(
+                        id = 0,
+                        url = proxy.remotePubkey,
+                        type = "bunker proxy request",
+                        message = "method=$method id=$id",
+                        time = System.currentTimeMillis(),
+                    ),
+                )
+            }
+
+            val published = Amber.instance.client.publishAndConfirm(
+                event = event,
+                relayList = proxy.relays.toSet(),
+                timeoutInSeconds = 5,
+            )
+
+            if (!published) {
+                Log.w(Amber.TAG, "Failed to publish bunker proxy request id=$id")
+                Amber.instance.getLogDatabase(account.npub).dao().insertLog(
+                    LogEntity(
+                        id = 0,
+                        url = proxy.remotePubkey,
+                        type = "bunker proxy request",
+                        message = "publish failed for $method id=$id",
+                        time = System.currentTimeMillis(),
+                    ),
+                )
+                return null
+            }
+
+            val response = withTimeoutOrNull(timeoutMs) { deferred.await() }
+            if (response == null) {
+                Log.w(Amber.TAG, "Bunker proxy request timed out id=$id method=$method")
+                Amber.instance.getLogDatabase(account.npub).dao().insertLog(
+                    LogEntity(
+                        id = 0,
+                        url = proxy.remotePubkey,
+                        type = "bunker proxy request",
+                        message = "timeout for $method id=$id",
+                        time = System.currentTimeMillis(),
+                    ),
+                )
+            }
+            return response
+        } finally {
+            pending.remove(id)
+        }
+    }
+
+    private fun BunkerResponse.requireResult(method: String): String {
+        if (!error.isNullOrBlank()) {
+            throw RemoteBunkerException("bunker error for $method: $error")
+        }
+        return result ?: throw RemoteBunkerException("bunker returned null result for $method")
+    }
+
+    suspend fun <T : Event> remoteSignEvent(account: Account, template: EventTemplate<T>): Event {
+        val proxy = account.proxy ?: error("remoteSignEvent on non-proxy account")
+        val unsignedJson = JacksonMapper.mapper.writeValueAsString(
+            mapOf(
+                "kind" to template.kind,
+                "content" to template.content,
+                "tags" to template.tags,
+                "created_at" to template.createdAt,
+                "pubkey" to proxy.remotePubkey,
+            ),
+        )
+        val response = request(account, "sign_event", listOf(unsignedJson))
+            ?: throw RemoteBunkerException("bunker timeout: sign_event")
+        val signedJson = response.requireResult("sign_event")
+        return Event.fromJson(signedJson)
+    }
+
+    suspend fun remoteSignEventSync(
+        account: Account,
+        createdAt: Long,
+        kind: Int,
+        tags: Array<Array<String>>,
+        content: String,
+    ): Event {
+        val proxy = account.proxy ?: error("remoteSignEventSync on non-proxy account")
+        val unsignedJson = JacksonMapper.mapper.writeValueAsString(
+            mapOf(
+                "kind" to kind,
+                "content" to content,
+                "tags" to tags,
+                "created_at" to createdAt,
+                "pubkey" to proxy.remotePubkey,
+            ),
+        )
+        val response = request(account, "sign_event", listOf(unsignedJson))
+            ?: throw RemoteBunkerException("bunker timeout: sign_event")
+        val signedJson = response.requireResult("sign_event")
+        return Event.fromJson(signedJson)
+    }
+
+    suspend fun remoteSignString(account: Account, message: String): String {
+        val response = request(account, "sign_message", listOf(message))
+            ?: throw RemoteBunkerException("bunker timeout: sign_message")
+        return response.requireResult("sign_message")
+    }
+
+    suspend fun remoteEncrypt(
+        account: Account,
+        plainText: String,
+        toPublicKey: String,
+        useNip44: Boolean,
+    ): String {
+        val method = if (useNip44) "nip44_encrypt" else "nip04_encrypt"
+        val response = request(account, method, listOf(toPublicKey, plainText))
+            ?: throw RemoteBunkerException("bunker timeout: $method")
+        return response.requireResult(method)
+    }
+
+    suspend fun remoteDecrypt(
+        account: Account,
+        cipherText: String,
+        fromPublicKey: String,
+        useNip44: Boolean,
+    ): String {
+        val method = if (useNip44) "nip44_decrypt" else "nip04_decrypt"
+        val response = request(account, method, listOf(fromPublicKey, cipherText))
+            ?: throw RemoteBunkerException("bunker timeout: $method")
+        return response.requireResult(method)
+    }
+
+    suspend fun remoteDecryptAuto(account: Account, cipherText: String, fromPublicKey: String): String {
+        val useNip44 = !EncryptedInfo.isNIP04(cipherText)
+        return remoteDecrypt(account, cipherText, fromPublicKey, useNip44)
+    }
+
+    suspend fun remoteDecryptZapEvent(account: Account, eventJson: String): String {
+        val response = request(account, "decrypt_zap_event", listOf(account.proxy!!.remotePubkey, eventJson))
+            ?: throw RemoteBunkerException("bunker timeout: decrypt_zap_event")
+        return response.requireResult("decrypt_zap_event")
+    }
+
+    suspend fun remoteGetPublicKey(account: Account): String {
+        val response = request(account, "get_public_key", emptyList())
+            ?: throw RemoteBunkerException("bunker timeout: get_public_key")
+        return response.requireResult("get_public_key")
+    }
+
+    /**
+     * Sends a `connect` request without using the [Account] (used during login,
+     * before the account is created).
+     *
+     * @param localSigner signer holding the local proxy keypair
+     * @param remotePubkey pubkey of the remote bunker
+     * @param relays relays to publish to
+     * @param secret optional secret value sent as the second param (per NIP-46 connect)
+     * @param permissions optional perms string sent as the third param
+     */
+    suspend fun connect(
+        localSigner: com.vitorpamplona.quartz.nip01Core.signers.NostrSignerInternal,
+        remotePubkey: String,
+        relays: List<com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl>,
+        secret: String,
+        permissions: String,
+        timeoutMs: Long = TIMEOUT_MS,
+    ): BunkerResponse? {
+        val params = buildList {
+            add(remotePubkey)
+            if (secret.isNotEmpty() || permissions.isNotEmpty()) add(secret)
+            if (permissions.isNotEmpty()) add(permissions)
+        }
+        return rawRequest(localSigner, remotePubkey, relays, "connect", params, timeoutMs)
+    }
+
+    /**
+     * Sends a `get_public_key` request without using an [Account].
+     */
+    suspend fun getPublicKey(
+        localSigner: com.vitorpamplona.quartz.nip01Core.signers.NostrSignerInternal,
+        remotePubkey: String,
+        relays: List<com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl>,
+        timeoutMs: Long = TIMEOUT_MS,
+    ): BunkerResponse? = rawRequest(localSigner, remotePubkey, relays, "get_public_key", emptyList(), timeoutMs)
+
+    /**
+     * Low-level helper used during login. Identical to [request] but does not require an [Account].
+     */
+    suspend fun rawRequest(
+        localSigner: com.vitorpamplona.quartz.nip01Core.signers.NostrSignerInternal,
+        remotePubkey: String,
+        relays: List<com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl>,
+        method: String,
+        params: List<String>,
+        timeoutMs: Long = TIMEOUT_MS,
+    ): BunkerResponse? {
+        if (relays.isEmpty()) return null
+        val id = UUID.randomUUID().toString()
+        val deferred = CompletableDeferred<BunkerResponse>()
+        pending[id] = deferred
+        try {
+            val payload = JacksonMapper.mapper.writeValueAsString(
+                mapOf(
+                    "id" to id,
+                    "method" to method,
+                    "params" to params,
+                ),
+            )
+            val encrypted = try {
+                localSigner.nip44Encrypt(payload, remotePubkey)
+            } catch (e: Exception) {
+                Log.w(Amber.TAG, "NIP-44 encrypt to bunker failed (raw); falling back to NIP-04", e)
+                localSigner.nip04Encrypt(payload, remotePubkey)
+            }
+            val event = localSigner.signerSync.sign<Event>(
+                createdAt = TimeUtils.now(),
+                kind = NostrConnectEvent.KIND,
+                tags = arrayOf(arrayOf("p", remotePubkey)),
+                content = encrypted,
+            )
+            val published = Amber.instance.client.publishAndConfirm(
+                event = event,
+                relayList = relays.toSet(),
+                timeoutInSeconds = 5,
+            )
+            if (!published) return null
+            return withTimeoutOrNull(timeoutMs) { deferred.await() }
+        } finally {
+            pending.remove(id)
+        }
+    }
+}
+
+class RemoteBunkerException(message: String) : RuntimeException(message)

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/AccountStateViewModel.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/AccountStateViewModel.kt
@@ -7,13 +7,16 @@ import com.greenart7c3.nostrsigner.AmberLog
 import com.greenart7c3.nostrsigner.BuildFlavorChecker
 import com.greenart7c3.nostrsigner.LocalPreferences
 import com.greenart7c3.nostrsigner.models.Account
+import com.greenart7c3.nostrsigner.models.ProxyAccountMetadata
 import com.greenart7c3.nostrsigner.models.TorMode
 import com.greenart7c3.nostrsigner.service.ApplicationBackup
 import com.greenart7c3.nostrsigner.service.BackupPayload
 import com.greenart7c3.nostrsigner.service.RestoreResult
 import com.greenart7c3.nostrsigner.service.TorManager
+import com.vitorpamplona.quartz.nip01Core.core.hexToByteArray
 import com.vitorpamplona.quartz.nip01Core.core.toHexKey
 import com.vitorpamplona.quartz.nip01Core.crypto.KeyPair
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
 import com.vitorpamplona.quartz.nip01Core.signers.NostrSignerInternal
 import com.vitorpamplona.quartz.nip06KeyDerivation.Nip06
 import com.vitorpamplona.quartz.nip19Bech32.bech32.bechToBytes
@@ -198,6 +201,42 @@ class AccountStateViewModel(npub: String?) : ViewModel() {
                 AmberLog.d(Amber.TAG, "Account saved")
                 LocalPreferences.saveToEncryptedStorage(Amber.instance, it.account, null, null, null)
             }
+        }
+    }
+
+    suspend fun startProxyUI(
+        localKeyPair: KeyPair,
+        remotePubkeyHex: String,
+        relays: List<NormalizedRelayUrl>,
+        bunkerName: String,
+        nostrConnectSecret: String,
+    ) {
+        val proxyMetadata = ProxyAccountMetadata(
+            remotePubkey = remotePubkeyHex,
+            relays = relays,
+            bunkerName = bunkerName,
+            nostrConnectSecret = nostrConnectSecret,
+        )
+        val account = Account(
+            hexKey = remotePubkeyHex,
+            npub = remotePubkeyHex.hexToByteArray().toNpub(),
+            name = MutableStateFlow(bunkerName),
+            picture = MutableStateFlow(""),
+            signPolicy = 1,
+            didBackup = true,
+            signer = NostrSignerInternal(localKeyPair),
+            proxy = proxyMetadata,
+        )
+        LocalPreferences.updatePrefsForLogin(
+            Amber.instance,
+            account,
+            remotePubkeyHex,
+            localKeyPair.privKey!!.toHexKey(),
+            null,
+        )
+        startUI(account, null)
+        Amber.instance.applicationIOScope.launch {
+            Amber.instance.proxyResponseSubscription.updateFilter()
         }
     }
 

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/AccountStateViewModel.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/AccountStateViewModel.kt
@@ -6,10 +6,13 @@ import androidx.lifecycle.ViewModel
 import com.greenart7c3.nostrsigner.Amber
 import com.greenart7c3.nostrsigner.LocalPreferences
 import com.greenart7c3.nostrsigner.models.Account
+import com.greenart7c3.nostrsigner.models.ProxyAccountMetadata
 import com.greenart7c3.nostrsigner.models.TorMode
 import com.greenart7c3.nostrsigner.service.TorManager
+import com.vitorpamplona.quartz.nip01Core.core.hexToByteArray
 import com.vitorpamplona.quartz.nip01Core.core.toHexKey
 import com.vitorpamplona.quartz.nip01Core.crypto.KeyPair
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
 import com.vitorpamplona.quartz.nip01Core.signers.NostrSignerInternal
 import com.vitorpamplona.quartz.nip06KeyDerivation.Nip06
 import com.vitorpamplona.quartz.nip19Bech32.bech32.bechToBytes
@@ -168,6 +171,42 @@ class AccountStateViewModel(npub: String?) : ViewModel() {
         }
         LocalPreferences.updatePrefsForLogin(Amber.instance, account, hexKey, privKey, key)
         startUI(account, null)
+    }
+
+    suspend fun startProxyUI(
+        localKeyPair: KeyPair,
+        remotePubkeyHex: String,
+        relays: List<NormalizedRelayUrl>,
+        bunkerName: String,
+        nostrConnectSecret: String,
+    ) {
+        val proxyMetadata = ProxyAccountMetadata(
+            remotePubkey = remotePubkeyHex,
+            relays = relays,
+            bunkerName = bunkerName,
+            nostrConnectSecret = nostrConnectSecret,
+        )
+        val account = Account(
+            hexKey = remotePubkeyHex,
+            npub = remotePubkeyHex.hexToByteArray().toNpub(),
+            name = MutableStateFlow(bunkerName),
+            picture = MutableStateFlow(""),
+            signPolicy = 1,
+            didBackup = true,
+            signer = NostrSignerInternal(localKeyPair),
+            proxy = proxyMetadata,
+        )
+        LocalPreferences.updatePrefsForLogin(
+            Amber.instance,
+            account,
+            remotePubkeyHex,
+            localKeyPair.privKey!!.toHexKey(),
+            null,
+        )
+        startUI(account, null)
+        Amber.instance.applicationIOScope.launch {
+            Amber.instance.proxyResponseSubscription.updateFilter()
+        }
     }
 
     fun startUI(

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/BunkerProxyLoginScreen.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/BunkerProxyLoginScreen.kt
@@ -1,0 +1,342 @@
+package com.greenart7c3.nostrsigner.ui
+
+import android.content.ClipData
+import android.widget.Toast
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.SecondaryTabRow
+import androidx.compose.material3.Tab
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.ClipEntry
+import androidx.compose.ui.platform.LocalClipboard
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import com.greenart7c3.nostrsigner.Amber
+import com.greenart7c3.nostrsigner.BuildFlavorChecker
+import com.greenart7c3.nostrsigner.R
+import com.greenart7c3.nostrsigner.service.RemoteBunkerClient
+import com.greenart7c3.nostrsigner.ui.components.AmberButton
+import com.greenart7c3.nostrsigner.ui.navigation.Route
+import com.vitorpamplona.quartz.nip01Core.core.toHexKey
+import com.vitorpamplona.quartz.nip01Core.crypto.KeyPair
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.RelayUrlNormalizer
+import com.vitorpamplona.quartz.nip01Core.signers.NostrSignerInternal
+import com.vitorpamplona.quartz.utils.RandomInstance
+import java.net.URLDecoder
+import java.util.UUID
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+@Composable
+fun BunkerProxyLoginScreen(
+    accountViewModel: AccountStateViewModel,
+    navHostControllerWrapper: NavHostControllerWrapper,
+    contentPadding: PaddingValues = PaddingValues(0.dp),
+) {
+    val tabs = listOf(R.string.bunker_proxy_tab_paste_uri, R.string.bunker_proxy_tab_generate)
+    var tabIndex by remember { mutableStateOf(0) }
+    val isLoading = remember { mutableStateOf(false) }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(contentPadding)
+            .padding(horizontal = 16.dp)
+            .verticalScroll(rememberScrollState()),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text(
+            text = stringResource(R.string.bunker_proxy_title),
+            fontWeight = FontWeight.Bold,
+            style = MaterialTheme.typography.headlineSmall,
+            modifier = Modifier.padding(top = 16.dp),
+        )
+        Spacer(Modifier.height(8.dp))
+        Text(
+            text = stringResource(R.string.bunker_proxy_description),
+            style = MaterialTheme.typography.bodyMedium,
+        )
+        Spacer(Modifier.height(16.dp))
+
+        if (BuildFlavorChecker.isOfflineFlavor()) {
+            Text(
+                text = stringResource(R.string.bunker_proxy_offline_unsupported),
+                color = MaterialTheme.colorScheme.error,
+            )
+            return
+        }
+
+        SecondaryTabRow(selectedTabIndex = tabIndex) {
+            tabs.forEachIndexed { i, res ->
+                Tab(
+                    selected = tabIndex == i,
+                    onClick = { tabIndex = i },
+                    text = { Text(stringResource(res)) },
+                )
+            }
+        }
+        Spacer(Modifier.height(16.dp))
+
+        when (tabIndex) {
+            0 -> PasteBunkerUriTab(accountViewModel, navHostControllerWrapper, isLoading)
+            1 -> GenerateNostrConnectUriTab(accountViewModel, navHostControllerWrapper, isLoading)
+        }
+
+        if (isLoading.value) {
+            Spacer(Modifier.height(16.dp))
+            CenterCircularProgressIndicator(
+                modifier = Modifier.fillMaxWidth(),
+                text = stringResource(R.string.bunker_proxy_connecting),
+            )
+        }
+    }
+}
+
+@Composable
+private fun PasteBunkerUriTab(
+    accountViewModel: AccountStateViewModel,
+    navHostControllerWrapper: NavHostControllerWrapper,
+    isLoading: MutableState<Boolean>,
+) {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    var uri by remember { mutableStateOf("") }
+    var errorMessage by remember { mutableStateOf<String?>(null) }
+
+    OutlinedTextField(
+        modifier = Modifier.fillMaxWidth(),
+        value = uri,
+        onValueChange = { uri = it },
+        label = { Text(stringResource(R.string.bunker_proxy_uri_label)) },
+        placeholder = { Text("bunker://...") },
+        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri, imeAction = ImeAction.Done),
+        singleLine = false,
+    )
+    errorMessage?.let {
+        Text(it, color = MaterialTheme.colorScheme.error, modifier = Modifier.padding(top = 8.dp))
+    }
+    Spacer(Modifier.height(16.dp))
+
+    AmberButton(
+        text = stringResource(R.string.bunker_proxy_connect),
+        enabled = !isLoading.value,
+        onClick = {
+            errorMessage = null
+            isLoading.value = true
+            scope.launch(Dispatchers.IO) {
+                try {
+                    val parsed = parseBunkerUri(uri)
+                    if (parsed == null) {
+                        errorMessage = context.getString(R.string.bunker_proxy_invalid_uri)
+                        isLoading.value = false
+                        return@launch
+                    }
+
+                    val localKeyPair = KeyPair(privKey = RandomInstance.bytes(32))
+                    val signer = NostrSignerInternal(localKeyPair)
+
+                    Amber.instance.proxyResponseSubscription.registerTransientLogin(localKeyPair.privKey!!, parsed.remotePubkey)
+                    Amber.instance.proxyResponseSubscription.subscribeForLocalKey(localKeyPair.pubKey.toHexKey(), parsed.remotePubkey, parsed.relays)
+
+                    val connectResp = RemoteBunkerClient.connect(
+                        localSigner = signer,
+                        remotePubkey = parsed.remotePubkey,
+                        relays = parsed.relays,
+                        secret = parsed.secret,
+                        permissions = "",
+                    )
+                    if (connectResp == null || !connectResp.error.isNullOrBlank()) {
+                        errorMessage = connectResp?.error ?: context.getString(R.string.bunker_proxy_connect_failed)
+                        isLoading.value = false
+                        return@launch
+                    }
+
+                    val pubKeyResp = RemoteBunkerClient.getPublicKey(signer, parsed.remotePubkey, parsed.relays)
+                    val remoteUserPubkey = pubKeyResp?.result
+                    if (remoteUserPubkey.isNullOrBlank()) {
+                        errorMessage = context.getString(R.string.bunker_proxy_no_pubkey)
+                        isLoading.value = false
+                        return@launch
+                    }
+
+                    accountViewModel.startProxyUI(
+                        localKeyPair = localKeyPair,
+                        remotePubkeyHex = remoteUserPubkey,
+                        relays = parsed.relays,
+                        bunkerName = "Bunker proxy",
+                        nostrConnectSecret = "",
+                    )
+                    Amber.instance.applicationIOScope.launch {
+                        Amber.instance.notificationSubscription.updateFilter()
+                        Amber.instance.profileSubscription.updateFilter()
+                        Amber.instance.proxyResponseSubscription.updateFilter()
+                    }
+                    Amber.instance.applicationIOScope.launch(Dispatchers.Main) {
+                        navHostControllerWrapper.navController.navigate(Route.Applications.route) {
+                            popUpTo(0)
+                        }
+                    }
+                } catch (e: Exception) {
+                    errorMessage = e.message ?: context.getString(R.string.bunker_proxy_connect_failed)
+                } finally {
+                    isLoading.value = false
+                }
+            }
+        },
+    )
+}
+
+@Composable
+private fun GenerateNostrConnectUriTab(
+    accountViewModel: AccountStateViewModel,
+    navHostControllerWrapper: NavHostControllerWrapper,
+    isLoading: MutableState<Boolean>,
+) {
+    val context = LocalContext.current
+    val clipboard = LocalClipboard.current
+    val scope = rememberCoroutineScope()
+    val defaultRelays = remember { Amber.instance.settings.defaultRelays.toList() }
+    var errorMessage by remember { mutableStateOf<String?>(null) }
+    val keyPair = remember { KeyPair(privKey = RandomInstance.bytes(32)) }
+    val secret = remember { UUID.randomUUID().toString() }
+    val nostrConnectUri = remember(keyPair, secret) {
+        val relayParams = defaultRelays.joinToString(separator = "&") { "relay=${it.url}" }
+        "nostrconnect://${keyPair.pubKey.toHexKey()}?$relayParams&secret=$secret&name=AmberProxy"
+    }
+
+    Text(stringResource(R.string.bunker_proxy_generate_explanation))
+    Spacer(Modifier.height(16.dp))
+    Text(nostrConnectUri, style = MaterialTheme.typography.bodySmall)
+    Spacer(Modifier.height(16.dp))
+    QrCodeDrawer(nostrConnectUri)
+    Spacer(Modifier.height(16.dp))
+    AmberButton(
+        text = stringResource(R.string.copy_to_clipboard),
+        onClick = {
+            scope.launch {
+                clipboard.setClipEntry(ClipEntry(ClipData.newPlainText("", nostrConnectUri)))
+                Toast.makeText(context, context.getString(R.string.copied), Toast.LENGTH_SHORT).show()
+            }
+        },
+    )
+    Spacer(Modifier.height(16.dp))
+    errorMessage?.let {
+        Text(it, color = MaterialTheme.colorScheme.error, modifier = Modifier.padding(bottom = 8.dp))
+    }
+    AmberButton(
+        text = stringResource(R.string.bunker_proxy_wait_for_connect),
+        enabled = !isLoading.value,
+        onClick = {
+            errorMessage = null
+            isLoading.value = true
+            scope.launch(Dispatchers.IO) {
+                try {
+                    val signer = NostrSignerInternal(keyPair)
+                    val pending = Amber.instance.proxyResponseSubscription.awaitInitialConnect(
+                        localKeyPair = keyPair,
+                        relays = defaultRelays,
+                        secret = secret,
+                        timeoutMs = 5 * 60 * 1000L,
+                    )
+                    if (pending == null) {
+                        errorMessage = context.getString(R.string.bunker_proxy_connect_failed)
+                        isLoading.value = false
+                        return@launch
+                    }
+                    val pubKeyResp = RemoteBunkerClient.getPublicKey(
+                        localSigner = signer,
+                        remotePubkey = pending,
+                        relays = defaultRelays,
+                    )
+                    val remoteUserPubkey = pubKeyResp?.result
+                    if (remoteUserPubkey.isNullOrBlank()) {
+                        errorMessage = context.getString(R.string.bunker_proxy_no_pubkey)
+                        isLoading.value = false
+                        return@launch
+                    }
+
+                    accountViewModel.startProxyUI(
+                        localKeyPair = keyPair,
+                        remotePubkeyHex = remoteUserPubkey,
+                        relays = defaultRelays,
+                        bunkerName = "Bunker proxy",
+                        nostrConnectSecret = secret,
+                    )
+                    Amber.instance.applicationIOScope.launch {
+                        Amber.instance.notificationSubscription.updateFilter()
+                        Amber.instance.profileSubscription.updateFilter()
+                        Amber.instance.proxyResponseSubscription.updateFilter()
+                    }
+                    Amber.instance.applicationIOScope.launch(Dispatchers.Main) {
+                        navHostControllerWrapper.navController.navigate(Route.Applications.route) {
+                            popUpTo(0)
+                        }
+                    }
+                } catch (e: Exception) {
+                    errorMessage = e.message ?: context.getString(R.string.bunker_proxy_connect_failed)
+                } finally {
+                    isLoading.value = false
+                }
+            }
+        },
+    )
+}
+
+internal data class ParsedBunkerUri(
+    val remotePubkey: String,
+    val relays: List<NormalizedRelayUrl>,
+    val secret: String,
+)
+
+internal fun parseBunkerUri(raw: String): ParsedBunkerUri? {
+    val trimmed = raw.trim()
+    if (!trimmed.startsWith("bunker://")) return null
+    val withoutScheme = trimmed.removePrefix("bunker://")
+    val parts = withoutScheme.split("?", limit = 2)
+    val remotePubkey = parts[0].trim()
+    if (remotePubkey.length != 64) return null
+    val relays = mutableListOf<NormalizedRelayUrl>()
+    var secret = ""
+    if (parts.size == 2) {
+        parts[1].split("&").forEach { kv ->
+            val eq = kv.indexOf('=')
+            if (eq <= 0) return@forEach
+            val k = kv.substring(0, eq)
+            val v = try {
+                URLDecoder.decode(kv.substring(eq + 1), "utf-8")
+            } catch (_: Exception) {
+                kv.substring(eq + 1)
+            }
+            when (k) {
+                "relay" -> RelayUrlNormalizer.normalizeOrNull(v)?.let { relays.add(it) }
+                "secret" -> secret = v
+            }
+        }
+    }
+    if (relays.isEmpty()) return null
+    return ParsedBunkerUri(remotePubkey, relays, secret)
+}

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/BunkerProxyLoginScreen.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/BunkerProxyLoginScreen.kt
@@ -214,7 +214,6 @@ private fun PasteBunkerUriTab(
                     )
                     Amber.instance.applicationIOScope.launch {
                         Amber.instance.notificationSubscription.updateFilter()
-                        Amber.instance.profileSubscription.updateFilter()
                         Amber.instance.proxyResponseSubscription.updateFilter()
                     }
                     Amber.instance.applicationIOScope.launch(Dispatchers.Main) {
@@ -314,7 +313,6 @@ private fun GenerateNostrConnectUriTab(
                     )
                     Amber.instance.applicationIOScope.launch {
                         Amber.instance.notificationSubscription.updateFilter()
-                        Amber.instance.profileSubscription.updateFilter()
                         Amber.instance.proxyResponseSubscription.updateFilter()
                     }
                     Amber.instance.applicationIOScope.launch(Dispatchers.Main) {

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/BunkerProxyLoginScreen.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/BunkerProxyLoginScreen.kt
@@ -3,6 +3,7 @@ package com.greenart7c3.nostrsigner.ui
 import android.content.ClipData
 import android.widget.Toast
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -13,7 +14,6 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SecondaryTabRow
 import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
@@ -39,6 +39,7 @@ import com.greenart7c3.nostrsigner.BuildFlavorChecker
 import com.greenart7c3.nostrsigner.R
 import com.greenart7c3.nostrsigner.service.RemoteBunkerClient
 import com.greenart7c3.nostrsigner.ui.components.AmberButton
+import com.greenart7c3.nostrsigner.ui.navigation.Route
 import com.vitorpamplona.quartz.nip01Core.core.toHexKey
 import com.vitorpamplona.quartz.nip01Core.crypto.KeyPair
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
@@ -54,64 +55,63 @@ import kotlinx.coroutines.launch
 fun BunkerProxyLoginScreen(
     accountViewModel: AccountStateViewModel,
     navHostControllerWrapper: NavHostControllerWrapper,
+    contentPadding: PaddingValues = PaddingValues(0.dp),
 ) {
     val tabs = listOf(R.string.bunker_proxy_tab_paste_uri, R.string.bunker_proxy_tab_generate)
     var tabIndex by remember { mutableStateOf(0) }
     val isLoading = remember { mutableStateOf(false) }
 
-    Scaffold { padding ->
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(padding)
-                .padding(horizontal = 16.dp)
-                .verticalScroll(rememberScrollState()),
-            horizontalAlignment = Alignment.CenterHorizontally,
-        ) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(contentPadding)
+            .padding(horizontal = 16.dp)
+            .verticalScroll(rememberScrollState()),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text(
+            text = stringResource(R.string.bunker_proxy_title),
+            fontWeight = FontWeight.Bold,
+            style = MaterialTheme.typography.headlineSmall,
+            modifier = Modifier.padding(top = 16.dp),
+        )
+        Spacer(Modifier.height(8.dp))
+        Text(
+            text = stringResource(R.string.bunker_proxy_description),
+            style = MaterialTheme.typography.bodyMedium,
+        )
+        Spacer(Modifier.height(16.dp))
+
+        if (BuildFlavorChecker.isOfflineFlavor()) {
             Text(
-                text = stringResource(R.string.bunker_proxy_title),
-                fontWeight = FontWeight.Bold,
-                style = MaterialTheme.typography.headlineSmall,
-                modifier = Modifier.padding(top = 16.dp),
+                text = stringResource(R.string.bunker_proxy_offline_unsupported),
+                color = MaterialTheme.colorScheme.error,
             )
-            Spacer(Modifier.height(8.dp))
-            Text(
-                text = stringResource(R.string.bunker_proxy_description),
-                style = MaterialTheme.typography.bodyMedium,
-            )
-            Spacer(Modifier.height(16.dp))
+            return
+        }
 
-            if (BuildFlavorChecker.isOfflineFlavor()) {
-                Text(
-                    text = stringResource(R.string.bunker_proxy_offline_unsupported),
-                    color = MaterialTheme.colorScheme.error,
-                )
-                return@Scaffold
-            }
-
-            SecondaryTabRow(selectedTabIndex = tabIndex) {
-                tabs.forEachIndexed { i, res ->
-                    Tab(
-                        selected = tabIndex == i,
-                        onClick = { tabIndex = i },
-                        text = { Text(stringResource(res)) },
-                    )
-                }
-            }
-            Spacer(Modifier.height(16.dp))
-
-            when (tabIndex) {
-                0 -> PasteBunkerUriTab(accountViewModel, isLoading)
-                1 -> GenerateNostrConnectUriTab(accountViewModel, isLoading)
-            }
-
-            if (isLoading.value) {
-                Spacer(Modifier.height(16.dp))
-                CenterCircularProgressIndicator(
-                    modifier = Modifier.fillMaxWidth(),
-                    text = stringResource(R.string.bunker_proxy_connecting),
+        SecondaryTabRow(selectedTabIndex = tabIndex) {
+            tabs.forEachIndexed { i, res ->
+                Tab(
+                    selected = tabIndex == i,
+                    onClick = { tabIndex = i },
+                    text = { Text(stringResource(res)) },
                 )
             }
+        }
+        Spacer(Modifier.height(16.dp))
+
+        when (tabIndex) {
+            0 -> PasteBunkerUriTab(accountViewModel, navHostControllerWrapper, isLoading)
+            1 -> GenerateNostrConnectUriTab(accountViewModel, navHostControllerWrapper, isLoading)
+        }
+
+        if (isLoading.value) {
+            Spacer(Modifier.height(16.dp))
+            CenterCircularProgressIndicator(
+                modifier = Modifier.fillMaxWidth(),
+                text = stringResource(R.string.bunker_proxy_connecting),
+            )
         }
     }
 }
@@ -119,6 +119,7 @@ fun BunkerProxyLoginScreen(
 @Composable
 private fun PasteBunkerUriTab(
     accountViewModel: AccountStateViewModel,
+    navHostControllerWrapper: NavHostControllerWrapper,
     isLoading: MutableState<Boolean>,
 ) {
     val context = LocalContext.current
@@ -196,6 +197,11 @@ private fun PasteBunkerUriTab(
                         Amber.instance.profileSubscription.updateFilter()
                         Amber.instance.proxyResponseSubscription.updateFilter()
                     }
+                    Amber.instance.applicationIOScope.launch(Dispatchers.Main) {
+                        navHostControllerWrapper.navController.navigate(Route.Applications.route) {
+                            popUpTo(0)
+                        }
+                    }
                 } catch (e: Exception) {
                     errorMessage = e.message ?: context.getString(R.string.bunker_proxy_connect_failed)
                 } finally {
@@ -209,6 +215,7 @@ private fun PasteBunkerUriTab(
 @Composable
 private fun GenerateNostrConnectUriTab(
     accountViewModel: AccountStateViewModel,
+    navHostControllerWrapper: NavHostControllerWrapper,
     isLoading: MutableState<Boolean>,
 ) {
     val context = LocalContext.current
@@ -285,6 +292,11 @@ private fun GenerateNostrConnectUriTab(
                         Amber.instance.notificationSubscription.updateFilter()
                         Amber.instance.profileSubscription.updateFilter()
                         Amber.instance.proxyResponseSubscription.updateFilter()
+                    }
+                    Amber.instance.applicationIOScope.launch(Dispatchers.Main) {
+                        navHostControllerWrapper.navController.navigate(Route.Applications.route) {
+                            popUpTo(0)
+                        }
                     }
                 } catch (e: Exception) {
                     errorMessage = e.message ?: context.getString(R.string.bunker_proxy_connect_failed)

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/BunkerProxyLoginScreen.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/BunkerProxyLoginScreen.kt
@@ -159,12 +159,19 @@ private fun PasteBunkerUriTab(
                     val localKeyPair = KeyPair(privKey = RandomInstance.bytes(32))
                     val signer = NostrSignerInternal(localKeyPair)
 
+                    // Make our login keypair available to the relay AUTH coordinator
+                    // BEFORE we trigger any traffic to the bunker's relays — otherwise
+                    // a relay (e.g. wss://auth.nostr1.com) would issue its NIP-42
+                    // challenge with no signer registered to answer it.
+                    Amber.instance.registerTransientAuthSigner(signer)
                     Amber.instance.proxyResponseSubscription.registerTransientLogin(localKeyPair.privKey!!, parsed.remotePubkey)
                     Amber.instance.proxyResponseSubscription.subscribeForLocalKey(localKeyPair.pubKey.toHexKey(), parsed.remotePubkey, parsed.relays)
-                    // Make our login keypair available to the relay AUTH coordinator so
-                    // relays like wss://auth.nostr1.com can challenge us before we have
-                    // a saved account to fall back on.
-                    Amber.instance.registerTransientAuthSigner(signer)
+
+                    // Give the relay a moment to send its AUTH challenge and the auth
+                    // coordinator a chance to deliver the signed AUTH response before we
+                    // publish the bunker `connect` event. Otherwise the very first
+                    // publish races the AUTH handshake and is rejected.
+                    kotlinx.coroutines.delay(750)
 
                     val connectResp = try {
                         RemoteBunkerClient.connect(

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/BunkerProxyLoginScreen.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/BunkerProxyLoginScreen.kt
@@ -1,0 +1,332 @@
+package com.greenart7c3.nostrsigner.ui
+
+import android.content.ClipData
+import android.widget.Toast
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SecondaryTabRow
+import androidx.compose.material3.Tab
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.ClipEntry
+import androidx.compose.ui.platform.LocalClipboard
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import com.greenart7c3.nostrsigner.Amber
+import com.greenart7c3.nostrsigner.BuildFlavorChecker
+import com.greenart7c3.nostrsigner.R
+import com.greenart7c3.nostrsigner.service.RemoteBunkerClient
+import com.greenart7c3.nostrsigner.ui.components.AmberButton
+import com.vitorpamplona.quartz.nip01Core.core.toHexKey
+import com.vitorpamplona.quartz.nip01Core.crypto.KeyPair
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.RelayUrlNormalizer
+import com.vitorpamplona.quartz.nip01Core.signers.NostrSignerInternal
+import com.vitorpamplona.quartz.utils.RandomInstance
+import java.net.URLDecoder
+import java.util.UUID
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+@Composable
+fun BunkerProxyLoginScreen(
+    accountViewModel: AccountStateViewModel,
+    navHostControllerWrapper: NavHostControllerWrapper,
+) {
+    val tabs = listOf(R.string.bunker_proxy_tab_paste_uri, R.string.bunker_proxy_tab_generate)
+    var tabIndex by remember { mutableStateOf(0) }
+    val isLoading = remember { mutableStateOf(false) }
+
+    Scaffold { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(horizontal = 16.dp)
+                .verticalScroll(rememberScrollState()),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Text(
+                text = stringResource(R.string.bunker_proxy_title),
+                fontWeight = FontWeight.Bold,
+                style = MaterialTheme.typography.headlineSmall,
+                modifier = Modifier.padding(top = 16.dp),
+            )
+            Spacer(Modifier.height(8.dp))
+            Text(
+                text = stringResource(R.string.bunker_proxy_description),
+                style = MaterialTheme.typography.bodyMedium,
+            )
+            Spacer(Modifier.height(16.dp))
+
+            if (BuildFlavorChecker.isOfflineFlavor()) {
+                Text(
+                    text = stringResource(R.string.bunker_proxy_offline_unsupported),
+                    color = MaterialTheme.colorScheme.error,
+                )
+                return@Scaffold
+            }
+
+            SecondaryTabRow(selectedTabIndex = tabIndex) {
+                tabs.forEachIndexed { i, res ->
+                    Tab(
+                        selected = tabIndex == i,
+                        onClick = { tabIndex = i },
+                        text = { Text(stringResource(res)) },
+                    )
+                }
+            }
+            Spacer(Modifier.height(16.dp))
+
+            when (tabIndex) {
+                0 -> PasteBunkerUriTab(accountViewModel, isLoading)
+                1 -> GenerateNostrConnectUriTab(accountViewModel, isLoading)
+            }
+
+            if (isLoading.value) {
+                Spacer(Modifier.height(16.dp))
+                CenterCircularProgressIndicator(
+                    modifier = Modifier.fillMaxWidth(),
+                    text = stringResource(R.string.bunker_proxy_connecting),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun PasteBunkerUriTab(
+    accountViewModel: AccountStateViewModel,
+    isLoading: MutableState<Boolean>,
+) {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    var uri by remember { mutableStateOf("") }
+    var errorMessage by remember { mutableStateOf<String?>(null) }
+
+    OutlinedTextField(
+        modifier = Modifier.fillMaxWidth(),
+        value = uri,
+        onValueChange = { uri = it },
+        label = { Text(stringResource(R.string.bunker_proxy_uri_label)) },
+        placeholder = { Text("bunker://...") },
+        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri, imeAction = ImeAction.Done),
+        singleLine = false,
+    )
+    errorMessage?.let {
+        Text(it, color = MaterialTheme.colorScheme.error, modifier = Modifier.padding(top = 8.dp))
+    }
+    Spacer(Modifier.height(16.dp))
+
+    AmberButton(
+        text = stringResource(R.string.bunker_proxy_connect),
+        enabled = !isLoading.value,
+        onClick = {
+            errorMessage = null
+            isLoading.value = true
+            scope.launch(Dispatchers.IO) {
+                try {
+                    val parsed = parseBunkerUri(uri)
+                    if (parsed == null) {
+                        errorMessage = context.getString(R.string.bunker_proxy_invalid_uri)
+                        isLoading.value = false
+                        return@launch
+                    }
+
+                    val localKeyPair = KeyPair(privKey = RandomInstance.bytes(32))
+                    val signer = NostrSignerInternal(localKeyPair)
+
+                    // Register the transient signer + subscribe so we receive the bunker's
+                    // connect/get_public_key responses before the account is persisted.
+                    Amber.instance.proxyResponseSubscription.registerTransientLogin(localKeyPair.privKey!!, parsed.remotePubkey)
+                    Amber.instance.proxyResponseSubscription.subscribeForLocalKey(localKeyPair.pubKey.toHexKey(), parsed.remotePubkey, parsed.relays)
+
+                    val connectResp = RemoteBunkerClient.connect(
+                        localSigner = signer,
+                        remotePubkey = parsed.remotePubkey,
+                        relays = parsed.relays,
+                        secret = parsed.secret,
+                        permissions = "",
+                    )
+                    if (connectResp == null || !connectResp.error.isNullOrBlank()) {
+                        errorMessage = connectResp?.error ?: context.getString(R.string.bunker_proxy_connect_failed)
+                        isLoading.value = false
+                        return@launch
+                    }
+
+                    val pubKeyResp = RemoteBunkerClient.getPublicKey(signer, parsed.remotePubkey, parsed.relays)
+                    val remoteUserPubkey = pubKeyResp?.result
+                    if (remoteUserPubkey.isNullOrBlank()) {
+                        errorMessage = context.getString(R.string.bunker_proxy_no_pubkey)
+                        isLoading.value = false
+                        return@launch
+                    }
+
+                    accountViewModel.startProxyUI(
+                        localKeyPair = localKeyPair,
+                        remotePubkeyHex = remoteUserPubkey,
+                        relays = parsed.relays,
+                        bunkerName = "Bunker proxy",
+                        nostrConnectSecret = "",
+                    )
+                    Amber.instance.applicationIOScope.launch {
+                        Amber.instance.notificationSubscription.updateFilter()
+                        Amber.instance.profileSubscription.updateFilter()
+                        Amber.instance.proxyResponseSubscription.updateFilter()
+                    }
+                } catch (e: Exception) {
+                    errorMessage = e.message ?: context.getString(R.string.bunker_proxy_connect_failed)
+                } finally {
+                    isLoading.value = false
+                }
+            }
+        },
+    )
+}
+
+@Composable
+private fun GenerateNostrConnectUriTab(
+    accountViewModel: AccountStateViewModel,
+    isLoading: MutableState<Boolean>,
+) {
+    val context = LocalContext.current
+    val clipboard = LocalClipboard.current
+    val scope = rememberCoroutineScope()
+    val defaultRelays = remember { Amber.instance.settings.defaultRelays.toList() }
+    var errorMessage by remember { mutableStateOf<String?>(null) }
+    val keyPair = remember { KeyPair(privKey = RandomInstance.bytes(32)) }
+    val secret = remember { UUID.randomUUID().toString() }
+    val nostrConnectUri = remember(keyPair, secret) {
+        val relayParams = defaultRelays.joinToString(separator = "&") { "relay=${it.url}" }
+        "nostrconnect://${keyPair.pubKey.toHexKey()}?$relayParams&secret=$secret&name=AmberProxy"
+    }
+
+    Text(stringResource(R.string.bunker_proxy_generate_explanation))
+    Spacer(Modifier.height(16.dp))
+    Text(nostrConnectUri, style = MaterialTheme.typography.bodySmall)
+    Spacer(Modifier.height(16.dp))
+    QrCodeDrawer(nostrConnectUri)
+    Spacer(Modifier.height(16.dp))
+    AmberButton(
+        text = stringResource(R.string.copy_to_clipboard),
+        onClick = {
+            scope.launch {
+                clipboard.setClipEntry(ClipEntry(ClipData.newPlainText("", nostrConnectUri)))
+                Toast.makeText(context, context.getString(R.string.copied), Toast.LENGTH_SHORT).show()
+            }
+        },
+    )
+    Spacer(Modifier.height(16.dp))
+    errorMessage?.let {
+        Text(it, color = MaterialTheme.colorScheme.error, modifier = Modifier.padding(bottom = 8.dp))
+    }
+    AmberButton(
+        text = stringResource(R.string.bunker_proxy_wait_for_connect),
+        enabled = !isLoading.value,
+        onClick = {
+            errorMessage = null
+            isLoading.value = true
+            scope.launch(Dispatchers.IO) {
+                try {
+                    val signer = NostrSignerInternal(keyPair)
+                    val pending = Amber.instance.proxyResponseSubscription.awaitInitialConnect(
+                        localKeyPair = keyPair,
+                        relays = defaultRelays,
+                        secret = secret,
+                        timeoutMs = 5 * 60 * 1000L,
+                    )
+                    if (pending == null) {
+                        errorMessage = context.getString(R.string.bunker_proxy_connect_failed)
+                        isLoading.value = false
+                        return@launch
+                    }
+                    val pubKeyResp = RemoteBunkerClient.getPublicKey(
+                        localSigner = signer,
+                        remotePubkey = pending,
+                        relays = defaultRelays,
+                    )
+                    val remoteUserPubkey = pubKeyResp?.result
+                    if (remoteUserPubkey.isNullOrBlank()) {
+                        errorMessage = context.getString(R.string.bunker_proxy_no_pubkey)
+                        isLoading.value = false
+                        return@launch
+                    }
+
+                    accountViewModel.startProxyUI(
+                        localKeyPair = keyPair,
+                        remotePubkeyHex = remoteUserPubkey,
+                        relays = defaultRelays,
+                        bunkerName = "Bunker proxy",
+                        nostrConnectSecret = secret,
+                    )
+                    Amber.instance.applicationIOScope.launch {
+                        Amber.instance.notificationSubscription.updateFilter()
+                        Amber.instance.profileSubscription.updateFilter()
+                        Amber.instance.proxyResponseSubscription.updateFilter()
+                    }
+                } catch (e: Exception) {
+                    errorMessage = e.message ?: context.getString(R.string.bunker_proxy_connect_failed)
+                } finally {
+                    isLoading.value = false
+                }
+            }
+        },
+    )
+}
+
+internal data class ParsedBunkerUri(
+    val remotePubkey: String,
+    val relays: List<NormalizedRelayUrl>,
+    val secret: String,
+)
+
+internal fun parseBunkerUri(raw: String): ParsedBunkerUri? {
+    val trimmed = raw.trim()
+    if (!trimmed.startsWith("bunker://")) return null
+    val withoutScheme = trimmed.removePrefix("bunker://")
+    val parts = withoutScheme.split("?", limit = 2)
+    val remotePubkey = parts[0].trim()
+    if (remotePubkey.length != 64) return null
+    val relays = mutableListOf<NormalizedRelayUrl>()
+    var secret = ""
+    if (parts.size == 2) {
+        parts[1].split("&").forEach { kv ->
+            val eq = kv.indexOf('=')
+            if (eq <= 0) return@forEach
+            val k = kv.substring(0, eq)
+            val v = try {
+                URLDecoder.decode(kv.substring(eq + 1), "utf-8")
+            } catch (_: Exception) {
+                kv.substring(eq + 1)
+            }
+            when (k) {
+                "relay" -> RelayUrlNormalizer.normalizeOrNull(v)?.let { relays.add(it) }
+                "secret" -> secret = v
+            }
+        }
+    }
+    if (relays.isEmpty()) return null
+    return ParsedBunkerUri(remotePubkey, relays, secret)
+}

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/BunkerProxyLoginScreen.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/BunkerProxyLoginScreen.kt
@@ -161,15 +161,25 @@ private fun PasteBunkerUriTab(
 
                     Amber.instance.proxyResponseSubscription.registerTransientLogin(localKeyPair.privKey!!, parsed.remotePubkey)
                     Amber.instance.proxyResponseSubscription.subscribeForLocalKey(localKeyPair.pubKey.toHexKey(), parsed.remotePubkey, parsed.relays)
+                    // Make our login keypair available to the relay AUTH coordinator so
+                    // relays like wss://auth.nostr1.com can challenge us before we have
+                    // a saved account to fall back on.
+                    Amber.instance.registerTransientAuthSigner(signer)
 
-                    val connectResp = RemoteBunkerClient.connect(
-                        localSigner = signer,
-                        remotePubkey = parsed.remotePubkey,
-                        relays = parsed.relays,
-                        secret = parsed.secret,
-                        permissions = "",
-                    )
+                    val connectResp = try {
+                        RemoteBunkerClient.connect(
+                            localSigner = signer,
+                            remotePubkey = parsed.remotePubkey,
+                            relays = parsed.relays,
+                            secret = parsed.secret,
+                            permissions = "",
+                        )
+                    } catch (e: Exception) {
+                        Amber.instance.unregisterTransientAuthSigner(signer)
+                        throw e
+                    }
                     if (connectResp == null || !connectResp.error.isNullOrBlank()) {
+                        Amber.instance.unregisterTransientAuthSigner(signer)
                         errorMessage = connectResp?.error ?: context.getString(R.string.bunker_proxy_connect_failed)
                         isLoading.value = false
                         return@launch
@@ -178,10 +188,15 @@ private fun PasteBunkerUriTab(
                     val pubKeyResp = RemoteBunkerClient.getPublicKey(signer, parsed.remotePubkey, parsed.relays)
                     val remoteUserPubkey = pubKeyResp?.result
                     if (remoteUserPubkey.isNullOrBlank()) {
+                        Amber.instance.unregisterTransientAuthSigner(signer)
                         errorMessage = context.getString(R.string.bunker_proxy_no_pubkey)
                         isLoading.value = false
                         return@launch
                     }
+
+                    // Account is about to be saved; the proxy account's own signer will
+                    // be picked up by the auth coordinator going forward.
+                    Amber.instance.unregisterTransientAuthSigner(signer)
 
                     accountViewModel.startProxyUI(
                         localKeyPair = localKeyPair,
@@ -254,8 +269,9 @@ private fun GenerateNostrConnectUriTab(
             errorMessage = null
             isLoading.value = true
             scope.launch(Dispatchers.IO) {
+                val signer = NostrSignerInternal(keyPair)
+                Amber.instance.registerTransientAuthSigner(signer)
                 try {
-                    val signer = NostrSignerInternal(keyPair)
                     val pending = Amber.instance.proxyResponseSubscription.awaitInitialConnect(
                         localKeyPair = keyPair,
                         relays = defaultRelays,
@@ -265,6 +281,7 @@ private fun GenerateNostrConnectUriTab(
                     if (pending == null) {
                         errorMessage = context.getString(R.string.bunker_proxy_connect_failed)
                         isLoading.value = false
+                        Amber.instance.unregisterTransientAuthSigner(signer)
                         return@launch
                     }
                     val pubKeyResp = RemoteBunkerClient.getPublicKey(
@@ -276,9 +293,11 @@ private fun GenerateNostrConnectUriTab(
                     if (remoteUserPubkey.isNullOrBlank()) {
                         errorMessage = context.getString(R.string.bunker_proxy_no_pubkey)
                         isLoading.value = false
+                        Amber.instance.unregisterTransientAuthSigner(signer)
                         return@launch
                     }
 
+                    Amber.instance.unregisterTransientAuthSigner(signer)
                     accountViewModel.startProxyUI(
                         localKeyPair = keyPair,
                         remotePubkeyHex = remoteUserPubkey,
@@ -298,6 +317,7 @@ private fun GenerateNostrConnectUriTab(
                     }
                 } catch (e: Exception) {
                     errorMessage = e.message ?: context.getString(R.string.bunker_proxy_connect_failed)
+                    Amber.instance.unregisterTransientAuthSigner(signer)
                 } finally {
                     isLoading.value = false
                 }

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/LoginScreen.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/LoginScreen.kt
@@ -103,6 +103,7 @@ import androidx.compose.ui.unit.sp
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import com.greenart7c3.nostrsigner.Amber
+import com.greenart7c3.nostrsigner.BuildFlavorChecker
 import com.greenart7c3.nostrsigner.LocalPreferences
 import com.greenart7c3.nostrsigner.R
 import com.greenart7c3.nostrsigner.models.TorMode
@@ -312,6 +313,17 @@ fun MainPage(
                             },
                             text = stringResource(R.string.recover_from_backup),
                         )
+
+                        if (!BuildFlavorChecker.isOfflineFlavor()) {
+                            AmberButton(
+                                onClick = {
+                                    Amber.instance.applicationIOScope.launch(Dispatchers.Main) {
+                                        navHostControllerWrapper.navController.navigate("bunkerProxyLogin")
+                                    }
+                                },
+                                text = stringResource(R.string.bunker_proxy_login_button),
+                            )
+                        }
                     }
 
                     Spacer(Modifier.weight(1f))
@@ -392,6 +404,16 @@ fun MainLoginPage(
                     accountViewModel = accountViewModel,
                     navHostControllerWrapper = navHostControllerWrapper,
                     onFinish = {},
+                )
+            },
+        )
+
+        composable(
+            "bunkerProxyLogin",
+            content = {
+                BunkerProxyLoginScreen(
+                    accountViewModel = accountViewModel,
+                    navHostControllerWrapper = navHostControllerWrapper,
                 )
             },
         )

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/LoginScreen.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/LoginScreen.kt
@@ -103,6 +103,7 @@ import androidx.compose.ui.unit.sp
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import com.greenart7c3.nostrsigner.Amber
+import com.greenart7c3.nostrsigner.BuildFlavorChecker
 import com.greenart7c3.nostrsigner.LocalPreferences
 import com.greenart7c3.nostrsigner.R
 import com.greenart7c3.nostrsigner.models.TorMode
@@ -312,6 +313,17 @@ fun MainPage(
                             },
                             text = stringResource(R.string.recover_from_backup),
                         )
+
+                        if (!BuildFlavorChecker.isOfflineFlavor()) {
+                            AmberButton(
+                                onClick = {
+                                    Amber.instance.applicationIOScope.launch(Dispatchers.Main) {
+                                        navHostControllerWrapper.navController.navigate("bunkerProxyLogin")
+                                    }
+                                },
+                                text = stringResource(R.string.bunker_proxy_login_button),
+                            )
+                        }
                     }
 
                     Spacer(Modifier.weight(1f))
@@ -393,6 +405,16 @@ fun MainLoginPage(
                     accountViewModel = accountViewModel,
                     navHostControllerWrapper = navHostControllerWrapper,
                     onFinish = {},
+                )
+            },
+        )
+
+        composable(
+            "bunkerProxyLogin",
+            content = {
+                BunkerProxyLoginScreen(
+                    accountViewModel = accountViewModel,
+                    navHostControllerWrapper = navHostControllerWrapper,
                 )
             },
         )

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/MainScreen.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/MainScreen.kt
@@ -369,6 +369,17 @@ fun MainScreen(
                     )
 
                     composable(
+                        "bunkerProxyLogin",
+                        content = {
+                            BunkerProxyLoginScreen(
+                                accountViewModel = accountStateViewModel,
+                                navHostControllerWrapper = navController,
+                                contentPadding = padding,
+                            )
+                        },
+                    )
+
+                    composable(
                         Route.IncomingRequest.route,
                         content = {
                             val scrollState = rememberScrollState()

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/MainScreen.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/MainScreen.kt
@@ -371,6 +371,7 @@ fun MainScreen(
                             BunkerProxyLoginScreen(
                                 accountViewModel = accountStateViewModel,
                                 navHostControllerWrapper = navController,
+                                contentPadding = padding,
                             )
                         },
                     )

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/MainScreen.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/MainScreen.kt
@@ -366,6 +366,16 @@ fun MainScreen(
                     )
 
                     composable(
+                        "bunkerProxyLogin",
+                        content = {
+                            BunkerProxyLoginScreen(
+                                accountViewModel = accountStateViewModel,
+                                navHostControllerWrapper = navController,
+                            )
+                        },
+                    )
+
+                    composable(
                         Route.IncomingRequest.route,
                         content = {
                             val scrollState = rememberScrollState()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -798,4 +798,19 @@
     <string name="event_kind_10044">Encryption key annoucement</string>
     <string name="event_kind_4455">Key transfer</string>
     <string name="event_kind_4454">Client key announcement</string>
+    <string name="copied">Copied</string>
+    <string name="bunker_proxy_login_button">Login as bunker proxy</string>
+    <string name="bunker_proxy_title">Bunker proxy</string>
+    <string name="bunker_proxy_description">Amber will forward every signing request to a remote NIP-46 bunker. No approval prompts will be shown — the remote bunker is the sole authority.</string>
+    <string name="bunker_proxy_offline_unsupported">Bunker proxy login requires network access and is not available in the offline build.</string>
+    <string name="bunker_proxy_tab_paste_uri">Paste bunker URI</string>
+    <string name="bunker_proxy_tab_generate">Generate URI</string>
+    <string name="bunker_proxy_uri_label">bunker:// URI</string>
+    <string name="bunker_proxy_connect">Connect</string>
+    <string name="bunker_proxy_invalid_uri">Invalid bunker URI</string>
+    <string name="bunker_proxy_connect_failed">Failed to connect to bunker</string>
+    <string name="bunker_proxy_no_pubkey">Bunker did not return a public key</string>
+    <string name="bunker_proxy_connecting">Connecting to bunker…</string>
+    <string name="bunker_proxy_generate_explanation">Open this URI in your bunker to authorise Amber to act as a proxy for it. Once you approve on the bunker, return here and tap “Wait for connect”.</string>
+    <string name="bunker_proxy_wait_for_connect">Wait for connect</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -758,4 +758,19 @@
     <string name="signin_restore_skip">Skip</string>
     <string name="event_kind_39701">Public web bookmark</string>
     <string name="event_kind_30618">Repository state announcements</string>
+    <string name="copied">Copied</string>
+    <string name="bunker_proxy_login_button">Login as bunker proxy</string>
+    <string name="bunker_proxy_title">Bunker proxy</string>
+    <string name="bunker_proxy_description">Amber will forward every signing request to a remote NIP-46 bunker. No approval prompts will be shown — the remote bunker is the sole authority.</string>
+    <string name="bunker_proxy_offline_unsupported">Bunker proxy login requires network access and is not available in the offline build.</string>
+    <string name="bunker_proxy_tab_paste_uri">Paste bunker URI</string>
+    <string name="bunker_proxy_tab_generate">Generate URI</string>
+    <string name="bunker_proxy_uri_label">bunker:// URI</string>
+    <string name="bunker_proxy_connect">Connect</string>
+    <string name="bunker_proxy_invalid_uri">Invalid bunker URI</string>
+    <string name="bunker_proxy_connect_failed">Failed to connect to bunker</string>
+    <string name="bunker_proxy_no_pubkey">Bunker did not return a public key</string>
+    <string name="bunker_proxy_connecting">Connecting to bunker…</string>
+    <string name="bunker_proxy_generate_explanation">Open this URI in your bunker to authorise Amber to act as a proxy for it. Once you approve on the bunker, return here and tap “Wait for connect”.</string>
+    <string name="bunker_proxy_wait_for_connect">Wait for connect</string>
 </resources>


### PR DESCRIPTION
## Summary
This PR adds support for Amber to function as a NIP-46 bunker proxy, allowing users to connect to remote bunkers and forward all signing operations to them. This enables Amber to act as a local signer interface while delegating cryptographic operations to a remote bunker service.

## Key Changes

- **New BunkerProxyLoginScreen UI**: Added a new login flow with two tabs:
  - "Paste URI" tab: Users can paste a `bunker://` URI to connect to an existing bunker
  - "Generate" tab: Users can generate a `nostrconnect://` URI to share with a bunker for pairing
  - Includes QR code generation and clipboard copy functionality

- **RemoteBunkerClient service**: New service class that handles all NIP-46 communication with remote bunkers:
  - Implements request/response pattern with timeout handling
  - Supports all major NIP-46 methods: `sign_event`, `sign_message`, `nip44_encrypt`, `nip04_encrypt`, `nip44_decrypt`, `nip04_decrypt`, `decrypt_zap_event`, `get_public_key`, `connect`
  - Handles both NIP-44 and NIP-04 encryption with automatic fallback
  - Includes logging of all proxy requests

- **ProxyResponseSubscription**: New subscription manager for receiving NIP-46 responses from remote bunkers:
  - Subscribes to response events (kind 24133) on configured relays
  - Handles both persistent (account-based) and transient (login-time) subscriptions
  - Decrypts responses and routes them to pending requests
  - Supports initial connection handshake for the generate flow

- **Account proxy support**: Extended Account model to support proxy mode:
  - Added `ProxyAccountMetadata` to store remote bunker pubkey, relays, and connection details
  - Modified signing methods to forward to `RemoteBunkerClient` when in proxy mode
  - Proxy accounts use a local keypair for communication while exposing the remote user's pubkey

- **Intent handling**: Added `handleProxyIntent()` in IntentUtils to short-circuit nostrsigner:// intents:
  - Forwards requests directly to remote bunker without approval UI
  - Bypasses per-app permissions for proxy accounts
  - Delivers results back to caller via setResult or callback URL

- **EventNotificationConsumer integration**: Added `forwardProxyRequest()` to handle inbound NIP-46 requests:
  - Silently forwards most requests to remote bunker
  - Shows UI only for CONNECT/GET_PUBLIC_KEY when multiple accounts exist
  - Relays bunker responses back to requesters

- **UI and navigation**: 
  - Added "Login as bunker proxy" button to login screen
  - Added route and navigation for bunker proxy login screen
  - Added string resources for all new UI elements

- **Persistence**: Extended LocalPreferences to save/load proxy account metadata (remote pubkey, relays, bunker name, secret)

## Notable Implementation Details

- Uses transient login subscriptions during the pairing flow to handle responses before the account is persisted
- Supports both `bunker://` URIs (direct connection) and `nostrconnect://` URIs (user-initiated pairing)
- Implements timeout handling (30 seconds default) for all remote bunker requests
- Gracefully falls back from NIP-44 to NIP-04 encryption if needed
- Maintains separate local and remote pubkeys: local keypair for relay communication, remote pubkey exposed to applications
- Offline flavor builds are prevented from using bunker proxy features

https://claude.ai/code/session_01U28mr2RosEzh1h45VD27Bn