### PR TITLE
Add close button to empty incoming requests screen

### DIFF
--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/IncomingRequestScreen.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/IncomingRequestScreen.kt
@@ -1,6 +1,5 @@
 package com.greenart7c3.nostrsigner.ui
 
-import android.app.Activity
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -16,13 +15,13 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.greenart7c3.nostrsigner.Amber
 import com.greenart7c3.nostrsigner.R
 import com.greenart7c3.nostrsigner.models.Account
 import com.greenart7c3.nostrsigner.models.AmberBunkerRequest
@@ -52,7 +51,6 @@ fun IncomingRequestScreen(
         CenterCircularProgressIndicator(modifier)
     } else {
         if (intents.isEmpty() && bunkerRequests.isEmpty()) {
-            val context = LocalContext.current
             Column(
                 modifier.fillMaxSize(),
                 Arrangement.Center,
@@ -71,7 +69,7 @@ fun IncomingRequestScreen(
                 Spacer(Modifier.size(16.dp))
                 OutlinedButton(
                     onClick = {
-                        (context as? Activity)?.finish()
+                        Amber.instance.getMainActivity()?.finishAndRemoveTask()
                     },
                 ) {
                     Text(stringResource(R.string.invalid_intent_close_app))

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/IncomingRequestScreen.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/IncomingRequestScreen.kt
@@ -1,11 +1,13 @@
 package com.greenart7c3.nostrsigner.ui
 
+import android.app.Activity
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -14,6 +16,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -49,6 +52,7 @@ fun IncomingRequestScreen(
         CenterCircularProgressIndicator(modifier)
     } else {
         if (intents.isEmpty() && bunkerRequests.isEmpty()) {
+            val context = LocalContext.current
             Column(
                 modifier.fillMaxSize(),
                 Arrangement.Center,
@@ -64,6 +68,14 @@ fun IncomingRequestScreen(
                     stringResource(R.string.why_not_explore_your_favorite_nostr_app_a_bit),
                     textAlign = TextAlign.Center,
                 )
+                Spacer(Modifier.size(16.dp))
+                OutlinedButton(
+                    onClick = {
+                        (context as? Activity)?.finish()
+                    },
+                ) {
+                    Text(stringResource(R.string.invalid_intent_close_app))
+                }
             }
         } else if (intents.size == 1) {
             IntentSingleEventHomeScreen(


### PR DESCRIPTION
## Summary
Added a close button to the incoming requests screen when there are no pending intents or bunker requests, allowing users to dismiss the activity.

## Key Changes
- Imported `Activity` from `android.app` and `OutlinedButton` from `androidx.compose.material3`
- Added `LocalContext` import to access the current Android context
- Added a close button (`OutlinedButton`) to the empty state UI that finishes the current activity when clicked
- The button is displayed below the informational text with appropriate spacing (16.dp)

## Implementation Details
- The button uses `LocalContext.current` to get the current context and safely casts it to `Activity` before calling `finish()`
- The button text is sourced from the string resource `R.string.invalid_intent_close_app`
- The button is only shown when both `intents` and `bunkerRequests` are empty, providing a graceful way for users to exit when there are no requests to process

https://claude.ai/code/session_015oDeo3J5LbxZLJMkT8r2NG