### PR TITLE
Add encrypted applications backup and restore functionality

### DIFF
--- a/app/src/main/java/com/greenart7c3/nostrsigner/Amber.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/Amber.kt
@@ -312,6 +312,7 @@ class Amber :
 
     fun startBackupApplicationsAlarm() {
         if (BuildFlavorChecker.isOfflineFlavor()) return
+        if (!settings.backupApplications) return
 
         val workManager = WorkManager.getInstance(this)
 

--- a/app/src/main/java/com/greenart7c3/nostrsigner/Amber.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/Amber.kt
@@ -46,6 +46,7 @@ import com.greenart7c3.nostrsigner.okhttp.OkHttpWebSocket
 import com.greenart7c3.nostrsigner.relays.AmberRelayStats
 import com.greenart7c3.nostrsigner.relays.NostrClientLoggerListener
 import com.greenart7c3.nostrsigner.service.ApplicationNameCache
+import com.greenart7c3.nostrsigner.service.BackupApplicationsWorker
 import com.greenart7c3.nostrsigner.service.ClearLogsWorker
 import com.greenart7c3.nostrsigner.service.ConnectivityService
 import com.greenart7c3.nostrsigner.service.NotificationSubscription
@@ -307,6 +308,31 @@ class Amber :
             ExistingPeriodicWorkPolicy.KEEP,
             periodicRequest,
         )
+    }
+
+    fun startBackupApplicationsAlarm() {
+        if (BuildFlavorChecker.isOfflineFlavor()) return
+
+        val workManager = WorkManager.getInstance(this)
+
+        val periodicRequest = PeriodicWorkRequestBuilder<BackupApplicationsWorker>(1, TimeUnit.DAYS)
+            .addTag("backupApplicationsWork")
+            .setConstraints(
+                Constraints.Builder()
+                    .setRequiredNetworkType(NetworkType.CONNECTED)
+                    .build(),
+            )
+            .build()
+
+        workManager.enqueueUniquePeriodicWork(
+            "BackupApplicationsWorker",
+            ExistingPeriodicWorkPolicy.KEEP,
+            periodicRequest,
+        )
+    }
+
+    fun cancelBackupApplicationsAlarm() {
+        WorkManager.getInstance(this).cancelUniqueWork("BackupApplicationsWorker")
     }
 
     override fun onCreate() {

--- a/app/src/main/java/com/greenart7c3/nostrsigner/LocalPreferences.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/LocalPreferences.kt
@@ -71,6 +71,7 @@ private enum class SettingsKeys(val key: String) {
     RATE_LIMIT_ENABLED("rate_limit_enabled"),
     RATE_LIMIT_MAX_PER_WINDOW("rate_limit_max_per_window"),
     RATE_LIMIT_WINDOW_SECONDS("rate_limit_window_seconds"),
+    BACKUP_APPLICATIONS("backup_applications"),
 }
 
 @Immutable
@@ -149,6 +150,7 @@ object LocalPreferences {
                 putBoolean(SettingsKeys.RATE_LIMIT_ENABLED.key, settings.rateLimitEnabled)
                 putInt(SettingsKeys.RATE_LIMIT_MAX_PER_WINDOW.key, settings.rateLimitMaxPerWindow)
                 putInt(SettingsKeys.RATE_LIMIT_WINDOW_SECONDS.key, settings.rateLimitWindowSeconds)
+                putBoolean(SettingsKeys.BACKUP_APPLICATIONS.key, settings.backupApplications)
             }
         }
     }
@@ -277,6 +279,7 @@ object LocalPreferences {
                 rateLimitEnabled = getBoolean(SettingsKeys.RATE_LIMIT_ENABLED.key, true),
                 rateLimitMaxPerWindow = getInt(SettingsKeys.RATE_LIMIT_MAX_PER_WINDOW.key, 5),
                 rateLimitWindowSeconds = getInt(SettingsKeys.RATE_LIMIT_WINDOW_SECONDS.key, 30),
+                backupApplications = getBoolean(SettingsKeys.BACKUP_APPLICATIONS.key, true),
             )
         }
     }
@@ -534,6 +537,15 @@ object LocalPreferences {
         sharedPrefs(context).edit {
             apply {
                 putBoolean(SettingsKeys.START_SERVICE_ON_BOOT.key, enabled)
+            }
+        }
+        Amber.instance.settings = loadSettingsFromEncryptedStorage()
+    }
+
+    fun updateBackupApplications(context: Context, enabled: Boolean) {
+        sharedPrefs(context).edit {
+            apply {
+                putBoolean(SettingsKeys.BACKUP_APPLICATIONS.key, enabled)
             }
         }
         Amber.instance.settings = loadSettingsFromEncryptedStorage()

--- a/app/src/main/java/com/greenart7c3/nostrsigner/LocalPreferences.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/LocalPreferences.kt
@@ -279,7 +279,7 @@ object LocalPreferences {
                 rateLimitEnabled = getBoolean(SettingsKeys.RATE_LIMIT_ENABLED.key, true),
                 rateLimitMaxPerWindow = getInt(SettingsKeys.RATE_LIMIT_MAX_PER_WINDOW.key, 5),
                 rateLimitWindowSeconds = getInt(SettingsKeys.RATE_LIMIT_WINDOW_SECONDS.key, 30),
-                backupApplications = getBoolean(SettingsKeys.BACKUP_APPLICATIONS.key, true),
+                backupApplications = getBoolean(SettingsKeys.BACKUP_APPLICATIONS.key, false),
             )
         }
     }

--- a/app/src/main/java/com/greenart7c3/nostrsigner/models/AmberSettings.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/models/AmberSettings.kt
@@ -37,6 +37,7 @@ data class AmberSettings(
     val rateLimitEnabled: Boolean = true,
     val rateLimitMaxPerWindow: Int = 5,
     val rateLimitWindowSeconds: Int = 30,
+    val backupApplications: Boolean = true,
 ) {
     val useProxy: Boolean get() = torMode != TorMode.DISABLED
 }

