### PR TITLE
Add read-through cache for permission queries on hot path

### DIFF
--- a/app/src/androidTest/java/com/greenart7c3/nostrsigner/database/PermissionCacheBenchmarkTest.kt
+++ b/app/src/androidTest/java/com/greenart7c3/nostrsigner/database/PermissionCacheBenchmarkTest.kt
@@ -1,0 +1,175 @@
+package com.greenart7c3.nostrsigner.database
+
+import androidx.room.Room
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import kotlin.system.measureNanoTime
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Real-Room benchmark for [CachingApplicationDao]. Builds an in-memory [AppDatabase],
+ * seeds it with the permission rows a typical app accumulates, then measures the
+ * SIGN_EVENT permission-check query mix (sign policy + kind-specific permission +
+ * NIP fallback) twice:
+ *
+ *  - raw  : direct DAO, every iteration hits SQLite.
+ *  - warm : caching DAO with the cache pre-primed, every iteration is a hit.
+ *
+ * Asserts warm is meaningfully faster than raw (5x floor — actual speedup is far
+ * larger on a real device since each raw call is a full SQLite roundtrip). Also
+ * sanity-checks that warm and raw return the same row for the same query.
+ */
+@RunWith(AndroidJUnit4::class)
+class PermissionCacheBenchmarkTest {
+    private lateinit var db: AppDatabase
+    private lateinit var raw: ApplicationDao
+    private lateinit var cached: CachingApplicationDao
+
+    private val pkKey = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+    private val seededKind = 1
+    private val unseededKind = 31337
+
+    @Before
+    fun setUp() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        db = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        raw = db.dao()
+        cached = CachingApplicationDao(raw)
+
+        runBlocking {
+            raw.insertApplication(
+                ApplicationEntity(
+                    key = pkKey,
+                    name = "Bench App",
+                    relays = emptyList(),
+                    url = "",
+                    icon = "",
+                    description = "",
+                    pubKey = pkKey,
+                    isConnected = true,
+                    secret = "",
+                    useSecret = false,
+                    signPolicy = 1,
+                    closeApplication = false,
+                    deleteAfter = 0L,
+                    lastUsed = 0L,
+                ),
+            )
+            val perms = mutableListOf<ApplicationPermissionsEntity>()
+            for (k in listOf(0, 1, 3, 4, 6, 7, 9735, 10002, 30023)) {
+                perms.add(
+                    ApplicationPermissionsEntity(
+                        id = null,
+                        pkKey = pkKey,
+                        type = "SIGN_EVENT",
+                        kind = k,
+                        acceptable = true,
+                        rememberType = 1,
+                        acceptUntil = 0L,
+                        rejectUntil = 0L,
+                    ),
+                )
+            }
+            for (nip in listOf(4, 44)) {
+                perms.add(
+                    ApplicationPermissionsEntity(
+                        id = null,
+                        pkKey = pkKey,
+                        type = "NIP",
+                        kind = nip,
+                        acceptable = true,
+                        rememberType = 1,
+                        acceptUntil = 0L,
+                        rejectUntil = 0L,
+                    ),
+                )
+            }
+            raw.insertPermissions(perms)
+        }
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    private fun queryMix(dao: ApplicationDao) {
+        // Mirrors SignerProvider.kt SIGN_EVENT path: sign policy + kind-specific
+        // permission + NIP fallback for an unseeded kind.
+        dao.getSignPolicy(pkKey)
+        dao.getPermission(pkKey, "SIGN_EVENT", seededKind)
+        dao.getPermission(pkKey, "SIGN_EVENT", unseededKind)
+        dao.getPermission(pkKey, "NIP", 4)
+    }
+
+    @Test
+    fun benchmark_signEvent_query_mix() {
+        // Correctness: cached must return the same data as raw.
+        assertEquals(raw.getSignPolicy(pkKey), cached.getSignPolicy(pkKey))
+        assertEquals(
+            raw.getPermission(pkKey, "SIGN_EVENT", seededKind)?.id,
+            cached.getPermission(pkKey, "SIGN_EVENT", seededKind)?.id,
+        )
+        assertEquals(
+            raw.getPermission(pkKey, "SIGN_EVENT", unseededKind),
+            cached.getPermission(pkKey, "SIGN_EVENT", unseededKind),
+        )
+
+        val warmupIters = 1_000
+        val measureIters = 10_000
+
+        // Warmup so JIT and SQLite statement caches are primed for both paths.
+        repeat(warmupIters) {
+            queryMix(raw)
+            queryMix(cached)
+        }
+
+        val rawNanos = measureNanoTime {
+            repeat(measureIters) { queryMix(raw) }
+        }
+
+        val warmNanos = measureNanoTime {
+            repeat(measureIters) { queryMix(cached) }
+        }
+
+        val rawMs = rawNanos / 1_000_000.0
+        val warmMs = warmNanos / 1_000_000.0
+        val speedup = rawNanos.toDouble() / warmNanos.toDouble()
+
+        println(
+            "[PermissionCacheBenchmark] iters=$measureIters  raw=${"%.2f".format(rawMs)}ms  " +
+                "warm=${"%.2f".format(warmMs)}ms  speedup=${"%.1f".format(speedup)}x",
+        )
+
+        assertTrue(
+            "Warm cache should be at least 5x faster than raw DAO; " +
+                "got raw=${rawMs}ms warm=${warmMs}ms (${"%.1f".format(speedup)}x)",
+            speedup >= 5.0,
+        )
+    }
+
+    @Test
+    fun benchmark_invalidation_correctness() {
+        // After a write that touches this app, the next read must NOT return a
+        // stale cached value. This is the regression we'd care about more than
+        // raw speed — caching is worthless if it returns wrong answers.
+        cached.getPermission(pkKey, "SIGN_EVENT", seededKind) // prime
+
+        runBlocking {
+            cached.deletePermissions(pkKey, "SIGN_EVENT", seededKind)
+        }
+
+        assertEquals(
+            null,
+            cached.getPermission(pkKey, "SIGN_EVENT", seededKind),
+        )
+    }
+}

