### PR TITLE
Add LOGOUT support for NIP-46 bunker protocol

### DIFF
--- a/app/src/main/java/com/greenart7c3/nostrsigner/models/SignerType.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/models/SignerType.kt
@@ -15,4 +15,5 @@ enum class SignerType {
     INVALID,
     SWITCH_RELAYS,
     SIGN_PSBT,
+    LOGOUT,
 }

--- a/app/src/main/java/com/greenart7c3/nostrsigner/service/BunkerRequestUtils.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/service/BunkerRequestUtils.kt
@@ -235,6 +235,7 @@ object BunkerRequestUtils {
         "ping" -> SignerType.PING
         "switch_relays" -> SignerType.SWITCH_RELAYS
         "sign_psbt" -> SignerType.SIGN_PSBT
+        "logout" -> SignerType.LOGOUT
         else -> SignerType.INVALID
     }
 
@@ -251,6 +252,7 @@ object BunkerRequestUtils {
         "nip44v3_encrypt", "nip44v3_decrypt" -> bunkerRequest.params.getOrElse(3) { "" }
         "ping" -> "pong"
         "sign_psbt" -> bunkerRequest.params.first()
+        "logout" -> "ack"
         else -> ""
     }
 

--- a/app/src/main/java/com/greenart7c3/nostrsigner/service/EventNotificationConsumer.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/service/EventNotificationConsumer.kt
@@ -384,6 +384,29 @@ class EventNotificationConsumer(private val applicationContext: Context) {
             return
         }
 
+        if (type == SignerType.LOGOUT) {
+            permission?.let {
+                BunkerRequestUtils.sendBunkerResponse(
+                    context = applicationContext,
+                    account = acc,
+                    bunkerRequest = request,
+                    bunkerResponse = BunkerResponse(bunkerRequest.id, "ack", null),
+                    relays = relays,
+                    onLoading = { },
+                    onDone = { success ->
+                        if (success) {
+                            Amber.instance.applicationIOScope.launch {
+                                dao.delete(permission.application.key)
+                                historyDao.deleteHistory(permission.application.key)
+                                Amber.instance.notificationSubscription.updateFilter()
+                            }
+                        }
+                    },
+                )
+            }
+            return
+        }
+
         if (type == SignerType.GET_PUBLIC_KEY) {
             val gpkPermission = dao.getPermission(event.pubKey, "GET_PUBLIC_KEY")
             val signPolicy = dao.getSignPolicy(event.pubKey)

--- a/app/src/test/java/com/greenart7c3/nostrsigner/service/BunkerRequestUtilsTest.kt
+++ b/app/src/test/java/com/greenart7c3/nostrsigner/service/BunkerRequestUtilsTest.kt
@@ -126,6 +126,11 @@ class BunkerRequestUtilsTest {
     }
 
     @Test
+    fun `getTypeFromBunker returns LOGOUT for logout`() {
+        assertEquals(SignerType.LOGOUT, BunkerRequestUtils.getTypeFromBunker(mockBunkerRequest("logout")))
+    }
+
+    @Test
     fun `getTypeFromBunker returns INVALID for unknown method`() {
         assertEquals(SignerType.INVALID, BunkerRequestUtils.getTypeFromBunker(mockBunkerRequest("unknown_method")))
     }
@@ -233,6 +238,11 @@ class BunkerRequestUtilsTest {
     @Test
     fun `getDataFromBunker returns empty string for switch_relays`() {
         assertEquals("", BunkerRequestUtils.getDataFromBunker(mockBunkerRequest("switch_relays")))
+    }
+
+    @Test
+    fun `getDataFromBunker returns ack for logout`() {
+        assertEquals("ack", BunkerRequestUtils.getDataFromBunker(mockBunkerRequest("logout")))
     }
 
     @Test


### PR DESCRIPTION
## Summary
Adds support for the `logout` method in the NIP-46 bunker protocol, allowing remote signers to request account logout and permission revocation.

## Changes
- **SignerType.kt**: Added `LOGOUT` enum value to represent the logout request type
- **BunkerRequestUtils.kt**: 
  - Added "logout" → `SignerType.LOGOUT` mapping in `getTypeFromBunker()`
  - Added "logout" → "ack" response mapping in `getDataFromBunker()`
- **EventNotificationConsumer.kt**: Implemented logout handler that:
  - Sends acknowledgment response to the bunker request
  - Deletes the application permission from the database
  - Clears associated history entries
  - Updates the notification filter subscription
- **BunkerRequestUtilsTest.kt**: Added unit tests for logout type and response data handling

## Implementation Details
The logout handler follows the existing pattern for NIP-46 request handling:
1. Validates the permission exists
2. Sends a bunker response with "ack" status
3. On successful response delivery, cleans up all associated data (permissions and history) in a background coroutine
4. Updates the notification subscription filter to reflect the removed permission

This ensures proper cleanup when a remote application requests to revoke its access to the signer.

https://claude.ai/code/session_011Qu6NCFZgXuGQaCHEsSy1V