--- a/app/src/main/java/com/greenart7c3/nostrsigner/models/AmberSettings.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/models/AmberSettings.kt
@@ -37,7 +37,7 @@ data class AmberSettings(
     val rateLimitEnabled: Boolean = true,
     val rateLimitMaxPerWindow: Int = 5,
     val rateLimitWindowSeconds: Int = 30,
-    val backupApplications: Boolean = true,
+    val backupApplications: Boolean = false,
 ) {
     val useProxy: Boolean get() = torMode != TorMode.DISABLED
 }

--- a/app/src/main/java/com/greenart7c3/nostrsigner/service/ApplicationBackup.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/service/ApplicationBackup.kt
@@ -34,6 +34,10 @@ private const val BACKUP_FETCH_TIMEOUT_MS = 15_000L
 private const val PAYLOAD_VERSION = 1
 
 private val AGGREGATOR_RELAY = RelayUrlNormalizer.normalizeOrNull("wss://aggr.nostr.land/")
+private val INBOX_FALLBACK_RELAYS = listOfNotNull(
+    RelayUrlNormalizer.normalizeOrNull("wss://nos.lol/"),
+    RelayUrlNormalizer.normalizeOrNull("wss://relay.damus.io/"),
+)
 
 data class BackupPermission(
     @param:JsonProperty("type") val type: String,
@@ -123,14 +127,20 @@ object ApplicationBackup {
 
     /**
      * Returns inbox relays (NIP-65 read-marker) ∪ default profile relays ∪ aggregator.
-     * Falls back to just profile relays + aggregator if the inbox fetch fails.
+     * When no inbox relays are advertised, falls back to nos.lol + relay.damus.io
+     * so the backup still reaches popular public relays.
      */
     suspend fun resolveBackupRelays(account: Account): Set<NormalizedRelayUrl> {
         val settings = Amber.instance.settings
         val out = mutableSetOf<NormalizedRelayUrl>()
         out.addAll(settings.defaultProfileRelays)
         AGGREGATOR_RELAY?.let { out.add(it) }
-        out.addAll(fetchInboxRelays(account))
+        val inbox = fetchInboxRelays(account)
+        if (inbox.isEmpty()) {
+            out.addAll(INBOX_FALLBACK_RELAYS)
+        } else {
+            out.addAll(inbox)
+        }
         return out
     }
 

--- a/app/src/main/java/com/greenart7c3/nostrsigner/service/ApplicationBackup.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/service/ApplicationBackup.kt
@@ -318,6 +318,10 @@ object ApplicationBackup {
             apps++
             permissions += perms.size
         }
+        Amber.instance.profileSubscription.closeSub()
+        Amber.instance.notificationSubscription.closeAllSubs()
+        Amber.instance.disconnectIntentionally()
+        Amber.instance.checkForNewRelaysAndUpdateAllFilters(shouldReconnect = true)
         RestoreResult.Success(apps, permissions)
     } catch (e: Exception) {
         if (e is CancellationException) throw e

--- a/app/src/main/java/com/greenart7c3/nostrsigner/service/ApplicationBackup.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/service/ApplicationBackup.kt
@@ -1,0 +1,334 @@
+package com.greenart7c3.nostrsigner.service
+
+import android.util.Log
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import com.greenart7c3.nostrsigner.Amber
+import com.greenart7c3.nostrsigner.BuildFlavorChecker
+import com.greenart7c3.nostrsigner.database.ApplicationEntity
+import com.greenart7c3.nostrsigner.database.ApplicationPermissionsEntity
+import com.greenart7c3.nostrsigner.database.ApplicationWithPermissions
+import com.greenart7c3.nostrsigner.models.Account
+import com.vitorpamplona.quartz.nip01Core.core.Event
+import com.vitorpamplona.quartz.nip01Core.crypto.verify
+import com.vitorpamplona.quartz.nip01Core.relay.client.accessories.publishAndConfirm
+import com.vitorpamplona.quartz.nip01Core.relay.client.listeners.RelayConnectionListener
+import com.vitorpamplona.quartz.nip01Core.relay.client.single.IRelayClient
+import com.vitorpamplona.quartz.nip01Core.relay.commands.toClient.EventMessage
+import com.vitorpamplona.quartz.nip01Core.relay.commands.toClient.Message
+import com.vitorpamplona.quartz.nip01Core.relay.filters.Filter
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.RelayUrlNormalizer
+import com.vitorpamplona.quartz.utils.TimeUtils
+import java.util.UUID
+import kotlin.coroutines.cancellation.CancellationException
+import kotlinx.coroutines.delay
+
+private const val BACKUP_KIND = 30078
+private const val BACKUP_D_TAG = "amber-app-backup"
+private const val INBOX_KIND = 10002
+private const val INBOX_FETCH_TIMEOUT_MS = 10_000L
+private const val BACKUP_FETCH_TIMEOUT_MS = 15_000L
+private const val PAYLOAD_VERSION = 1
+
+private val AGGREGATOR_RELAY = RelayUrlNormalizer.normalizeOrNull("wss://aggr.nostr.land/")
+
+data class BackupPermission(
+    @param:JsonProperty("type") val type: String,
+    @param:JsonProperty("kind") val kind: Int?,
+    @param:JsonProperty("acceptable") val acceptable: Boolean,
+    @param:JsonProperty("rememberType") val rememberType: Int,
+    @param:JsonProperty("acceptUntil") val acceptUntil: Long,
+    @param:JsonProperty("rejectUntil") val rejectUntil: Long,
+    @param:JsonProperty("relay") val relay: String = "",
+)
+
+data class BackupApplication(
+    @param:JsonProperty("key") val key: String,
+    @param:JsonProperty("name") val name: String,
+    @param:JsonProperty("relays") val relays: List<String>,
+    @param:JsonProperty("url") val url: String,
+    @param:JsonProperty("icon") val icon: String,
+    @param:JsonProperty("description") val description: String,
+    @param:JsonProperty("pubKey") val pubKey: String,
+    @param:JsonProperty("isConnected") val isConnected: Boolean,
+    @param:JsonProperty("secret") val secret: String,
+    @param:JsonProperty("useSecret") val useSecret: Boolean,
+    @param:JsonProperty("signPolicy") val signPolicy: Int,
+    @param:JsonProperty("closeApplication") val closeApplication: Boolean,
+    @param:JsonProperty("deleteAfter") val deleteAfter: Long,
+    @param:JsonProperty("lastUsed") val lastUsed: Long,
+    @param:JsonProperty("localKey") val localKey: String = "",
+    @param:JsonProperty("permissions") val permissions: List<BackupPermission>,
+)
+
+data class BackupPayload(
+    @param:JsonProperty("v") val version: Int = PAYLOAD_VERSION,
+    @param:JsonProperty("ts") val timestamp: Long = TimeUtils.now(),
+    @param:JsonProperty("applications") val applications: List<BackupApplication>,
+)
+
+sealed interface RestoreResult {
+    data class Success(val apps: Int, val permissions: Int) : RestoreResult
+    data object NoBackupFound : RestoreResult
+    data class Failed(val message: String) : RestoreResult
+}
+
+object ApplicationBackup {
+    private val mapper = jacksonObjectMapper()
+        .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+
+    suspend fun buildPayload(npub: String, account: Account): BackupPayload {
+        val dao = Amber.instance.dao(npub)
+        val apps = dao.getAll(account.hexKey)
+        val backupApps = apps.map { app ->
+            val perms = dao.getAllByKey(app.key)
+            BackupApplication(
+                key = app.key,
+                name = app.name,
+                relays = app.relays.map { it.url },
+                url = app.url,
+                icon = app.icon,
+                description = app.description,
+                pubKey = app.pubKey,
+                isConnected = app.isConnected,
+                secret = app.secret,
+                useSecret = app.useSecret,
+                signPolicy = app.signPolicy,
+                closeApplication = app.closeApplication,
+                deleteAfter = app.deleteAfter,
+                lastUsed = app.lastUsed,
+                localKey = app.localKey,
+                permissions = perms.map { p ->
+                    BackupPermission(
+                        type = p.type,
+                        kind = p.kind,
+                        acceptable = p.acceptable,
+                        rememberType = p.rememberType,
+                        acceptUntil = p.acceptUntil,
+                        rejectUntil = p.rejectUntil,
+                        relay = p.relay,
+                    )
+                },
+            )
+        }
+        return BackupPayload(applications = backupApps)
+    }
+
+    fun toJson(payload: BackupPayload): String = mapper.writeValueAsString(payload)
+
+    fun fromJson(json: String): BackupPayload = mapper.readValue(json)
+
+    /**
+     * Returns inbox relays (NIP-65 read-marker) ∪ default profile relays ∪ aggregator.
+     * Falls back to just profile relays + aggregator if the inbox fetch fails.
+     */
+    suspend fun resolveBackupRelays(account: Account): Set<NormalizedRelayUrl> {
+        val settings = Amber.instance.settings
+        val out = mutableSetOf<NormalizedRelayUrl>()
+        out.addAll(settings.defaultProfileRelays)
+        AGGREGATOR_RELAY?.let { out.add(it) }
+        out.addAll(fetchInboxRelays(account))
+        return out
+    }
+
+    private suspend fun fetchInboxRelays(account: Account): Set<NormalizedRelayUrl> {
+        val client = Amber.instance.client
+        val profileRelays = Amber.instance.settings.defaultProfileRelays
+        if (profileRelays.isEmpty()) return emptySet()
+
+        val subId = UUID.randomUUID().toString()
+        val latest = mutableMapOf<Long, Event>()
+
+        val listener = object : RelayConnectionListener {
+            override fun onIncomingMessage(relay: IRelayClient, msgStr: String, msg: Message) {
+                if (msg is EventMessage && msg.subId == subId && msg.event.kind == INBOX_KIND && msg.event.pubKey == account.hexKey) {
+                    if (msg.event.verify()) {
+                        latest[msg.event.createdAt] = msg.event
+                    }
+                }
+                super.onIncomingMessage(relay, msgStr, msg)
+            }
+        }
+
+        client.addConnectionListener(listener)
+        try {
+            val filter = Filter(
+                kinds = listOf(INBOX_KIND),
+                authors = listOf(account.hexKey),
+                limit = 1,
+            )
+            client.subscribe(subId, profileRelays.associateWith { listOf(filter) })
+            delay(INBOX_FETCH_TIMEOUT_MS)
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
+            Log.w(Amber.TAG, "ApplicationBackup: inbox relay fetch failed", e)
+        } finally {
+            runCatching { client.unsubscribe(subId) }
+            client.removeConnectionListener(listener)
+        }
+
+        val newest = latest.maxByOrNull { it.key }?.value ?: return emptySet()
+        return newest.tags
+            .asSequence()
+            .filter { it.size >= 2 && it[0] == "r" }
+            .mapNotNull { tag ->
+                val url = tag[1]
+                val marker = tag.getOrNull(2)?.lowercase()
+                if (marker == null || marker == "read") {
+                    RelayUrlNormalizer.normalizeOrNull(url)
+                } else {
+                    null
+                }
+            }
+            .toSet()
+    }
+
+    suspend fun publishBackup(npub: String, account: Account): Boolean {
+        if (BuildFlavorChecker.isOfflineFlavor()) return false
+        try {
+            val payload = buildPayload(npub, account)
+            if (payload.applications.isEmpty()) {
+                Log.d(Amber.TAG, "ApplicationBackup: no applications to backup for $npub, skipping")
+                return true
+            }
+            val json = toJson(payload)
+            val encrypted = account.nip44Encrypt(json, account.hexKey)
+            val event = account.signSync<Event>(
+                TimeUtils.now(),
+                BACKUP_KIND,
+                arrayOf(
+                    arrayOf("d", BACKUP_D_TAG),
+                    arrayOf("client", "amber"),
+                ),
+                encrypted,
+            )
+            val relays = resolveBackupRelays(account)
+            if (relays.isEmpty()) {
+                Log.w(Amber.TAG, "ApplicationBackup: no relays resolved for backup")
+                return false
+            }
+            val ok = Amber.instance.client.publishAndConfirm(event, relays)
+            Log.d(Amber.TAG, "ApplicationBackup: publish for $npub result=$ok relays=${relays.size}")
+            return ok
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
+            Log.e(Amber.TAG, "ApplicationBackup: failed to publish backup for $npub", e)
+            return false
+        }
+    }
+
+    suspend fun fetchLatestBackupEvent(account: Account, relays: Set<NormalizedRelayUrl>): Event? {
+        if (BuildFlavorChecker.isOfflineFlavor()) return null
+        if (relays.isEmpty()) return null
+
+        val client = Amber.instance.client
+        val subId = UUID.randomUUID().toString()
+        val received = mutableMapOf<Long, Event>()
+
+        val listener = object : RelayConnectionListener {
+            override fun onIncomingMessage(relay: IRelayClient, msgStr: String, msg: Message) {
+                if (msg is EventMessage &&
+                    msg.subId == subId &&
+                    msg.event.kind == BACKUP_KIND &&
+                    msg.event.pubKey == account.hexKey
+                ) {
+                    val identifier = msg.event.tags.firstOrNull { it.size >= 2 && it[0] == "d" }?.getOrNull(1)
+                    if (identifier == BACKUP_D_TAG && msg.event.verify()) {
+                        received[msg.event.createdAt] = msg.event
+                    }
+                }
+                super.onIncomingMessage(relay, msgStr, msg)
+            }
+        }
+
+        client.addConnectionListener(listener)
+        try {
+            val filter = Filter(
+                kinds = listOf(BACKUP_KIND),
+                authors = listOf(account.hexKey),
+                tags = mapOf("d" to listOf(BACKUP_D_TAG)),
+                limit = 1,
+            )
+            client.subscribe(subId, relays.associateWith { listOf(filter) })
+            delay(BACKUP_FETCH_TIMEOUT_MS)
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
+            Log.e(Amber.TAG, "ApplicationBackup: failed to fetch backup event", e)
+        } finally {
+            runCatching { client.unsubscribe(subId) }
+            client.removeConnectionListener(listener)
+        }
+
+        return received.maxByOrNull { it.key }?.value
+    }
+
+    suspend fun decryptPayload(event: Event, account: Account): BackupPayload? = try {
+        val json = account.nip44Decrypt(event.content, account.hexKey)
+        fromJson(json)
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        Log.e(Amber.TAG, "ApplicationBackup: failed to decrypt/parse backup payload", e)
+        null
+    }
+
+    suspend fun restoreFromPayload(npub: String, payload: BackupPayload): RestoreResult = try {
+        val dao = Amber.instance.dao(npub)
+        var apps = 0
+        var permissions = 0
+        payload.applications.forEach { backupApp ->
+            val entity = ApplicationEntity(
+                key = backupApp.key,
+                name = backupApp.name,
+                relays = backupApp.relays.mapNotNull { RelayUrlNormalizer.normalizeOrNull(it) },
+                url = backupApp.url,
+                icon = backupApp.icon,
+                description = backupApp.description,
+                pubKey = backupApp.pubKey,
+                isConnected = backupApp.isConnected,
+                secret = backupApp.secret,
+                useSecret = backupApp.useSecret,
+                signPolicy = backupApp.signPolicy,
+                closeApplication = backupApp.closeApplication,
+                deleteAfter = backupApp.deleteAfter,
+                lastUsed = backupApp.lastUsed,
+                localKey = backupApp.localKey,
+            )
+            val perms = backupApp.permissions.map { p ->
+                ApplicationPermissionsEntity(
+                    id = null,
+                    pkKey = backupApp.key,
+                    type = p.type,
+                    kind = p.kind,
+                    acceptable = p.acceptable,
+                    rememberType = p.rememberType,
+                    acceptUntil = p.acceptUntil,
+                    rejectUntil = p.rejectUntil,
+                    relay = p.relay,
+                )
+            }
+            dao.insertApplicationWithPermissions(
+                ApplicationWithPermissions(
+                    application = entity,
+                    permissions = perms.toMutableList(),
+                ),
+            )
+            apps++
+            permissions += perms.size
+        }
+        RestoreResult.Success(apps, permissions)
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        Log.e(Amber.TAG, "ApplicationBackup: failed to restore payload for $npub", e)
+        RestoreResult.Failed(e.message ?: "Unknown error")
+    }
+
+    suspend fun restoreFromRelays(npub: String, account: Account): RestoreResult {
+        val relays = resolveBackupRelays(account)
+        val event = fetchLatestBackupEvent(account, relays) ?: return RestoreResult.NoBackupFound
+        val payload = decryptPayload(event, account) ?: return RestoreResult.Failed("Failed to decrypt backup")
+        return restoreFromPayload(npub, payload)
+    }
+}

--- a/app/src/main/java/com/greenart7c3/nostrsigner/service/ApplicationBackup.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/service/ApplicationBackup.kt
@@ -126,28 +126,39 @@ object ApplicationBackup {
     fun fromJson(json: String): BackupPayload = mapper.readValue(json)
 
     /**
-     * Returns inbox relays (NIP-65 read-marker) ∪ default profile relays ∪ aggregator.
-     * When no inbox relays are advertised, falls back to nos.lol + relay.damus.io
-     * so the backup still reaches popular public relays.
+     * Relays to query when fetching an existing backup:
+     * inbox (NIP-65 read-marker) ∪ aggregator ∪ INBOX_FALLBACK_RELAYS.
      */
-    suspend fun resolveBackupRelays(account: Account): Set<NormalizedRelayUrl> {
-        val settings = Amber.instance.settings
+    suspend fun resolveReadRelays(account: Account): Set<NormalizedRelayUrl> {
         val out = mutableSetOf<NormalizedRelayUrl>()
-        out.addAll(settings.defaultProfileRelays)
         AGGREGATOR_RELAY?.let { out.add(it) }
+        out.addAll(INBOX_FALLBACK_RELAYS)
+        out.addAll(fetchInboxRelays(account))
+        return out
+    }
+
+    /**
+     * Relays to publish to: only the user's inbox relays. When the user has not
+     * advertised an inbox list yet, fall back to aggregator + INBOX_FALLBACK_RELAYS
+     * so the backup still lands somewhere a fresh device can find.
+     */
+    suspend fun resolveWriteRelays(account: Account): Set<NormalizedRelayUrl> {
         val inbox = fetchInboxRelays(account)
-        if (inbox.isEmpty()) {
-            out.addAll(INBOX_FALLBACK_RELAYS)
-        } else {
-            out.addAll(inbox)
-        }
+        if (inbox.isNotEmpty()) return inbox
+        val out = mutableSetOf<NormalizedRelayUrl>()
+        AGGREGATOR_RELAY?.let { out.add(it) }
+        out.addAll(INBOX_FALLBACK_RELAYS)
         return out
     }
 
     private suspend fun fetchInboxRelays(account: Account): Set<NormalizedRelayUrl> {
         val client = Amber.instance.client
-        val profileRelays = Amber.instance.settings.defaultProfileRelays
-        if (profileRelays.isEmpty()) return emptySet()
+        val discoveryRelays = mutableSetOf<NormalizedRelayUrl>().apply {
+            addAll(Amber.instance.settings.defaultProfileRelays)
+            AGGREGATOR_RELAY?.let { add(it) }
+            addAll(INBOX_FALLBACK_RELAYS)
+        }
+        if (discoveryRelays.isEmpty()) return emptySet()
 
         val subId = UUID.randomUUID().toString()
         val latest = mutableMapOf<Long, Event>()
@@ -170,7 +181,7 @@ object ApplicationBackup {
                 authors = listOf(account.hexKey),
                 limit = 1,
             )
-            client.subscribe(subId, profileRelays.associateWith { listOf(filter) })
+            client.subscribe(subId, discoveryRelays.associateWith { listOf(filter) })
             delay(INBOX_FETCH_TIMEOUT_MS)
         } catch (e: Exception) {
             if (e is CancellationException) throw e
@@ -215,7 +226,7 @@ object ApplicationBackup {
                 ),
                 encrypted,
             )
-            val relays = resolveBackupRelays(account)
+            val relays = resolveWriteRelays(account)
             if (relays.isEmpty()) {
                 Log.w(Amber.TAG, "ApplicationBackup: no relays resolved for backup")
                 return false
@@ -340,7 +351,7 @@ object ApplicationBackup {
     }
 
     suspend fun restoreFromRelays(npub: String, account: Account): RestoreResult {
-        val relays = resolveBackupRelays(account)
+        val relays = resolveReadRelays(account)
         val event = fetchLatestBackupEvent(account, relays) ?: return RestoreResult.NoBackupFound
         val payload = decryptPayload(event, account) ?: return RestoreResult.Failed("Failed to decrypt backup")
         return restoreFromPayload(npub, payload)

--- a/app/src/main/java/com/greenart7c3/nostrsigner/service/BackupApplicationsWorker.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/service/BackupApplicationsWorker.kt
@@ -1,0 +1,32 @@
+package com.greenart7c3.nostrsigner.service
+
+import android.content.Context
+import android.util.Log
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import com.greenart7c3.nostrsigner.Amber
+import com.greenart7c3.nostrsigner.BuildFlavorChecker
+import com.greenart7c3.nostrsigner.LocalPreferences
+import kotlin.coroutines.cancellation.CancellationException
+
+class BackupApplicationsWorker(appContext: Context, workerParams: WorkerParameters) : CoroutineWorker(appContext, workerParams) {
+
+    override suspend fun doWork(): Result {
+        if (BuildFlavorChecker.isOfflineFlavor()) return Result.success()
+
+        val amber = Amber.instance
+        if (!amber.settings.backupApplications) return Result.success()
+
+        LocalPreferences.allSavedAccounts(applicationContext).forEach { info ->
+            try {
+                val account = LocalPreferences.loadFromEncryptedStorage(applicationContext, info.npub) ?: return@forEach
+                ApplicationBackup.publishBackup(info.npub, account)
+            } catch (e: Exception) {
+                if (e is CancellationException) throw e
+                Log.e(Amber.TAG, "BackupApplicationsWorker: failed for ${info.npub}", e)
+            }
+        }
+
+        return Result.success()
+    }
+}

--- a/app/src/main/java/com/greenart7c3/nostrsigner/service/ConnectivityService.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/service/ConnectivityService.kt
@@ -98,6 +98,7 @@ class ConnectivityService : Service() {
 
         Amber.instance.startCleanLogsAlarm()
         Amber.instance.startUpdateCheckAlarm()
+        Amber.instance.startBackupApplicationsAlarm()
 
         HttpClientManager.setDefaultUserAgent("Amber/${BuildConfig.VERSION_NAME}")
 

--- a/app/src/main/java/com/greenart7c3/nostrsigner/service/NotificationSubscription.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/service/NotificationSubscription.kt
@@ -145,6 +145,11 @@ class NotificationSubscription(
         LocalKeyAccountIndex.replaceAll(indexEntries)
     }
 
+    fun closeAllSubs() {
+        subIds.values.forEach { client.unsubscribe(it) }
+        subIds.clear()
+    }
+
     private fun computeSince(): Long {
         var since = TimeUtils.now()
         val latest = if (Amber.instance.notificationCache.size() > 0) Amber.instance.notificationCache.snapshot().maxOf { it.value } else 0L

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/AccountStateViewModel.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/AccountStateViewModel.kt
@@ -4,9 +4,13 @@ import android.util.Log
 import androidx.compose.runtime.Stable
 import androidx.lifecycle.ViewModel
 import com.greenart7c3.nostrsigner.Amber
+import com.greenart7c3.nostrsigner.BuildFlavorChecker
 import com.greenart7c3.nostrsigner.LocalPreferences
 import com.greenart7c3.nostrsigner.models.Account
 import com.greenart7c3.nostrsigner.models.TorMode
+import com.greenart7c3.nostrsigner.service.ApplicationBackup
+import com.greenart7c3.nostrsigner.service.BackupPayload
+import com.greenart7c3.nostrsigner.service.RestoreResult
 import com.greenart7c3.nostrsigner.service.TorManager
 import com.vitorpamplona.quartz.nip01Core.core.toHexKey
 import com.vitorpamplona.quartz.nip01Core.crypto.KeyPair
@@ -16,6 +20,7 @@ import com.vitorpamplona.quartz.nip19Bech32.bech32.bechToBytes
 import com.vitorpamplona.quartz.nip19Bech32.toNpub
 import com.vitorpamplona.quartz.nip49PrivKeyEnc.Nip49
 import com.vitorpamplona.quartz.utils.Hex
+import kotlin.coroutines.cancellation.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -23,11 +28,18 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
+sealed interface RestorePromptState {
+    data object Loading : RestorePromptState
+    data class Found(val account: Account, val payload: BackupPayload, val createdAt: Long) : RestorePromptState
+}
+
 @Stable
 class AccountStateViewModel(npub: String?) : ViewModel() {
     private val _accountContent = MutableStateFlow<AccountState>(AccountState.LoggedOff)
     val accountContent = _accountContent.asStateFlow()
     private var observerJob: Job? = null
+
+    val restorePrompt: MutableStateFlow<RestorePromptState?> = MutableStateFlow(null)
 
     init {
         tryLoginExistingAccount(null, npub)
@@ -128,6 +140,7 @@ class AccountStateViewModel(npub: String?) : ViewModel() {
         }
         LocalPreferences.updatePrefsForLogin(Amber.instance, account, keyPair.pubKey.toHexKey(), keyPair.privKey!!.toHexKey(), null)
         startUI(account, route)
+        maybeOfferRestore(account)
     }
 
     suspend fun newKey(
@@ -183,5 +196,49 @@ class AccountStateViewModel(npub: String?) : ViewModel() {
                 LocalPreferences.saveToEncryptedStorage(Amber.instance, it.account, null, null, null)
             }
         }
+    }
+
+    fun maybeOfferRestore(account: Account) {
+        if (BuildFlavorChecker.isOfflineFlavor()) return
+        if (!Amber.instance.settings.backupApplications) return
+
+        Amber.instance.applicationIOScope.launch {
+            try {
+                val dao = Amber.instance.dao(account.npub)
+                if (dao.getAll(account.hexKey).isNotEmpty()) return@launch
+
+                restorePrompt.value = RestorePromptState.Loading
+
+                val relays = ApplicationBackup.resolveBackupRelays(account)
+                val event = ApplicationBackup.fetchLatestBackupEvent(account, relays)
+                if (event == null) {
+                    restorePrompt.value = null
+                    return@launch
+                }
+                val payload = ApplicationBackup.decryptPayload(event, account)
+                if (payload == null || payload.applications.isEmpty()) {
+                    restorePrompt.value = null
+                    return@launch
+                }
+                restorePrompt.value = RestorePromptState.Found(account, payload, event.createdAt)
+            } catch (e: Exception) {
+                if (e is CancellationException) throw e
+                Log.e(Amber.TAG, "maybeOfferRestore: failed", e)
+                restorePrompt.value = null
+            }
+        }
+    }
+
+    fun acceptRestore(onResult: (RestoreResult) -> Unit) {
+        val current = restorePrompt.value as? RestorePromptState.Found ?: return
+        Amber.instance.applicationIOScope.launch {
+            val result = ApplicationBackup.restoreFromPayload(current.account.npub, current.payload)
+            restorePrompt.value = null
+            launch(Dispatchers.Main) { onResult(result) }
+        }
+    }
+
+    fun dismissRestore() {
+        restorePrompt.value = null
     }
 }

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/AccountStateViewModel.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/AccountStateViewModel.kt
@@ -209,7 +209,7 @@ class AccountStateViewModel(npub: String?) : ViewModel() {
 
                 restorePrompt.value = RestorePromptState.Loading
 
-                val relays = ApplicationBackup.resolveBackupRelays(account)
+                val relays = ApplicationBackup.resolveReadRelays(account)
                 val event = ApplicationBackup.fetchLatestBackupEvent(account, relays)
                 if (event == null) {
                     restorePrompt.value = null

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/ApplicationsBackupScreen.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/ApplicationsBackupScreen.kt
@@ -1,0 +1,191 @@
+package com.greenart7c3.nostrsigner.ui
+
+import android.widget.Toast
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.greenart7c3.nostrsigner.Amber
+import com.greenart7c3.nostrsigner.LocalPreferences
+import com.greenart7c3.nostrsigner.R
+import com.greenart7c3.nostrsigner.models.Account
+import com.greenart7c3.nostrsigner.service.ApplicationBackup
+import com.greenart7c3.nostrsigner.service.RestoreResult
+import com.greenart7c3.nostrsigner.ui.components.AmberButton
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+@Composable
+fun ApplicationsBackupScreen(
+    modifier: Modifier = Modifier,
+    account: Account,
+) {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    var backupApplications by remember { mutableStateOf(Amber.instance.settings.backupApplications) }
+    var isBusy by remember { mutableStateOf(false) }
+    var showRestoreConfirm by remember { mutableStateOf(false) }
+
+    Column(modifier = modifier) {
+        Row(
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 4.dp)
+                .clickable {
+                    val newValue = !backupApplications
+                    backupApplications = newValue
+                    scope.launch(Dispatchers.IO) {
+                        LocalPreferences.updateBackupApplications(context, newValue)
+                        if (newValue) {
+                            Amber.instance.startBackupApplicationsAlarm()
+                        } else {
+                            Amber.instance.cancelBackupApplicationsAlarm()
+                        }
+                    }
+                },
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(text = stringResource(R.string.enable_applications_backup))
+                Text(
+                    text = stringResource(R.string.applications_backup_explainer),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = Color.Gray,
+                )
+            }
+            Switch(
+                checked = backupApplications,
+                onCheckedChange = { enabled ->
+                    backupApplications = enabled
+                    scope.launch(Dispatchers.IO) {
+                        LocalPreferences.updateBackupApplications(context, enabled)
+                        if (enabled) {
+                            Amber.instance.startBackupApplicationsAlarm()
+                        } else {
+                            Amber.instance.cancelBackupApplicationsAlarm()
+                        }
+                    }
+                },
+            )
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        AmberButton(
+            modifier = Modifier.fillMaxWidth(),
+            text = stringResource(R.string.backup_now),
+            enabled = !isBusy,
+            onClick = {
+                if (isBusy) return@AmberButton
+                isBusy = true
+                scope.launch(Dispatchers.IO) {
+                    val ok = ApplicationBackup.publishBackup(account.npub, account)
+                    withContext(Dispatchers.Main) {
+                        Toast.makeText(
+                            context,
+                            if (ok) context.getString(R.string.backup_success) else context.getString(R.string.backup_failed),
+                            Toast.LENGTH_LONG,
+                        ).show()
+                        isBusy = false
+                    }
+                }
+            },
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        AmberButton(
+            modifier = Modifier.fillMaxWidth(),
+            text = stringResource(R.string.restore_from_relays),
+            enabled = !isBusy,
+            onClick = {
+                if (!isBusy) showRestoreConfirm = true
+            },
+        )
+    }
+
+    if (showRestoreConfirm) {
+        AlertDialog(
+            onDismissRequest = { showRestoreConfirm = false },
+            title = { Text(stringResource(R.string.restore_confirm_title)) },
+            text = { Text(stringResource(R.string.restore_confirm_text)) },
+            confirmButton = {
+                TextButton(onClick = {
+                    showRestoreConfirm = false
+                    isBusy = true
+                    scope.launch(Dispatchers.IO) {
+                        val result = ApplicationBackup.restoreFromRelays(account.npub, account)
+                        withContext(Dispatchers.Main) {
+                            val msg = when (result) {
+                                is RestoreResult.Success -> context.getString(R.string.restore_success, result.apps, result.permissions)
+                                is RestoreResult.NoBackupFound -> context.getString(R.string.restore_no_backup_found)
+                                is RestoreResult.Failed -> context.getString(R.string.restore_failed, result.message)
+                            }
+                            Toast.makeText(context, msg, Toast.LENGTH_LONG).show()
+                            isBusy = false
+                        }
+                    }
+                }) { Text(stringResource(R.string.yes)) }
+            },
+            dismissButton = {
+                TextButton(onClick = { showRestoreConfirm = false }) { Text(stringResource(R.string.no)) }
+            },
+        )
+    }
+}
+
+@Composable
+fun RestoreBackupDialog(accountStateViewModel: AccountStateViewModel) {
+    val state by accountStateViewModel.restorePrompt.collectAsState()
+    val found = state as? RestorePromptState.Found ?: return
+    val context = LocalContext.current
+    val apps = found.payload.applications.size
+    val perms = found.payload.applications.sumOf { it.permissions.size }
+
+    AlertDialog(
+        onDismissRequest = { accountStateViewModel.dismissRestore() },
+        title = { Text(stringResource(R.string.signin_restore_title)) },
+        text = { Text(stringResource(R.string.signin_restore_message, apps, perms)) },
+        confirmButton = {
+            TextButton(onClick = {
+                accountStateViewModel.acceptRestore { result ->
+                    val msg = when (result) {
+                        is RestoreResult.Success -> context.getString(R.string.restore_success, result.apps, result.permissions)
+                        is RestoreResult.NoBackupFound -> context.getString(R.string.restore_no_backup_found)
+                        is RestoreResult.Failed -> context.getString(R.string.restore_failed, result.message)
+                    }
+                    Toast.makeText(context, msg, Toast.LENGTH_LONG).show()
+                }
+            }) { Text(stringResource(R.string.signin_restore_accept)) }
+        },
+        dismissButton = {
+            TextButton(onClick = { accountStateViewModel.dismissRestore() }) {
+                Text(stringResource(R.string.signin_restore_skip))
+            }
+        },
+    )
+}

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/LoginScreen.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/LoginScreen.kt
@@ -166,6 +166,7 @@ fun MainPage(
                                     val account = LocalPreferences.loadFromEncryptedStorage(Amber.instance, accounts.first().npub)
                                     account?.let {
                                         accountViewModel.startUI(account, null)
+                                        accountViewModel.maybeOfferRestore(account)
                                     }
                                 }
                             }

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/MainScreen.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/MainScreen.kt
@@ -1067,8 +1067,27 @@ fun MainScreen(
                             )
                         },
                     )
+
+                    composable(
+                        Route.ApplicationsBackup.route,
+                        content = {
+                            val scrollState = rememberScrollState()
+                            ApplicationsBackupScreen(
+                                modifier = Modifier
+                                    .fillMaxSize()
+                                    .padding(padding)
+                                    .verticalScrollbar(scrollState)
+                                    .verticalScroll(scrollState)
+                                    .padding(horizontal = verticalPadding)
+                                    .padding(top = verticalPadding * 1.5f),
+                                account = account,
+                            )
+                        },
+                    )
                 }
             }
+
+            RestoreBackupDialog(accountStateViewModel)
 
             DisplayCrashMessages(account, navController)
 

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/SettingsScreen.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/SettingsScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CloudUpload
 import androidx.compose.material.icons.filled.Draw
 import androidx.compose.material.icons.filled.Feedback
 import androidx.compose.material.icons.filled.FilterList
@@ -240,6 +241,22 @@ fun SettingsScreen(
                         onNav(Route.SignPolicy.route)
                     },
                 )
+            }
+
+            if (!BuildFlavorChecker.isOfflineFlavor()) {
+                Box(
+                    Modifier
+                        .padding(vertical = 8.dp),
+                ) {
+                    IconRow(
+                        title = stringResource(R.string.applications_backup),
+                        icon = Icons.Default.CloudUpload,
+                        tint = MaterialTheme.colorScheme.onBackground,
+                        onClick = {
+                            onNav(Route.ApplicationsBackup.route)
+                        },
+                    )
+                }
             }
 
             Box(

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/navigation/Route.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/navigation/Route.kt
@@ -226,6 +226,12 @@ sealed class Route(
         route = "ServiceSettings",
         icon = R.drawable.settings,
     )
+
+    data object ApplicationsBackup : Route(
+        title = Amber.instance.getString(R.string.applications_backup),
+        route = "ApplicationsBackup",
+        icon = R.drawable.settings,
+    )
 }
 
 val routes = listOf(
@@ -262,4 +268,5 @@ val routes = listOf(
     Route.UpdateSettings,
     Route.CloudBackup,
     Route.ServiceSettings,
+    Route.ApplicationsBackup,
 )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -688,4 +688,20 @@
     <string name="event_kind_10044">Encryption key annoucement</string>
     <string name="event_kind_4455">Key transfer</string>
     <string name="event_kind_4454">Client key announcement</string>
+    <string name="applications_backup">Applications backup</string>
+    <string name="applications_backup_explainer">When enabled, Amber publishes an encrypted copy of your connected applications and their permissions to relays once a day so you can restore them on a new device. Only you can decrypt the backup.</string>
+    <string name="enable_applications_backup">Enable encrypted applications backup</string>
+    <string name="backup_now">Backup now</string>
+    <string name="restore_from_relays">Restore from relays</string>
+    <string name="restore_confirm_title">Restore applications?</string>
+    <string name="restore_confirm_text">Permissions for applications that already exist on this device will be replaced with the backed-up permissions. New applications from the backup will be added. Continue?</string>
+    <string name="backup_success">Backup published</string>
+    <string name="backup_failed">Failed to publish backup</string>
+    <string name="restore_success">Restored %1$d applications and %2$d permissions</string>
+    <string name="restore_failed">Restore failed: %1$s</string>
+    <string name="restore_no_backup_found">No backup found on relays</string>
+    <string name="signin_restore_title">Restore backup?</string>
+    <string name="signin_restore_message">Found an encrypted applications backup with %1$d applications and %2$d permissions. Restore now?</string>
+    <string name="signin_restore_accept">Restore</string>
+    <string name="signin_restore_skip">Skip</string>
 </resources>


### PR DESCRIPTION
## Summary

Adds encrypted backup and restore functionality for connected applications and their permissions. Users can enable automatic daily backups that are published to relays as NIP-78 events (kind 30078), encrypted with NIP-44. On login to a new device, users are offered the option to restore their backed-up applications.

## Key Changes

- **ApplicationBackup service** (`ApplicationBackup.kt`): Core backup/restore logic
  - `buildPayload()` — serializes all applications and permissions for an account
  - `publishBackup()` — encrypts payload and publishes to relays as kind 30078 event
  - `fetchLatestBackupEvent()` — retrieves the most recent backup from relays
  - `decryptPayload()` — decrypts and deserializes backup data
  - `restoreFromPayload()` — imports applications and permissions into the database
  - `resolveBackupRelays()` — determines target relays (inbox relays + profile relays + aggregator)

- **BackupApplicationsWorker** (`BackupApplicationsWorker.kt`): Periodic work that triggers daily backups for all accounts

- **UI Components**:
  - `ApplicationsBackupScreen` — settings screen with toggle, manual backup button, and restore button
  - `RestoreBackupDialog` — post-login prompt offering to restore backed-up applications
  - New route `ApplicationsBackup` in navigation

- **Integration points**:
  - `AccountStateViewModel.maybeOfferRestore()` — checks for backups after login and prompts user
  - `Amber.kt` — `startBackupApplicationsAlarm()` / `cancelBackupApplicationsAlarm()` to manage periodic work
  - `ConnectivityService` — starts backup alarm on service startup
  - `LocalPreferences` — persists `backupApplications` setting
  - `AmberSettings` — adds `backupApplications` boolean flag
  - `NotificationSubscription.closeAllSubs()` — helper to close all subscriptions during restore

- **Strings** — added UI labels and messages for backup/restore flows

## Implementation Details

- Backups are encrypted with the user's own key (NIP-44), ensuring only they can decrypt
- Relay resolution follows NIP-65 (inbox relays) with fallback to profile relays
- Restore only triggers if the account has no existing applications (prevents accidental overwrites)
- Uses `applicationIOScope` for all async backup/restore operations
- Respects offline flavor — all backup/restore operations are guarded by `BuildFlavorChecker.isOfflineFlavor()`
- Backup payload includes version and timestamp for future compatibility

https://claude.ai/code/session_019dFgCZjLjfLdnHWmK11Dvb