### PR TITLE
Simplify invalid intent screen UI and messaging

### DIFF
--- a/app/src/main/java/com/greenart7c3/nostrsigner/SignerActivity.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/SignerActivity.kt
@@ -124,11 +124,9 @@ class SignerActivity : AppCompatActivity() {
                             modifier = Modifier.fillMaxWidth(),
                             color = MaterialTheme.colorScheme.background,
                         ) {
-                            val err = invalidIntent
-                            if (err != null) {
+                            if (invalidIntent != null) {
                                 InvalidIntentScreen(
                                     modifier = Modifier.fillMaxSize(),
-                                    info = err,
                                     onClose = {
                                         IntentUtils.clearInvalidIntents()
                                         finishAndRemoveTask()

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/InvalidIntentScreen.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/InvalidIntentScreen.kt
@@ -22,66 +22,23 @@ package com.greenart7c3.nostrsigner.ui
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.Done
-import androidx.compose.material3.Button
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalClipboard
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
-import com.greenart7c3.nostrsigner.Amber
-import com.greenart7c3.nostrsigner.BuildConfig
-import com.greenart7c3.nostrsigner.LocalPreferences
 import com.greenart7c3.nostrsigner.R
-import com.greenart7c3.nostrsigner.service.IntentUtils
-import com.greenart7c3.nostrsigner.service.ReportSender
-import kotlinx.coroutines.launch
 
 @Composable
 fun InvalidIntentScreen(
     modifier: Modifier = Modifier,
-    info: IntentUtils.InvalidIntentInfo,
     onClose: () -> Unit,
 ) {
-    val context = LocalContext.current
-    val clipboardManager = LocalClipboard.current
-
-    val initialReport = remember(info.id) {
-        buildString {
-            appendLine("Reason: ${info.message}")
-            appendLine("Caller: ${info.callingPackage ?: "unknown"}")
-            appendLine("Type extra: ${info.typeExtra ?: "(none)"}")
-            appendLine("Data: ${info.dataString ?: "(none)"}")
-            appendLine("Amber: ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})")
-            appendLine("Time: ${info.timestampMs}")
-            info.stackTrace?.let {
-                appendLine()
-                append(it)
-            }
-        }
-    }
-    var editedReport by remember { mutableStateOf(initialReport) }
-
     Column(
         modifier = modifier
             .fillMaxSize()
@@ -104,57 +61,15 @@ fun InvalidIntentScreen(
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
-
-            OutlinedTextField(
-                value = editedReport,
-                onValueChange = { editedReport = it },
-                modifier = Modifier
-                    .weight(1f)
-                    .fillMaxWidth(),
-                textStyle = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
-            )
         }
 
-        Row(
+        OutlinedButton(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(top = 8.dp),
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            onClick = onClose,
         ) {
-            OutlinedButton(
-                modifier = Modifier.weight(1f),
-                onClick = onClose,
-            ) {
-                Text(stringResource(R.string.invalid_intent_close_app))
-            }
-
-            Button(
-                modifier = Modifier.weight(1f),
-                onClick = {
-                    val report = editedReport
-                    Amber.instance.applicationIOScope.launch {
-                        val account = LocalPreferences.loadFromEncryptedStorage(context)
-                        ReportSender.send(
-                            account = account,
-                            report = report,
-                            clipboard = clipboardManager,
-                            onDone = onClose,
-                        )
-                    }
-                },
-            ) {
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    Icon(
-                        imageVector = Icons.Outlined.Done,
-                        tint = Color.Black,
-                        contentDescription = stringResource(R.string.invalid_intent_send_report),
-                    )
-                    Spacer(Modifier.size(4.dp))
-                    Text(stringResource(R.string.invalid_intent_send_report), color = Color.Black)
-                }
-            }
+            Text(stringResource(R.string.invalid_intent_close_app))
         }
     }
 }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -572,9 +572,8 @@
     <string name="copy_crash_report_to_clipboard">Would you like to copy the crash report to your clipboard and open a Client to send it to Amber?</string>
     <string name="crashreport_found_send">Send it</string>
     <string name="invalid_intent_title">Invalid request</string>
-    <string name="invalid_intent_body">Amber received a malformed nostrsigner request and cannot process it. You can close the app or send the details to the developer to help fix the issue.</string>
+    <string name="invalid_intent_body">Amber received a malformed nostrsigner request and cannot process it. Please contact the client developer to report this issue.</string>
     <string name="invalid_intent_close_app">Close app</string>
-    <string name="invalid_intent_send_report">Send report to developer</string>
     <string name="event_kind_14">Direct Message</string>
     <string name="wants_to_encrypt_with">" wants to encrypt %1$s with %2$s"</string>
     <string name="wants_to_encrypt_event_kind">wants to encrypt %1$s with %2$s</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -572,9 +572,8 @@
     <string name="copy_crash_report_to_clipboard">Would you like to copy the crash report to your clipboard and open a Client to send it to Amber?</string>
     <string name="crashreport_found_send">Send it</string>
     <string name="invalid_intent_title">Invalid request</string>
-    <string name="invalid_intent_body">Amber received a malformed nostrsigner request and cannot process it. You can close the app or send the details to the developer to help fix the issue.</string>
+    <string name="invalid_intent_body">Amber received a malformed nostrsigner request and cannot process it. Please contact the client developer to report this issue.</string>
     <string name="invalid_intent_close_app">Close app</string>
-    <string name="invalid_intent_send_report">Send report to developer</string>
     <string name="event_kind_14">Direct Message</string>
     <string name="wants_to_encrypt_with">" wants to encrypt %1$s with %2$s"</string>
     <string name="wants_to_encrypt_event_kind">wants to encrypt %1$s with %2$s</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -572,9 +572,8 @@
     <string name="copy_crash_report_to_clipboard">Would you like to copy the crash report to your clipboard and open a Client to send it to Amber?</string>
     <string name="crashreport_found_send">Send it</string>
     <string name="invalid_intent_title">Invalid request</string>
-    <string name="invalid_intent_body">Amber received a malformed nostrsigner request and cannot process it. You can close the app or send the details to the developer to help fix the issue.</string>
+    <string name="invalid_intent_body">Amber received a malformed nostrsigner request and cannot process it. Please contact the client developer to report this issue.</string>
     <string name="invalid_intent_close_app">Close app</string>
-    <string name="invalid_intent_send_report">Send report to developer</string>
     <string name="event_kind_14">Direct Message</string>
     <string name="wants_to_encrypt_with">" wants to encrypt %1$s with %2$s"</string>
     <string name="wants_to_encrypt_event_kind">wants to encrypt %1$s with %2$s</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -570,9 +570,8 @@
     <string name="copy_crash_report_to_clipboard">Você gostaria de copiar o relatório de falha para a área de transferência e abrir um Cliente para enviá-lo ao Amber?</string>
     <string name="crashreport_found_send">Enviar</string>
     <string name="invalid_intent_title">Invalid request</string>
-    <string name="invalid_intent_body">Amber received a malformed nostrsigner request and cannot process it. You can close the app or send the details to the developer to help fix the issue.</string>
+    <string name="invalid_intent_body">Amber received a malformed nostrsigner request and cannot process it. Please contact the client developer to report this issue.</string>
     <string name="invalid_intent_close_app">Close app</string>
-    <string name="invalid_intent_send_report">Send report to developer</string>
     <string name="event_kind_14">Mensagem direta</string>
     <string name="wants_to_encrypt_with">" quer criptografar %1$s com %2$s"</string>
     <string name="wants_to_encrypt_event_kind">quer criptografar %1$s com %2$s</string>

--- a/app/src/main/res/values-sw-rKE/strings.xml
+++ b/app/src/main/res/values-sw-rKE/strings.xml
@@ -569,9 +569,8 @@
     <string name="copy_crash_report_to_clipboard">Would you like to copy the crash report to your clipboard and open a Client to send it to Amber?</string>
     <string name="crashreport_found_send">Send it</string>
     <string name="invalid_intent_title">Invalid request</string>
-    <string name="invalid_intent_body">Amber received a malformed nostrsigner request and cannot process it. You can close the app or send the details to the developer to help fix the issue.</string>
+    <string name="invalid_intent_body">Amber received a malformed nostrsigner request and cannot process it. Please contact the client developer to report this issue.</string>
     <string name="invalid_intent_close_app">Close app</string>
-    <string name="invalid_intent_send_report">Send report to developer</string>
     <string name="event_kind_14">Direct Message</string>
     <string name="wants_to_encrypt_with">" wants to encrypt %1$s with %2$s"</string>
     <string name="wants_to_encrypt_event_kind">wants to encrypt %1$s with %2$s</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -572,9 +572,8 @@
     <string name="copy_crash_report_to_clipboard">Çökme raporunu panonuza kopyalamak ve onu Amber\'a göndermek için bir İstemci açmak ister misiniz?</string>
     <string name="crashreport_found_send">Gönder</string>
     <string name="invalid_intent_title">Invalid request</string>
-    <string name="invalid_intent_body">Amber received a malformed nostrsigner request and cannot process it. You can close the app or send the details to the developer to help fix the issue.</string>
+    <string name="invalid_intent_body">Amber received a malformed nostrsigner request and cannot process it. Please contact the client developer to report this issue.</string>
     <string name="invalid_intent_close_app">Close app</string>
-    <string name="invalid_intent_send_report">Send report to developer</string>
     <string name="event_kind_14">Doğrudan Mesaj</string>
     <string name="wants_to_encrypt_with">" %1$s ögesini %2$s ile şifrelemek istiyor"</string>
     <string name="wants_to_encrypt_event_kind">%1$s ögesini %2$s ile şifrelemek istiyor</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -572,9 +572,8 @@
     <string name="copy_crash_report_to_clipboard">想要复制崩溃报告到剪贴板并打开客户端发送给 Amber 吗？</string>
     <string name="crashreport_found_send">发送</string>
     <string name="invalid_intent_title">无效的请求</string>
-    <string name="invalid_intent_body">Amber 收到了一个无法处理的错误格式 Nostr 签名器请求。你可以关闭这个应用或发送详情给开发者以帮助修复该问题。</string>
+    <string name="invalid_intent_body">Amber 收到了一个无法处理的错误格式 Nostr 签名器请求。请联系客户端开发者报告此问题。</string>
     <string name="invalid_intent_close_app">关闭应用</string>
-    <string name="invalid_intent_send_report">发送报告给开发者</string>
     <string name="event_kind_14">私信</string>
     <string name="wants_to_encrypt_with">" 将要使用 %2$s 加密 %1$s"</string>
     <string name="wants_to_encrypt_event_kind">将要使用 %2$s 解密 %1$s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -579,9 +579,8 @@
     <string name="copy_crash_report_to_clipboard">Would you like to copy the crash report to your clipboard and open a Client to send it to Amber?</string>
     <string name="crashreport_found_send">Send it</string>
     <string name="invalid_intent_title">Invalid request</string>
-    <string name="invalid_intent_body">Amber received a malformed nostrsigner request and cannot process it. You can close the app or send the details to the developer to help fix the issue.</string>
+    <string name="invalid_intent_body">Amber received a malformed nostrsigner request and cannot process it. Please contact the client developer to report this issue.</string>
     <string name="invalid_intent_close_app">Close app</string>
-    <string name="invalid_intent_send_report">Send report to developer</string>
     <string name="event_kind_14">Direct Message</string>
     <string name="wants_to_encrypt_with">" wants to encrypt %1$s with %2$s"</string>
     <string name="wants_to_encrypt_event_kind">wants to encrypt %1$s with %2$s</string>


### PR DESCRIPTION
## Summary
Removes the error report submission feature from the invalid intent screen and simplifies the UI to only show a close button. Updates user-facing messaging across all locales to direct users to contact the client developer instead of sending reports directly from the app.

## Changes
- **InvalidIntentScreen.kt**: Removed all report-related functionality including:
  - `IntentUtils.InvalidIntentInfo` parameter and related state management
  - Error report text field and editing capability
  - Report submission button and associated coroutine logic
  - Clipboard and context dependencies
  - Simplified layout to single close button
  
- **SignerActivity.kt**: Removed `info` parameter when instantiating `InvalidIntentScreen`

- **String resources** (all locales): 
  - Updated `invalid_intent_body` message to direct users to contact the client developer instead of offering in-app report submission
  - Removed `invalid_intent_send_report` string resource (no longer needed)

## Implementation Details
The screen now serves as a simple error notification that informs users of the malformed request and directs them to contact the originating client's developer. This shifts responsibility for error reporting away from the Amber app itself, simplifying the codebase and reducing unnecessary dependencies on clipboard and coroutine management for this error path.

https://claude.ai/code/session_015D7VkuiR45K87LqNJMACiS