--- a/app/src/androidTest/res/values/strings.xml
+++ b/app/src/androidTest/res/values/strings.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!--
+        The debug buildType emits `resValue("string", "app_name", "@string/app_name_debug")`
+        into the androidTest APK as well as the main APK. The test APK does not include
+        the main app's res/, so the reference fails to link unless we supply the target
+        strings here. These values never surface to users — they only exist to satisfy
+        the test APK's resource linker.
+    -->
+    <string name="app_name_debug" translatable="false">Amber Debug</string>
+    <string name="app_name_release" translatable="false">Amber</string>
+</resources>

--- a/app/src/main/java/com/greenart7c3/nostrsigner/Amber.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/Amber.kt
@@ -32,6 +32,8 @@ import coil3.request.ImageRequest
 import coil3.request.SuccessResult
 import coil3.request.crossfade
 import com.greenart7c3.nostrsigner.database.AppDatabase
+import com.greenart7c3.nostrsigner.database.ApplicationDao
+import com.greenart7c3.nostrsigner.database.CachingApplicationDao
 import com.greenart7c3.nostrsigner.database.HistoryDatabase
 import com.greenart7c3.nostrsigner.database.LogDatabase
 import com.greenart7c3.nostrsigner.models.Account
@@ -147,6 +149,7 @@ class Amber :
     var databases = ConcurrentHashMap<String, AppDatabase>()
     private var logDatabases = ConcurrentHashMap<String, LogDatabase>()
     private var historyDatabases = ConcurrentHashMap<String, HistoryDatabase>()
+    private val cachingDaos = ConcurrentHashMap<String, CachingApplicationDao>()
 
     // Hoisted out of runMigrations() so re-entry (e.g. test re-init) can't
     // double-register and double-fire foreground/background callbacks.
@@ -421,6 +424,18 @@ class Amber :
         return databases[npub]!!
     }
 
