### PR TITLE
Add update channel selection (stable/beta) for app updates

### DIFF
--- a/app/src/main/java/com/greenart7c3/nostrsigner/LocalPreferences.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/LocalPreferences.kt
@@ -11,6 +11,7 @@ import androidx.core.os.LocaleListCompat
 import com.greenart7c3.nostrsigner.models.Account
 import com.greenart7c3.nostrsigner.models.AmberSettings
 import com.greenart7c3.nostrsigner.models.TorMode
+import com.greenart7c3.nostrsigner.models.UpdateChannel
 import com.greenart7c3.nostrsigner.models.UpdateCheckFrequency
 import com.greenart7c3.nostrsigner.models.defaultAppRelays
 import com.greenart7c3.nostrsigner.models.defaultIndexerRelays
@@ -59,6 +60,7 @@ private enum class SettingsKeys(val key: String) {
     AUTH_WHITELIST("auth_whitelist"),
     AUTO_CHECK_UPDATES("auto_check_updates"),
     UPDATE_CHECK_FREQUENCY("update_check_frequency"),
+    UPDATE_CHANNEL("update_channel"),
     LAST_UPDATE_CHECK_TIME("last_update_check_time"),
     START_SERVICE_ON_BOOT("start_service_on_boot"),
     WEBDAV_URL("webdav_url"),
@@ -263,6 +265,13 @@ object LocalPreferences {
                     )
                 } catch (_: IllegalArgumentException) {
                     UpdateCheckFrequency.DAILY
+                },
+                updateChannel = try {
+                    UpdateChannel.valueOf(
+                        getString(SettingsKeys.UPDATE_CHANNEL.key, UpdateChannel.STABLE.name)!!,
+                    )
+                } catch (_: IllegalArgumentException) {
+                    UpdateChannel.STABLE
                 },
                 startServiceOnBoot = getBoolean(SettingsKeys.START_SERVICE_ON_BOOT.key, true),
                 rateLimitEnabled = getBoolean(SettingsKeys.RATE_LIMIT_ENABLED.key, true),
