### PR TITLE
Add loading state callbacks to report screens

### DIFF
--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/CrashReportScreen.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/CrashReportScreen.kt
@@ -59,6 +59,7 @@ fun CrashReportScreen(
     modifier: Modifier = Modifier,
     account: Account,
     onDismiss: () -> Unit,
+    onLoading: (Boolean) -> Unit = {},
 ) {
     val initialStack = remember { Amber.instance.pendingCrashReport ?: "" }
     var editedStack by remember { mutableStateOf(initialStack) }
@@ -115,12 +116,15 @@ fun CrashReportScreen(
             Button(
                 modifier = Modifier.weight(1f),
                 onClick = {
+                    if (editedStack.isBlank()) return@Button
+                    onLoading(true)
                     ReportSender.send(
                         account = account,
                         report = editedStack,
                         clipboard = clipboardManager,
                         onDone = {
                             Amber.instance.pendingCrashReport = null
+                            onLoading(false)
                             onDismiss()
                         },
                     )

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/MainScreen.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/MainScreen.kt
@@ -989,6 +989,9 @@ fun MainScreen(
                                         navController.navController.navigateUp()
                                     }
                                 },
+                                onLoading = {
+                                    isLoading = it
+                                },
                             )
                         },
                     )
@@ -1008,6 +1011,9 @@ fun MainScreen(
                                     Amber.instance.applicationIOScope.launch(Dispatchers.Main) {
                                         navController.navController.navigateUp()
                                     }
+                                },
+                                onLoading = {
+                                    isLoading = it
                                 },
                             )
                         },

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/TranslationReportScreen.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/TranslationReportScreen.kt
@@ -72,6 +72,7 @@ fun TranslationReportScreen(
     modifier: Modifier = Modifier,
     account: Account,
     onDismiss: () -> Unit,
+    onLoading: (Boolean) -> Unit = {},
 ) {
     val initialMessage = remember { Amber.instance.pendingTranslationReport.value ?: "" }
     var editedMessage by remember { mutableStateOf(initialMessage) }
@@ -129,6 +130,7 @@ fun TranslationReportScreen(
                 modifier = Modifier.weight(1f),
                 onClick = {
                     val report = editedMessage.ifBlank { return@Button }
+                    onLoading(true)
                     if (BuildFlavorChecker.isOfflineFlavor()) {
                         Amber.instance.applicationIOScope.launch(Dispatchers.Main) {
                             try {
@@ -141,9 +143,11 @@ fun TranslationReportScreen(
                                 intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
                                 Amber.instance.startActivity(intent)
                                 Amber.instance.pendingTranslationReport.value = null
+                                onLoading(false)
                                 onDismiss()
                             } catch (_: Exception) {
                                 Amber.instance.pendingTranslationReport.value = null
+                                onLoading(false)
                                 onDismiss()
                             }
                         }
@@ -171,6 +175,7 @@ fun TranslationReportScreen(
                                 )
                             }
                             Amber.instance.pendingTranslationReport.value = null
+                            onLoading(false)
                             onDismiss()
                             delay(10000)
                             client.disconnect()


### PR DESCRIPTION
## Summary
This PR adds loading state management to the crash report and translation report screens by introducing `onLoading` callbacks that propagate loading states to the parent `MainScreen`.

## Key Changes
- **TranslationReportScreen**: Added `onLoading: (Boolean) -> Unit` parameter to track loading state during report submission. Loading state is set to `true` before submission and `false` after completion (success or error).
- **CrashReportScreen**: Added `onLoading: (Boolean) -> Unit` parameter and implemented loading state callbacks. Also added validation to prevent submission of blank crash reports.
- **MainScreen**: Connected the `onLoading` callbacks from both report screens to update the main screen's `isLoading` state, enabling proper UI feedback during report submission operations.

## Implementation Details
- Both report screens now call `onLoading(true)` before initiating report submission
- Loading state is reset to `false` in completion handlers (both success and error paths)
- The callbacks use default empty implementations to maintain backward compatibility
- CrashReportScreen includes an additional blank validation check before allowing submission

https://claude.ai/code/session_012BsanzwiFyakUVqw9xj8nH