### PR TITLE
Fix nostrconnect listening req

### DIFF
--- a/app/src/main/java/com/greenart7c3/nostrsigner/okhttp/HttpClientManager.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/okhttp/HttpClientManager.kt
@@ -38,6 +38,9 @@ object HttpClientManager {
     val DEFAULT_TIMEOUT_ON_WIFI: Duration = Duration.ofSeconds(10L)
     val DEFAULT_TIMEOUT_ON_MOBILE: Duration = Duration.ofSeconds(30L)
 
+    /** How often OkHttp should send WebSocket pings to detect half-closed connections. */
+    private val PING_INTERVAL: Duration = Duration.ofSeconds(30L)
+
     private var defaultTimeout = DEFAULT_TIMEOUT_ON_WIFI
     private var defaultHttpClient: OkHttpClient? = null
     private var defaultHttpClientWithoutProxy: OkHttpClient? = null
@@ -89,6 +92,17 @@ object HttpClientManager {
             .readTimeout(duration)
             .connectTimeout(duration)
             .writeTimeout(duration)
+            // Send a WebSocket ping every 30s. Without this, OkHttp accepts
+            // writes to half-closed WebSockets (returning `true` from
+            // `send()`) without ever surfacing a failure, because the only
+            // detection is a TCP write timeout on the next queued frame —
+            // which can take ~40-60s and leaves REQ/EVENT messages stranded
+            // in the outbound buffer. The periodic ping turns silent
+            // half-closes into explicit `onFailure` callbacks, so Amber's
+            // reconnect-with-backoff path can rebuild the socket and
+            // `NostrClient.onConnected → syncFilters` can re-issue the
+            // stranded subscriptions.
+            .pingInterval(PING_INTERVAL)
             .addInterceptor(DefaultContentTypeInterceptor(userAgent))
             .addNetworkInterceptor(LoggingInterceptor())
             .addNetworkInterceptor(EncryptedBlobInterceptor(cache))

--- a/app/src/main/java/com/greenart7c3/nostrsigner/service/BunkerRequestUtils.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/service/BunkerRequestUtils.kt
@@ -412,8 +412,22 @@ object BunkerRequestUtils {
                 ),
                 account.npub,
             )
-            if (didChangeRelays) {
-                Amber.instance.checkForNewRelaysAndUpdateAllFilters(true)
+            // A new `nostrconnect://` approval always mints a fresh `localKey`
+            // for the connection (see `generateBunkerPrivKey()` above). The
+            // corresponding listening REQ (kind 24133, #p=localPubKey) must be
+            // registered on the relay *before* we publish the connect response
+            // — otherwise the client's follow-up `get_public_key` RPC can
+            // arrive at the relay while we have no subscriber for it (the
+            // event is ephemeral, so the relay drops it), and the client
+            // times out waiting for a response.
+            //
+            // Previously this only ran when `didChangeRelays`, so CONNECTs
+            // against an already-configured relay left the listening sub to
+            // be picked up by the 30-second `ConnectivityService` timer — a
+            // window in which the pool could idle-disconnect the relay and
+            // lose any RPC published by the client in the meantime.
+            if (type == SignerType.CONNECT || didChangeRelays) {
+                Amber.instance.checkForNewRelaysAndUpdateAllFilters(didChangeRelays)
             }
             if (!Amber.instance.client.isActive()) {
                 Amber.instance.client.connect()

--- a/app/src/main/java/com/greenart7c3/nostrsigner/service/BunkerRequestUtils.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/service/BunkerRequestUtils.kt
@@ -429,9 +429,7 @@ object BunkerRequestUtils {
             if (type == SignerType.CONNECT || didChangeRelays) {
                 Amber.instance.checkForNewRelaysAndUpdateAllFilters(didChangeRelays)
             }
-            if (!Amber.instance.client.isActive()) {
-                Amber.instance.client.connect()
-            }
+            Amber.instance.client.connect()
 
             val signerPrivKey = application.application.localKey
             val bunkerRequestWithKey = if (signerPrivKey.isNotEmpty() && bunkerRequest.signerPrivKey.isEmpty()) {


### PR DESCRIPTION
I have been trying hard to make Amber and Ditto work nicely again.

Ditto is sending RPC requests to Amber. Amber is not responding.

When the issue happens, I can reproduce it consistently. I added logging everywhere: to Ditto, to my relay, and pulled in Amber logcat data.

Based on the logcat data and relay logs, Amber is not sending a REQ to the relay for the pubkey generated through the nostrconnect flow. This is apparently an edge case.

After killing and restarting Amber (without these changes - just the latest release) I wasn't reproducing the issue anymore. So, I don't even know if this fix works.

But it seems legit.