### PR TITLE
Add expand/collapse functionality to TagsSection and EventSection

### DIFF
--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/EventSection.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/EventSection.kt
@@ -13,6 +13,10 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -29,7 +33,9 @@ fun EventSection(
     displayValue: String,
     onCopy: () -> Unit,
     padding: Dp = 16.dp,
+    showFullContent: Boolean = false,
 ) {
+    var expanded by remember { mutableStateOf(showFullContent) }
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -45,13 +51,15 @@ fun EventSection(
                 color = MaterialTheme.colorScheme.onSurface,
             )
             Text(
-                modifier = Modifier.padding(top = 12.dp),
+                modifier = Modifier
+                    .padding(top = 12.dp)
+                    .clickable { expanded = !expanded },
                 text = displayValue,
                 style = MaterialTheme.typography.bodyMedium.copy(
                     lineHeight = 24.sp,
                 ),
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
+                maxLines = if (expanded) Int.MAX_VALUE else 1,
+                overflow = if (expanded) TextOverflow.Clip else TextOverflow.Ellipsis,
                 fontWeight = FontWeight.Bold,
             )
         }

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/TagsSection.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/TagsSection.kt
@@ -13,6 +13,10 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -29,9 +33,11 @@ fun TagsSection(
     onCopy: () -> Unit,
     horizontalPadding: Int = 16,
     verticalPadding: Int = 12,
+    showFullContent: Boolean = false,
 ) {
-    val tagsToShow = tags.take(10)
-    val moreCount = tags.size - 10
+    var expanded by remember { mutableStateOf(showFullContent) }
+    val tagsToShow = if (expanded) tags.toList() else tags.take(10)
+    val moreCount = if (expanded) 0 else tags.size - 10
 
     Row(
         modifier = Modifier
@@ -49,7 +55,9 @@ fun TagsSection(
             )
             if (tags.isNotEmpty()) {
                 Column(
-                    modifier = Modifier.padding(top = 12.dp),
+                    modifier = Modifier
+                        .padding(top = 12.dp)
+                        .clickable { expanded = !expanded },
                     verticalArrangement = Arrangement.spacedBy(6.dp),
                 ) {
                     tagsToShow.forEach { tag ->
@@ -61,8 +69,8 @@ fun TagsSection(
                             style = MaterialTheme.typography.bodyMedium.copy(
                                 lineHeight = 24.sp,
                             ),
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
+                            maxLines = if (expanded) Int.MAX_VALUE else 1,
+                            overflow = if (expanded) TextOverflow.Clip else TextOverflow.Ellipsis,
                             fontWeight = FontWeight.Bold,
                         )
                     }


### PR DESCRIPTION
## Summary
Add interactive expand/collapse functionality to `TagsSection` and `EventSection` components, allowing users to toggle between truncated and full content views.

## Key Changes
- **TagsSection.kt**
  - Added `showFullContent` parameter to control initial expansion state
  - Introduced `expanded` state variable using `remember` and `mutableStateOf`
  - Made the tags column clickable to toggle expansion
  - Dynamically adjust `maxLines` and `TextOverflow` based on expansion state
  - Show all tags when expanded, limit to 10 when collapsed

- **EventSection.kt**
  - Added `showFullContent` parameter to control initial expansion state
  - Introduced `expanded` state variable using `remember` and `mutableStateOf`
  - Made the text display clickable to toggle expansion
  - Dynamically adjust `maxLines` and `TextOverflow` based on expansion state
  - Allow full text display when expanded, truncate with ellipsis when collapsed

## Implementation Details
- Both components now use Compose state management (`remember`, `mutableStateOf`, `by` delegation) to track expansion state
- The clickable modifier is applied to the content area, providing clear visual feedback for interactivity
- Text overflow behavior switches between `TextOverflow.Ellipsis` (collapsed) and `TextOverflow.Clip` (expanded)
- The `showFullContent` parameter allows parent composables to control whether content starts in expanded or collapsed state

https://claude.ai/code/session_012o3stPCRDek8YpPhEo8y6z