@@ -530,6 +539,15 @@ object LocalPreferences {
         sharedPrefs(context).edit {
             apply {
                 putString(SettingsKeys.UPDATE_CHECK_FREQUENCY.key, frequency.name)
+            }
+        }
+        Amber.instance.settings = loadSettingsFromEncryptedStorage()
+    }
+
+    fun updateUpdateChannel(context: Context, channel: UpdateChannel) {
+        sharedPrefs(context).edit {
+            apply {
+                putString(SettingsKeys.UPDATE_CHANNEL.key, channel.name)
             }
         }
         Amber.instance.settings = loadSettingsFromEncryptedStorage()

--- a/app/src/main/java/com/greenart7c3/nostrsigner/models/AmberSettings.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/models/AmberSettings.kt
@@ -32,6 +32,7 @@ data class AmberSettings(
     val authWhitelist: List<String> = emptyList(),
     val autoCheckUpdates: Boolean = true,
     val updateCheckFrequency: UpdateCheckFrequency = UpdateCheckFrequency.DAILY,
+    val updateChannel: UpdateChannel = UpdateChannel.STABLE,
     val startServiceOnBoot: Boolean = true,
     val rateLimitEnabled: Boolean = true,
     val rateLimitMaxPerWindow: Int = 5,

--- a/app/src/main/java/com/greenart7c3/nostrsigner/models/UpdateChannel.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/models/UpdateChannel.kt
@@ -1,0 +1,8 @@
+package com.greenart7c3.nostrsigner.models
+
+import com.greenart7c3.nostrsigner.R
+
+enum class UpdateChannel(val resourceId: Int) {
+    STABLE(R.string.update_channel_stable),
+    BETA(R.string.update_channel_beta),
+}

--- a/app/src/main/java/com/greenart7c3/nostrsigner/service/ZapstoreUpdater.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/service/ZapstoreUpdater.kt
@@ -8,6 +8,7 @@ import androidx.core.content.FileProvider
 import com.greenart7c3.nostrsigner.Amber
 import com.greenart7c3.nostrsigner.BuildConfig
 import com.greenart7c3.nostrsigner.BuildFlavorChecker
+import com.greenart7c3.nostrsigner.models.UpdateChannel
 import com.greenart7c3.nostrsigner.okhttp.HttpClientManager
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.crypto.verify
@@ -34,7 +35,11 @@ import okhttp3.Request
 
 private const val EOSE_TIMEOUT_MS = 15_000L
 private const val RELEASE_KIND = 30063
-private const val ZAPSTORE_RELAY = "wss://relay.zapstore.dev"
+private val UPDATE_RELAY_URLS = listOf(
+    "wss://relay.zapstore.dev",
+    "wss://relay.damus.io",
+    "wss://nos.lol",
+)
 private const val APP_IDENTIFIER = "com.greenart7c3.nostrsigner"
 
 enum class DownloadState {
@@ -57,7 +62,8 @@ class ZapstoreUpdater(
     private val fileSubId = UUID.randomUUID().toString()
     private val pendingFileEventIds = mutableListOf<String>()
     private val versionByEventId = mutableMapOf<String, Pair<String, Long>>()
-    private val zapstoreRelay: NormalizedRelayUrl? = RelayUrlNormalizer.normalizeOrNull(ZAPSTORE_RELAY)
+    private val updateRelays: List<NormalizedRelayUrl> =
+        UPDATE_RELAY_URLS.mapNotNull { RelayUrlNormalizer.normalizeOrNull(it) }
     private var timeoutJob: Job? = null
 
     init {
@@ -76,7 +82,7 @@ class ZapstoreUpdater(
 
     fun checkForUpdates() {
         if (BuildFlavorChecker.isOfflineFlavor()) return
-        val relay = zapstoreRelay ?: return
+        if (updateRelays.isEmpty()) return
         if (isChecking.value) return
 
         isChecking.value = true
@@ -91,7 +97,7 @@ class ZapstoreUpdater(
             limit = 10,
         )
 
-        client.subscribe(releaseSubId, mapOf(relay to listOf(releaseFilter)))
+        client.subscribe(releaseSubId, updateRelays.associateWith { listOf(releaseFilter) })
 
         timeoutJob = scope.launch {
             delay(EOSE_TIMEOUT_MS)
@@ -113,6 +119,12 @@ class ZapstoreUpdater(
         val appId = tags.firstOrNull { it.size > 1 && it[0] == "i" }?.getOrNull(1) ?: ""
         val isForThisApp = identifier.startsWith(APP_IDENTIFIER) || appId == APP_IDENTIFIER
         if (!isForThisApp) return
+
+        // Channel filter: stable users skip events tagged c=beta. Events with no `c`
+        // tag (legacy releases) are treated as stable and shown on both channels.
+        val channelTag = tags.firstOrNull { it.size > 1 && it[0] == "c" }?.getOrNull(1)
+        val isBeta = channelTag.equals("beta", ignoreCase = true)
+        if (isBeta && Amber.instance.settings.updateChannel == UpdateChannel.STABLE) return
 
         val version = tags.firstOrNull { it.size > 1 && it[0] == "version" }?.getOrNull(1) ?: return
         if (!isNewerVersion(version)) return
@@ -144,14 +156,14 @@ class ZapstoreUpdater(
     }
 
     private fun fetchFileEvents() {
-        val relay = zapstoreRelay ?: run {
+        if (updateRelays.isEmpty()) {
             finishCheck()
             return
         }
         val fileFilter = Filter(
             ids = pendingFileEventIds.toList(),
         )
-        client.subscribe(fileSubId, mapOf(relay to listOf(fileFilter)))
+        client.subscribe(fileSubId, updateRelays.associateWith { listOf(fileFilter) })
     }
 
     private fun processFileEvent(event: Event) {

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/UpdateSettingsScreen.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/UpdateSettingsScreen.kt
@@ -30,6 +30,7 @@ import com.greenart7c3.nostrsigner.Amber
 import com.greenart7c3.nostrsigner.BuildConfig
 import com.greenart7c3.nostrsigner.LocalPreferences
 import com.greenart7c3.nostrsigner.R
+import com.greenart7c3.nostrsigner.models.UpdateChannel
 import com.greenart7c3.nostrsigner.models.UpdateCheckFrequency
 import com.greenart7c3.nostrsigner.service.DownloadState
 import com.greenart7c3.nostrsigner.ui.components.TitleExplainer
@@ -68,6 +69,7 @@ fun UpdateSettingsScreen(modifier: Modifier = Modifier) {
         val dlProgress by updater.downloadProgress.collectAsStateWithLifecycle()
         var autoCheck by remember { mutableStateOf(Amber.instance.settings.autoCheckUpdates) }
         var frequency by remember { mutableStateOf(Amber.instance.settings.updateCheckFrequency) }
+        var channel by remember { mutableStateOf(Amber.instance.settings.updateChannel) }
 
         // Status row
         val statusText = when {
@@ -168,5 +170,30 @@ fun UpdateSettingsScreen(modifier: Modifier = Modifier) {
                 },
             )
         }
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        val channelOptions = UpdateChannel.entries.map {
+            TitleExplainer(stringResource(it.resourceId))
+        }.toImmutableList()
+
+        SettingsRow(
+            name = R.string.update_channel,
+            description = R.string.update_channel_description,
+            selectedItems = channelOptions,
+            selectedIndex = UpdateChannel.entries.indexOf(channel),
+            onSelect = { index ->
+                val selected = UpdateChannel.entries[index]
+                if (selected != channel) {
+                    channel = selected
+                    scope.launch(Dispatchers.IO) {
+                        LocalPreferences.updateUpdateChannel(context, selected)
+                        // Reset last-check timestamp so the next check actually runs
+                        // and surfaces a release on the newly selected channel.
+                        LocalPreferences.setLastUpdateCheckTime(context, 0L)
+                    }
+                }
+            },
+        )
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -628,6 +628,10 @@
     <string name="update_frequency_on_startup">Every app start</string>
     <string name="update_frequency_daily">Daily</string>
     <string name="update_frequency_weekly">Weekly</string>
+    <string name="update_channel">Update channel</string>
+    <string name="update_channel_description">Choose between stable and beta (pre-release) builds</string>
+    <string name="update_channel_stable">Stable</string>
+    <string name="update_channel_beta">Beta (pre-release)</string>
     <string name="current_version">Current version: %1$s</string>
     <string name="updates_not_available">Updates are not available for this build.</string>
     <string name="discover_more">Discover more Nostr apps for android at</string>


### PR DESCRIPTION
## Summary
This PR adds the ability for users to choose between stable and beta (pre-release) update channels. Users can now opt-in to receive beta builds through a new settings option, while stable channel users will only receive production-ready releases.

## Key Changes
- **New UpdateChannel enum**: Created `UpdateChannel.kt` with STABLE and BETA options, each with associated string resources
- **Settings persistence**: Added `updateChannel` field to `AmberSettings` data class and implemented storage/retrieval in `LocalPreferences`
- **UI settings screen**: Added update channel selector to `UpdateSettingsScreen` with radio-button style selection
- **Update filtering logic**: Modified `ZapstoreUpdater` to filter releases based on the selected channel:
  - Stable channel users skip events tagged with `c=beta`
  - Legacy releases (no channel tag) are shown to both channels
  - When channel is changed, the last update check timestamp is reset to force an immediate check
- **Multi-relay support**: Expanded update checks from a single relay to query multiple relays (`relay.zapstore.dev`, `relay.damus.io`, `nos.lol`) for better redundancy and availability
- **String resources**: Added UI strings for the new update channel setting and its description

## Notable Implementation Details
- Channel filtering happens at the event processing level in `ZapstoreUpdater.processReleaseEvent()`
- Changing the update channel automatically resets the last check time to ensure users see releases from the newly selected channel immediately
- The implementation maintains backward compatibility by treating releases without a channel tag as stable releases

https://claude.ai/code/session_01S3725ZQm6APrZd9iXYhNg8