### PR TITLE
Release v6.2.0: NIP-44 v3 encryption and UX improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+## Amber 6.2.0
+
+- Add NIP-44 v3 encryption support, including a dedicated approval screen, intent preview, bunker preview, history logging and auto-reject for invalid requests
+- Register NIP-44 v3 ContentProvider authorities
+- Auto-accept NIP-46 ping requests on connect
+- Ignore empty `nostrsigner:` intents so the app can be opened directly
+- Simplify the invalid intent screen to only close the app
+- Use a segmented toggle for option pickers, with a scrollbar and shrinking segments when they get too narrow to fit the screen
+- Remove the `sign_message` signer method
+- Remove the 1 minute option from the sign-automatically pickers
+- Disable resource shrinking in release builds
+- New Crowdin translations
+
+Download it with [Zapstore](https://zapstore.dev/apps/com.greenart7c3.nostrsigner), [Obtainium](https://github.com/ImranR98/Obtainium), [f-droid](https://f-droid.org/packages/com.greenart7c3.nostrsigner) or download it directly in the [releases page](https://github.com/greenart7c3/Amber/releases/tag/v6.2.0)
+
+If you like my work consider making a [donation](https://greenart7c3.com)
+
 ## Amber 6.1.0
 
 - Better layout when connecting a new app

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,36 @@ Download it with [Zapstore](https://zapstore.dev/apps/com.greenart7c3.nostrsigne
 
 If you like my work consider making a [donation](https://greenart7c3.com)
 
+## Verifying the release
+
+In order to verify the release, you'll need to have `gpg` or `gpg2` installed on your system. Once you've obtained a copy (and hopefully verified that as well), you'll first need to import the keys that have signed this release if you haven't done so already:
+
+``` bash
+gpg --keyserver hkps://keys.openpgp.org --recv-keys 44F0AAEB77F373747E3D5444885822EED3A26A6D
+```
+
+Once you have his PGP key you can verify the release (assuming `manifest-v6.2.0.txt` and `manifest-v6.2.0.txt.sig` are in the current directory) with:
+
+``` bash
+gpg --verify manifest-v6.2.0.txt.sig manifest-v6.2.0.txt
+```
+
+You should see the following if the verification was successful:
+
+``` bash
+gpg: Signature made Fri 13 Sep 2024 08:06:52 AM -03
+gpg:                using RSA key 44F0AAEB77F373747E3D5444885822EED3A26A6D
+gpg: Good signature from "greenart7c3 <greenart7c3@proton.me>"
+```
+
+That will verify the signature on the main manifest page which ensures integrity and authenticity of the binaries you've downloaded locally. Next, depending on your operating system you should then re-calculate the sha256 sum of the binary, and compare that with the following hashes:
+
+``` bash
+cat manifest-v6.2.0.txt
+```
+
+One can use the `shasum -a 256 <file name here>` tool in order to re-compute the `sha256` hash of the target binary for your operating system. The produced hash should be compared with the hashes listed above and they should match exactly.
+
 ## Amber 6.1.0
 
 - Better layout when connecting a new app


### PR DESCRIPTION
## Summary

This release adds comprehensive NIP-44 v3 encryption support to Amber with a dedicated approval workflow, along with several UX improvements and protocol enhancements.

## Key Changes

- **NIP-44 v3 Encryption Support**: Full implementation including dedicated approval screen, intent preview, bunker preview, history logging, and auto-reject for invalid requests
- **NIP-44 v3 ContentProvider**: Register NIP-44 v3 ContentProvider authorities for IPC signing
- **NIP-46 Improvements**: Auto-accept ping requests on connect to improve connection reliability
- **Intent Handling**: Ignore empty `nostrsigner:` intents to allow direct app opening
- **UI Refinements**:
  - Simplify invalid intent screen to only close the app
  - Replace option pickers with segmented toggles featuring scrollbar support and dynamic segment shrinking for narrow screens
- **API Cleanup**: Remove deprecated `sign_message` signer method
- **Configuration**: Remove 1-minute option from sign-automatically pickers
- **Build Optimization**: Disable resource shrinking in release builds
- **Localization**: New Crowdin translations

## Implementation Details

The NIP-44 v3 support integrates with the existing three-path request ingestion system (Intent → ContentProvider → NIP-46 relay events), following the established pattern of converging on `Account.sign()` methods backed by `NostrSignerInternal`. The approval workflow includes dedicated UI for encryption requests with proper history logging and permission management.

https://claude.ai/code/session_01YZ4yFxp39Sq1NJpjw1Mj5h