+    /**
+     * Returns the per-account permission DAO with read-through caching. All hot-path
+     * permission lookups should go through this; writes routed through it also
+     * invalidate the cache.
+     */
+    fun dao(npub: String): ApplicationDao {
+        cachingDaos[npub]?.let { return it }
+        return cachingDaos.computeIfAbsent(npub) {
+            CachingApplicationDao(getDatabase(npub).dao())
+        }
+    }
+
     fun getLogDatabase(npub: String): LogDatabase {
         if (!logDatabases.containsKey(npub)) {
             logDatabases[npub] = LogDatabase.getDatabase(applicationContext, npub)
@@ -444,6 +459,7 @@ class Amber :
         databases.remove(npub)?.runCatching { close() }
         logDatabases.remove(npub)?.runCatching { close() }
         historyDatabases.remove(npub)?.runCatching { close() }
+        cachingDaos.remove(npub)
         ApplicationNameCache.clearForAccount(npub)
     }
 

--- a/app/src/main/java/com/greenart7c3/nostrsigner/SignerProvider.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/SignerProvider.kt
@@ -83,16 +83,15 @@ class SignerProvider : ContentProvider() {
                         Log.d(Amber.TAG, "No account from storage")
                         return null
                     }
-                    val database = Amber.instance.getDatabase(account.npub)
                     val historyDatabase = Amber.instance.getHistoryDatabase(account.npub)
+                    val permDao = Amber.instance.dao(account.npub)
                     val permission =
-                        database
-                            .dao()
+                        permDao
                             .getPermission(
                                 packageName,
                                 "SIGN_MESSAGE",
                             )
-                    val signPolicy = database.dao().getSignPolicy(packageName)
+                    val signPolicy = permDao.getSignPolicy(packageName)
                     val isRemembered = IntentUtils.isRemembered(signPolicy, permission) ?: return null
                     if (!isRemembered) {
                         scope.launch {
@@ -166,8 +165,8 @@ class SignerProvider : ContentProvider() {
                         return null
                     }
 
-                    val database = Amber.instance.getDatabase(account.npub)
                     val historyDatabase = Amber.instance.getHistoryDatabase(account.npub)
+                    val permDao = Amber.instance.dao(account.npub)
 
                     // For kind 22242 (NIP-42 relay auth), extract relay host once for both whitelist and permission checks
                     val relayHost = if (event.kind == 22242) {
@@ -207,11 +206,10 @@ class SignerProvider : ContentProvider() {
 
                     var permission = if (event.kind == 22242) {
                         // Kind 22242 = relay client auth (NIP-42): check relay-specific permission first
-                        database.dao().getPermissionForRelay(packageName, "SIGN_EVENT", 22242, relayHost)
-                            ?: database.dao().getWildcardRelayPermission(packageName, "SIGN_EVENT", 22242)
+                        permDao.getPermissionForRelay(packageName, "SIGN_EVENT", 22242, relayHost)
+                            ?: permDao.getWildcardRelayPermission(packageName, "SIGN_EVENT", 22242)
                     } else {
-                        database
-                            .dao()
+                        permDao
                             .getPermission(
                                 packageName,
                                 "SIGN_EVENT",
@@ -224,8 +222,7 @@ class SignerProvider : ContentProvider() {
                             permission = if (nipNumber == null) {
                                 null
                             } else {
-                                database
-                                    .dao()
+                                permDao
                                     .getPermission(
                                         packageName,
                                         "NIP",
@@ -234,7 +231,7 @@ class SignerProvider : ContentProvider() {
                             }
                         }
                     }
-                    val signPolicy = database.dao().getSignPolicy(packageName)
+                    val signPolicy = permDao.getSignPolicy(packageName)
                     val isRemembered = whitelistAutoAccept || IntentUtils.isRemembered(signPolicy, permission) ?: return null
                     if (!isRemembered) {
                         scope.launch {
@@ -309,9 +306,9 @@ class SignerProvider : ContentProvider() {
                     val stringType = uriString.replace("content://$appId.", "")
                     val pubkey = projection[1]
                     val account = LocalPreferences.loadFromEncryptedStorageSync(context!!, npub) ?: return null
-                    val database = Amber.instance.getDatabase(account.npub)
                     val logDatabase = Amber.instance.getLogDatabase(account.npub)
                     val historyDatabase = Amber.instance.getHistoryDatabase(account.npub)
+                    val permDao = Amber.instance.dao(account.npub)
                     val type =
                         when (stringType) {
                             "NIP04_DECRYPT" -> SignerType.NIP04_DECRYPT
@@ -358,9 +355,9 @@ class SignerProvider : ContentProvider() {
                     val classifyContent = if (isEncrypt) content else (result ?: content)
                     val permType = permissionTypeFromContent(classifyContent, isEncrypt, type)
 
-                    var permission = database.dao().getPermission(packageName, permType)
+                    var permission = permDao.getPermission(packageName, permType)
                     if (permission == null) {
-                        permission = database.dao().getPermission(
+                        permission = permDao.getPermission(
                             packageName,
                             type.toString(),
                         )
@@ -376,8 +373,7 @@ class SignerProvider : ContentProvider() {
                         }
                         nip?.let {
                             permission =
-                                database
-                                    .dao()
+                                permDao
                                     .getPermission(
                                         packageName,
                                         "NIP",
@@ -385,7 +381,7 @@ class SignerProvider : ContentProvider() {
                                     )
                         }
                     }
-                    val signPolicy = database.dao().getSignPolicy(packageName)
+                    val signPolicy = permDao.getSignPolicy(packageName)
                     val isRemembered = IntentUtils.isRemembered(signPolicy, permission) ?: return null
                     if (!isRemembered) {
                         scope.launch {
@@ -477,16 +473,15 @@ class SignerProvider : ContentProvider() {
                         Log.d(Amber.TAG, "No account from storage")
                         return null
                     }
-                    val database = Amber.instance.getDatabase(account.npub)
                     val historyDatabase = Amber.instance.getHistoryDatabase(account.npub)
+                    val permDao = Amber.instance.dao(account.npub)
                     val permission =
-                        database
-                            .dao()
+                        permDao
                             .getPermission(
                                 packageName,
                                 "SIGN_PSBT",
                             )
-                    val signPolicy = database.dao().getSignPolicy(packageName)
+                    val signPolicy = permDao.getSignPolicy(packageName)
                     val isRemembered = IntentUtils.isRemembered(signPolicy, permission) ?: return null
                     if (!isRemembered) {
                         scope.launch {
@@ -573,17 +568,16 @@ class SignerProvider : ContentProvider() {
                     if (account == null) {
                         return null
                     }
-                    val database = Amber.instance.getDatabase(account.npub)
                     val historyDatabase = Amber.instance.getHistoryDatabase(account.npub)
+                    val permDao = Amber.instance.dao(account.npub)
                     val permission =
-                        database
-                            .dao()
+                        permDao
                             .getPermission(
                                 packageName,
                                 "PING",
                             )
 
-                    val signPolicy = database.dao().getSignPolicy(packageName)
+                    val signPolicy = permDao.getSignPolicy(packageName)
                     val isRemembered = IntentUtils.isRemembered(signPolicy, permission) ?: return null
                     if (!isRemembered) {
                         scope.launch {

--- a/app/src/main/java/com/greenart7c3/nostrsigner/database/CachingApplicationDao.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/database/CachingApplicationDao.kt
@@ -1,0 +1,223 @@
+package com.greenart7c3.nostrsigner.database
+
+import androidx.collection.LruCache
+import androidx.paging.PagingSource
+
+/**
+ * Bounded read-through cache in front of [ApplicationDao] for the five queries
+ * on the signing hot path. SignerProvider runs its lookups inside a runBlocking
+ * on the calling app's binder thread, so each redundant SQLite roundtrip costs
+ * IPC latency. Most apps issue many requests against the same permission rows,
+ * so a small LRU per account eliminates almost all of those roundtrips.
+ *
+ * Negative results are cached too — "no permission row" is the common branch
+ * and dominates the miss path otherwise.
+ *
+ * Writes invalidate every cache entry whose key shares the affected pkKey
+ * (coarse-grained per-app). Every mutation in [ApplicationDao] is scoped to a
+ * single app key, so this matches the natural granularity without forcing
+ * callers to know which exact (type, kind, relay) tuple they touched.
+ */
+class CachingApplicationDao(
+    private val delegate: ApplicationDao,
+) : ApplicationDao {
+    private enum class Method { SIGN_POLICY, PERM, PERM_KIND, PERM_RELAY, PERM_WILDCARD }
+
+    private data class Key(
+        val method: Method,
+        val pkKey: String,
+        val type: String?,
+        val kind: Int?,
+        val relay: String?,
+    )
+
+    private data class Value(
+        val signPolicy: Int?,
+        val permission: ApplicationPermissionsEntity?,
+    )
+
+    private val cache = LruCache<Key, Value>(MAX_ENTRIES)
+
+    private fun lookup(key: Key): Value? = synchronized(cache) { cache.get(key) }
+
+    private fun store(key: Key, value: Value) {
+        synchronized(cache) { cache.put(key, value) }
+    }
+
+    private fun invalidateApp(pkKey: String) {
+        synchronized(cache) {
+            val toRemove = cache.snapshot().keys.filter { it.pkKey == pkKey }
+            toRemove.forEach { cache.remove(it) }
+        }
+    }
+
+    private fun invalidateAll() {
+        synchronized(cache) { cache.evictAll() }
+    }
+
+    // -------- cached reads --------
+
+    override fun getSignPolicy(key: String): Int? {
+        val k = Key(Method.SIGN_POLICY, key, null, null, null)
+        lookup(k)?.let { return it.signPolicy }
+        val result = delegate.getSignPolicy(key)
+        store(k, Value(result, null))
+        return result
+    }
+
+    override fun getPermission(key: String, type: String, kind: Int?): ApplicationPermissionsEntity? {
+        val k = Key(Method.PERM_KIND, key, type, kind, null)
+        lookup(k)?.let { return it.permission }
+        val result = delegate.getPermission(key, type, kind)
+        store(k, Value(null, result))
+        return result
+    }
+
+    override fun getPermission(key: String, type: String): ApplicationPermissionsEntity? {
+        val k = Key(Method.PERM, key, type, null, null)
+        lookup(k)?.let { return it.permission }
+        val result = delegate.getPermission(key, type)
+        store(k, Value(null, result))
+        return result
+    }
+
+    override fun getPermissionForRelay(key: String, type: String, kind: Int, relay: String): ApplicationPermissionsEntity? {
+        val k = Key(Method.PERM_RELAY, key, type, kind, relay)
+        lookup(k)?.let { return it.permission }
+        val result = delegate.getPermissionForRelay(key, type, kind, relay)
+        store(k, Value(null, result))
+        return result
+    }
+
+    override fun getWildcardRelayPermission(key: String, type: String, kind: Int): ApplicationPermissionsEntity? {
+        val k = Key(Method.PERM_WILDCARD, key, type, kind, null)
+        lookup(k)?.let { return it.permission }
+        val result = delegate.getWildcardRelayPermission(key, type, kind)
+        store(k, Value(null, result))
+        return result
+    }
+
+    // -------- writes that must invalidate --------
+
+    override suspend fun insertPermissions(permissions: List<ApplicationPermissionsEntity>): List<Long>? {
+        val result = delegate.insertPermissions(permissions)
+        permissions.asSequence().map { it.pkKey }.distinct().forEach(::invalidateApp)
+        return result
+    }
+
+    override suspend fun insertPermissions2(permissions: List<ApplicationPermissionsEntity>): List<Long>? {
+        val result = delegate.insertPermissions2(permissions)
+        permissions.asSequence().map { it.pkKey }.distinct().forEach(::invalidateApp)
+        return result
+    }
+
+    override suspend fun insertApplicationWithPermissions(application: ApplicationWithPermissions) {
+        delegate.insertApplicationWithPermissions(application)
+        invalidateApp(application.application.key)
+    }
+
+    override suspend fun deletePermissions(key: String) {
+        delegate.deletePermissions(key)
+        invalidateApp(key)
+    }
+
+    override suspend fun deletePermissions(key: String, type: String) {
+        delegate.deletePermissions(key, type)
+        invalidateApp(key)
+    }
+
+    override suspend fun deletePermissions(key: String, type: String, kind: Int) {
+        delegate.deletePermissions(key, type, kind)
+        invalidateApp(key)
+    }
+
+    override suspend fun deletePermissions(key: String, type: String, kind: Int, relay: String) {
+        delegate.deletePermissions(key, type, kind, relay)
+        invalidateApp(key)
+    }
+
+    override suspend fun deletePermissionsForKind(key: String, type: String, kind: Int) {
+        delegate.deletePermissionsForKind(key, type, kind)
+        invalidateApp(key)
+    }
+
+    override suspend fun deletePermission(permission: ApplicationPermissionsEntity) {
+        delegate.deletePermission(permission)
+        invalidateApp(permission.pkKey)
+    }
+
+    override suspend fun delete(entity: ApplicationEntity) {
+        delegate.delete(entity)
+        invalidateApp(entity.key)
+    }
+
+    override suspend fun delete(key: String) {
+        delegate.delete(key)
+        invalidateApp(key)
+    }
+
+    // Affects many apps at once (timestamp predicate), so wipe the whole cache.
+    override fun updateExpiredPermissions(time: Long) {
+        delegate.updateExpiredPermissions(time)
+        invalidateAll()
+    }
+
+    override suspend fun deleteOldApplications(time: Long): Int {
+        val n = delegate.deleteOldApplications(time)
+        if (n > 0) invalidateAll()
+        return n
+    }
+
+    // -------- pass-through (not cached, not invalidating) --------
+
+    override suspend fun getAll(pubKey: String): List<ApplicationEntity> = delegate.getAll(pubKey)
+
+    override suspend fun getAllNotConnected(): List<ApplicationWithPermissions> = delegate.getAllNotConnected()
+
+    override fun getAllPaging(pubKey: String): PagingSource<Int, ApplicationEntity> = delegate.getAllPaging(pubKey)
+
+    override fun getAllRelayLists(): List<RelayListWrapper> = delegate.getAllRelayLists()
+
+    override suspend fun getAppName(key: String): String? = delegate.getAppName(key)
+
+    override suspend fun getByKey(key: String): ApplicationWithPermissions? = delegate.getByKey(key)
+
+    override fun getByKeySync(key: String): ApplicationWithPermissions? = delegate.getByKeySync(key)
+
+    override suspend fun getByName(name: String): ApplicationWithPermissions? = delegate.getByName(name)
+
+    override suspend fun getBySecret(secret: String): ApplicationWithPermissions? = delegate.getBySecret(secret)
+
+    override suspend fun getAllWithLocalKey(pubKey: String): List<ApplicationEntity> = delegate.getAllWithLocalKey(pubKey)
+
+    override suspend fun getAllByKey(key: String): List<ApplicationPermissionsEntity> = delegate.getAllByKey(key)
+
+    override fun getApplicationKeyNames(): List<ApplicationKeyName> = delegate.getApplicationKeyNames()
+
+    override fun getAllRejectedPermissions(): List<ApplicationPermissionsEntity> = delegate.getAllRejectedPermissions()
+
+    override fun getAllAcceptedPermissions(): List<ApplicationPermissionsEntity> = delegate.getAllAcceptedPermissions()
+
+    override suspend fun insertApplication(event: ApplicationEntity): Long? {
+        val result = delegate.insertApplication(event)
+        // ApplicationEntity columns like signPolicy and lastUsed feed cached reads
+        // (getSignPolicy), so invalidate the affected app's entries.
+        invalidateApp(event.key)
+        return result
+    }
+
+    override fun insertAll(events: List<ApplicationEntity>): List<Long>? {
+        val result = delegate.insertAll(events)
+        events.forEach { invalidateApp(it.key) }
+        return result
+    }
+
+    override suspend fun updateLastUsed(key: String, time: Long) {
+        delegate.updateLastUsed(key, time)
+        // lastUsed doesn't affect any cached read, so no invalidation needed.
+    }
+
+    companion object {
+        private const val MAX_ENTRIES = 512
+    }
+}

--- a/app/src/main/java/com/greenart7c3/nostrsigner/service/BunkerRequestUtils.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/service/BunkerRequestUtils.kt
@@ -270,18 +270,18 @@ object BunkerRequestUtils {
     ) {
         onLoading(true)
         Amber.instance.applicationIOScope.launch {
-            val database = Amber.instance.getDatabase(account.npub)
+            val dao = Amber.instance.dao(account.npub)
             val historyDatabase = Amber.instance.getHistoryDatabase(account.npub)
             val defaultRelays = Amber.instance.settings.defaultRelays
 
             if (oldKey.isNotBlank()) {
-                database.dao().delete(oldKey)
+                dao.delete(oldKey)
                 historyDatabase.dao().deleteHistory(oldKey)
             }
 
-            var savedApplication = database.dao().getByKey(key)
+            var savedApplication = dao.getByKey(key)
             if (savedApplication == null && bunkerRequest.request is BunkerRequestConnect && bunkerRequest.request.secret?.isNotBlank() == true) {
-                savedApplication = database.dao().getByKey(bunkerRequest.request.secret!!)
+                savedApplication = dao.getByKey(bunkerRequest.request.secret!!)
                 if (savedApplication != null) {
                     val tempApplication = savedApplication.application.copy(
                         key = key,
@@ -293,11 +293,11 @@ object BunkerRequestUtils {
                         }.toMutableList(),
                     )
 
-                    database.dao().delete(bunkerRequest.request.secret!!)
-                    database.dao().insertApplicationWithPermissions(tempApp2)
+                    dao.delete(bunkerRequest.request.secret!!)
+                    dao.insertApplicationWithPermissions(tempApp2)
                 }
             }
-            savedApplication = database.dao().getByKey(key)
+            savedApplication = dao.getByKey(key)
             if (bunkerRequest.request is BunkerRequestConnect) {
                 savedApplication?.application?.deleteAfter = deleteAfter
             }
@@ -362,7 +362,7 @@ object BunkerRequestUtils {
 
             var didChangeRelays = false
             if (type == SignerType.CONNECT) {
-                database.dao().deletePermissions(key)
+                dao.deletePermissions(key)
                 application.application.isConnected = true
                 shouldCloseApplication?.let {
                     application.application.closeApplication = it
@@ -392,7 +392,7 @@ object BunkerRequestUtils {
 
             // assume that everything worked and try to revert it if it fails
             EventNotificationConsumer(context).notificationManager().cancelAll()
-            database.dao().insertApplicationWithPermissions(application)
+            dao.insertApplicationWithPermissions(application)
             historyDatabase.dao().addHistory(
                 listOf(
                     HistoryEntity(
@@ -452,13 +452,13 @@ object BunkerRequestUtils {
                             if (rememberType != RememberType.NEVER) {
                                 if (type == SignerType.SIGN_EVENT) {
                                     kind?.let {
-                                        database.dao().deletePermissions(key, type.toString(), kind)
+                                        dao.deletePermissions(key, type.toString(), kind)
                                     }
                                 } else {
                                     if (type == SignerType.CONNECT) {
-                                        database.dao().delete(application.application)
+                                        dao.delete(application.application)
                                         if (!bunkerRequest.isNostrConnectUri) {
-                                            database.dao().insertApplicationWithPermissions(
+                                            dao.insertApplicationWithPermissions(
                                                 application.copy(
                                                     application = application.application.copy(
                                                         isConnected = false,
@@ -468,7 +468,7 @@ object BunkerRequestUtils {
                                             )
                                         }
                                     } else {
-                                        database.dao().deletePermissions(key, type.toString())
+                                        dao.deletePermissions(key, type.toString())
                                     }
                                 }
                             }
@@ -495,7 +495,7 @@ object BunkerRequestUtils {
     ) {
         onLoading(true)
         Amber.instance.applicationIOScope.launch(Dispatchers.IO) {
-            val savedApplication = Amber.instance.getDatabase(account.npub).dao().getByKey(key)
+            val savedApplication = Amber.instance.dao(account.npub).getByKey(key)
             val defaultRelays = Amber.instance.settings.defaultRelays
             val relays = savedApplication?.application?.relays?.ifEmpty { defaultRelays } ?: bunkerRequest.relays.ifEmpty { defaultRelays }
 
@@ -554,7 +554,7 @@ object BunkerRequestUtils {
             }
 
             if (bunkerRequest.request !is BunkerRequestConnect) {
-                Amber.instance.getDatabase(account.npub).dao().insertApplicationWithPermissions(application)
+                Amber.instance.dao(account.npub).insertApplicationWithPermissions(application)
                 Amber.instance.getHistoryDatabase(account.npub).dao().addHistory(
                     listOf(
                         HistoryEntity(

--- a/app/src/main/java/com/greenart7c3/nostrsigner/service/ClearLogsWorker.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/service/ClearLogsWorker.kt
@@ -47,9 +47,9 @@ class ClearLogsWorker(appContext: Context, workerParams: WorkerParameters) : Cor
                     Log.d(Amber.TAG, "Trimmed $excessLogs excess log entries (cap: $MAX_LOG_ENTRIES)")
                 }
 
-                val database = Amber.instance.getDatabase(it.npub)
-                database.dao().updateExpiredPermissions(TimeUtils.now())
-                val deleted = database.dao().deleteOldApplications(now / 1000)
+                val dao = Amber.instance.dao(it.npub)
+                dao.updateExpiredPermissions(TimeUtils.now())
+                val deleted = dao.deleteOldApplications(now / 1000)
                 if (deleted > 0) {
                     logDao.insertLog(
                         LogEntity(

--- a/app/src/main/java/com/greenart7c3/nostrsigner/service/EventNotificationConsumer.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/service/EventNotificationConsumer.kt
@@ -210,8 +210,7 @@ class EventNotificationConsumer(private val applicationContext: Context) {
         connectionPrivKey: String = "",
     ) {
         val responseRelay = listOf(relay)
-        val database = Amber.instance.getDatabase(acc.npub)
-        val dao = database.dao()
+        val dao = Amber.instance.dao(acc.npub)
         val historyDao = Amber.instance.getHistoryDatabase(acc.npub).dao()
 
         val notification = Amber.instance.notificationCache[event.id]

--- a/app/src/main/java/com/greenart7c3/nostrsigner/service/IntentUtils.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/service/IntentUtils.kt
@@ -758,8 +758,8 @@ object IntentUtils {
         onLoading(true)
         Amber.instance.applicationIOScope.launch {
             try {
-                val database = Amber.instance.getDatabase(account.npub)
-                val savedApplication = database.dao().getByKey(key)
+                val dao = Amber.instance.dao(account.npub)
+                val savedApplication = dao.getByKey(key)
 
                 val application =
                     savedApplication ?: run {
@@ -836,7 +836,7 @@ object IntentUtils {
                 }
 
                 if (packageName != null) {
-                    database.dao().insertApplicationWithPermissions(application)
+                    dao.insertApplicationWithPermissions(application)
                     val historyDatabase = Amber.instance.getHistoryDatabase(account.npub)
                     Amber.instance.applicationIOScope.launch {
                         historyDatabase.dao().addHistory(
@@ -989,7 +989,7 @@ object IntentUtils {
                 )
             }
 
-            Amber.instance.getDatabase(account.npub).dao().insertApplicationWithPermissions(application)
+            Amber.instance.dao(account.npub).insertApplicationWithPermissions(application)
             Amber.instance.getHistoryDatabase(account.npub).dao().addHistory(
                 listOf(
                     HistoryEntity(

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/EditConfigurationScreen.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/EditConfigurationScreen.kt
@@ -320,8 +320,8 @@ fun EditConfigurationScreen(
                                     relays = relays,
                                     closeApplication = closeApp,
                                 )
-                            Amber.instance.getDatabase(account.npub).dao().delete(it.application)
-                            Amber.instance.getDatabase(account.npub).dao().insertApplicationWithPermissions(
+                            Amber.instance.dao(account.npub).delete(it.application)
+                            Amber.instance.dao(account.npub).insertApplicationWithPermissions(
                                 ApplicationWithPermissions(
                                     localApplicationData,
                                     it.permissions,
@@ -387,7 +387,7 @@ fun EditConfigurationScreen(
                 onClick = {
                     application?.let {
                         scope.launch(Dispatchers.IO) {
-                            Amber.instance.getDatabase(account.npub).dao().delete(it.application)
+                            Amber.instance.dao(account.npub).delete(it.application)
                             Amber.instance.getHistoryDatabase(account.npub).dao().deleteHistory(it.application.key)
 
                             scope.launch(Dispatchers.Main) {

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/EditPermission.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/EditPermission.kt
@@ -90,7 +90,7 @@ fun EditPermission(
 
     LaunchedEffect(selectedPackage) {
         val result = withContext(Dispatchers.IO) {
-            val dao = Amber.instance.getDatabase(account.npub).dao()
+            val dao = Amber.instance.dao(account.npub)
             dao.updateExpiredPermissions(TimeUtils.now())
             val perms = dao.getAllByKey(selectedPackage)
                 .sortedBy { "${it.type}-${it.kind}" }
@@ -122,8 +122,7 @@ fun EditPermission(
             },
         ) {
             scope.launch(Dispatchers.IO) {
-                Amber.instance.getDatabase(account.npub)
-                    .dao()
+                Amber.instance.dao(account.npub)
                     .deletePermissions(applicationData.key)
 
                 withContext(Dispatchers.Main) {
@@ -205,8 +204,7 @@ fun EditPermission(
 
                     scope.launch(Dispatchers.IO) {
                         Amber.instance
-                            .getDatabase(account.npub)
-                            .dao()
+                            .dao(account.npub)
                             .insertPermissions(listOf(updated))
                     }
                 },
@@ -215,8 +213,7 @@ fun EditPermission(
 
                     scope.launch(Dispatchers.IO) {
                         Amber.instance
-                            .getDatabase(account.npub)
-                            .dao()
+                            .dao(account.npub)
                             .deletePermission(deleted)
                     }
                 },

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/NewNsecBunkerScreen.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/NewNsecBunkerScreen.kt
@@ -283,7 +283,7 @@ fun NewNsecBunkerScreen(
                                 localKey = connPrivKey,
                             )
 
-                        Amber.instance.getDatabase(account.npub).dao().insertApplication(
+                        Amber.instance.dao(account.npub).insertApplication(
                             application,
                         )
                         scope.launch(Dispatchers.Main) {
@@ -310,7 +310,7 @@ fun NewNsecBunkerCreatedScreen(
     LaunchedEffect(Unit) {
         isLoading.value = true
         launch(Dispatchers.IO) {
-            application = Amber.instance.getDatabase(account.npub).dao().getByKey(key)?.application ?: ApplicationEntity.empty()
+            application = Amber.instance.dao(account.npub).getByKey(key)?.application ?: ApplicationEntity.empty()
             isLoading.value = false
         }
     }

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/actions/LogoutButton.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/actions/LogoutButton.kt
@@ -38,10 +38,10 @@ fun LogoutButton(
                 scope.launch(Dispatchers.IO) {
                     val account = LocalPreferences.loadFromEncryptedStorage(context, acc.npub)
                     account?.let {
-                        val database = Amber.instance.getDatabase(it.npub)
-                        val permissions = database.dao().getAll(it.hexKey)
+                        val dao = Amber.instance.dao(it.npub)
+                        val permissions = dao.getAll(it.hexKey)
                         permissions.forEach { app ->
-                            database.dao().delete(app)
+                            dao.delete(app)
                         }
                     }
 

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/BunkerMultiEventHomeScreen.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/BunkerMultiEventHomeScreen.kt
@@ -225,15 +225,14 @@ fun BunkerMultiEventHomeScreen(
                                 } ?: continue
 
                             val localKey = request.localKey
-                            val database = Amber.instance.getDatabase(thisAccount.npub)
+                            val dao = Amber.instance.dao(thisAccount.npub)
                             val secret = if (request.request is BunkerRequestConnect) {
                                 request.request.secret ?: ""
                             } else {
                                 ""
                             }
                             val application =
-                                database
-                                    .dao()
+                                dao
                                     .getByKey(localKey) ?: ApplicationWithPermissions(
                                     application = ApplicationEntity(
                                         localKey,
@@ -315,9 +314,9 @@ fun BunkerMultiEventHomeScreen(
                                     } ?: continue
 
                                 val localKey = request.localKey
-                                val database = Amber.instance.getDatabase(thisAccount.npub)
+                                val dao = Amber.instance.dao(thisAccount.npub)
                                 val historyDatabase = Amber.instance.getHistoryDatabase(thisAccount.npub)
-                                val savedApplication = database.dao().getByKey(localKey)
+                                val savedApplication = dao.getByKey(localKey)
 
                                 val secret = if (request.request is BunkerRequestConnect) {
                                     request.request.secret ?: ""
@@ -374,7 +373,7 @@ fun BunkerMultiEventHomeScreen(
                                         )
                                     }
 
-                                    database.dao().insertApplicationWithPermissions(application)
+                                    dao.insertApplicationWithPermissions(application)
 
                                     historyDatabase.dao().addHistory(
                                         listOf(
@@ -427,7 +426,7 @@ fun BunkerMultiEventHomeScreen(
                                         )
                                     }
 
-                                    database.dao().insertApplicationWithPermissions(application)
+                                    dao.insertApplicationWithPermissions(application)
                                     historyDatabase.dao().addHistory(
                                         listOf(
                                             HistoryEntity(
@@ -468,7 +467,7 @@ fun BunkerMultiEventHomeScreen(
                                     }
                                 } else if (request.request is BunkerRequestConnect) {
                                     if (savedApplication == null) {
-                                        database.dao().insertApplicationWithPermissions(application)
+                                        dao.insertApplicationWithPermissions(application)
 
                                         historyDatabase.dao().addHistory(
                                             listOf(
@@ -522,7 +521,7 @@ fun BunkerMultiEventHomeScreen(
                                         )
                                     }
 
-                                    database.dao().insertApplicationWithPermissions(application)
+                                    dao.insertApplicationWithPermissions(application)
 
                                     historyDatabase.dao().addHistory(
                                         listOf(

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/IntentMultiEventHomeScreen.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/IntentMultiEventHomeScreen.kt
@@ -198,8 +198,8 @@ fun IntentMultiEventHomeScreen(
                                 LocalPreferences.loadFromEncryptedStorage(context, accountNpub)
                             } ?: continue
 
-                            val database = Amber.instance.getDatabase(thisAccount.npub)
-                            val application = database.dao().getByKey(localKey) ?: ApplicationWithPermissions(
+                            val dao = Amber.instance.dao(thisAccount.npub)
+                            val application = dao.getByKey(localKey) ?: ApplicationWithPermissions(
                                 application = ApplicationEntity(
                                     localKey,
                                     "",
@@ -252,7 +252,7 @@ fun IntentMultiEventHomeScreen(
                             }
 
                             if (permissionsChanged || application.application.key.isBlank()) {
-                                database.dao().insertApplicationWithPermissions(application)
+                                dao.insertApplicationWithPermissions(application)
                             }
                         }
 
@@ -293,9 +293,9 @@ fun IntentMultiEventHomeScreen(
                                     LocalPreferences.loadFromEncryptedStorage(context, accountNpub)
                                 } ?: continue
 
-                                val database = Amber.instance.getDatabase(thisAccount.npub)
+                                val dao = Amber.instance.dao(thisAccount.npub)
                                 val historyDatabase = Amber.instance.getHistoryDatabase(thisAccount.npub)
-                                val application = database.dao().getByKey(localKey) ?: ApplicationWithPermissions(
+                                val application = dao.getByKey(localKey) ?: ApplicationWithPermissions(
                                     application = ApplicationEntity(
                                         localKey,
                                         "",
@@ -468,7 +468,7 @@ fun IntentMultiEventHomeScreen(
                                 }
 
                                 if (permissionsChanged || application.application.key.isBlank()) {
-                                    database.dao().insertApplicationWithPermissions(application)
+                                    dao.insertApplicationWithPermissions(application)
                                 }
                                 historyDatabase.dao().addHistory(historyList, thisAccount.npub)
                             }


### PR DESCRIPTION
## Summary

Introduces `CachingApplicationDao`, a bounded LRU cache wrapper around `ApplicationDao` that eliminates redundant SQLite roundtrips for permission lookups on the signing hot path. Since `SignerProvider` runs permission checks inside `runBlocking` on the calling app's binder thread, each database query incurs IPC latency. Most apps issue many requests against the same permission rows, so a small per-account cache dramatically reduces latency.

## Key Changes

- **New `CachingApplicationDao` class** — LRU cache (512 entries) wrapping the five hot-path queries:
  - `getSignPolicy(key)`
  - `getPermission(key, type)` and `getPermission(key, type, kind)`
  - `getPermissionForRelay(key, type, kind, relay)`
  - `getWildcardRelayPermission(key, type, kind)`
  - Caches both positive and negative results (null = "no permission row")
  - Coarse-grained per-app invalidation: any write touching an app key invalidates all cache entries for that app
  - Global invalidation for bulk operations (`updateExpiredPermissions`, `deleteOldApplications`)

- **New `Amber.dao(npub)` method** — Returns the per-account caching DAO; all hot-path permission lookups now route through this instead of `getDatabase().dao()`

- **Updated all call sites** — `SignerProvider`, `BunkerRequestUtils`, `IntentUtils`, UI screens, and workers now use `Amber.instance.dao(npub)` for permission queries

- **Benchmark test** (`PermissionCacheBenchmarkTest`) — Validates that warm cache is ≥5x faster than raw DAO and that invalidation correctness is maintained

- **Test resources** — Added `androidTest/res/values/strings.xml` to satisfy test APK resource linking

## Implementation Details

- Thread-safe via `synchronized(cache)` blocks around all cache operations
- Cache key includes method enum, app key, and query parameters (type, kind, relay) to distinguish different queries
- Invalidation strategy matches natural granularity: writes are scoped to a single app key in `ApplicationDao`, so per-app invalidation avoids false positives
- Pass-through for non-cached reads (paging, bulk queries, app lookups) — no caching overhead for those paths
- `updateLastUsed()` skips invalidation since it doesn't affect any cached read

https://claude.ai/code/session_01Q9jujfLrDCChwyJwb1Gpii