### PR TITLE
Add auto-accept PING permission for applications

### DIFF
--- a/app/src/main/java/com/greenart7c3/nostrsigner/service/BunkerRequestUtils.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/service/BunkerRequestUtils.kt
@@ -381,6 +381,20 @@ object BunkerRequestUtils {
                         ),
                     )
                 }
+                if (!application.permissions.any { it.type == SignerType.PING.toString() }) {
+                    application.permissions.add(
+                        ApplicationPermissionsEntity(
+                            null,
+                            key,
+                            SignerType.PING.toString(),
+                            null,
+                            true,
+                            RememberType.ALWAYS.screenCode,
+                            Long.MAX_VALUE / 1000,
+                            0,
+                        ),
+                    )
+                }
                 // check if application has any relay not in saved relays
                 val savedRelays = Amber.instance.getSavedRelays(account)
                 if (relays.any { !savedRelays.contains(it) }) {


### PR DESCRIPTION
## Summary
Automatically grant applications the PING permission with an "always accept" policy when they first connect via NIP-46. This ensures applications can perform keep-alive pings without requiring user approval each time.

## Changes
- Added logic to `BunkerRequestUtils.kt` to check if an application already has a PING permission
- If missing, automatically create a new `ApplicationPermissionsEntity` for the PING signer type with:
  - `rememberType` set to `ALWAYS` (auto-accept)
  - `acceptUntil` set to `Long.MAX_VALUE / 1000` (effectively no expiration)
  - All other fields initialized appropriately

## Implementation Details
The permission is added during the application connection flow in `BunkerRequestUtils`, following the same pattern as other auto-granted permissions. The PING permission will be silently accepted for all future requests from that application without user interaction, consistent with the permission system's auto-accept mechanism described in the architecture.

https://claude.ai/code/session_013V6QVcdGxZVQTmwMP4Vqmi