### PR TITLE
Conditionally hide close button in IncomingRequestScreen for internal requests

### DIFF
--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/IncomingRequestScreen.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/IncomingRequestScreen.kt
@@ -44,6 +44,7 @@ fun IncomingRequestScreen(
     account: Account,
     onRemoveIntentData: (List<IntentData>, IntentResultType) -> Unit,
     onLoading: (Boolean) -> Unit,
+    isExternalRequest: Boolean = false,
 ) {
     var loading by remember { mutableStateOf(false) }
 
@@ -66,13 +67,15 @@ fun IncomingRequestScreen(
                     stringResource(R.string.why_not_explore_your_favorite_nostr_app_a_bit),
                     textAlign = TextAlign.Center,
                 )
-                Spacer(Modifier.size(16.dp))
-                OutlinedButton(
-                    onClick = {
-                        Amber.instance.getMainActivity()?.finishAndRemoveTask()
-                    },
-                ) {
-                    Text(stringResource(R.string.invalid_intent_close_app))
+                if (isExternalRequest) {
+                    Spacer(Modifier.size(16.dp))
+                    OutlinedButton(
+                        onClick = {
+                            Amber.instance.getMainActivity()?.finishAndRemoveTask()
+                        },
+                    ) {
+                        Text(stringResource(R.string.invalid_intent_close_app))
+                    }
                 }
             }
         } else if (intents.size == 1) {

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/MainScreen.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/MainScreen.kt
@@ -399,6 +399,7 @@ fun MainScreen(
                                 onLoading = {
                                     isLoading = it
                                 },
+                                isExternalRequest = isExternalRequest,
                             )
                         },
                     )


### PR DESCRIPTION
## Summary
Add support for distinguishing between external and internal requests in the `IncomingRequestScreen`, allowing the "close app" button to be hidden when the request originates from within the application.

## Changes
- Add `isExternalRequest` parameter to `IncomingRequestScreen` composable (defaults to `false`)
- Conditionally render the "close app" button and spacer only when `isExternalRequest` is `true`
- Pass `isExternalRequest` flag from `MainScreen` to `IncomingRequestScreen`

## Implementation Details
The change allows the UI to adapt based on request origin:
- **External requests** (via `nostrsigner://` Intent or ContentProvider): Show the close button to allow users to exit the signer app
- **Internal requests** (from within the app): Hide the close button since the user is already in the application context

This improves UX by removing unnecessary UI elements for internal request flows while maintaining the exit option for external integrations.

https://claude.ai/code/session_0199q1jcMdwK1Epp31kncE32