### PR TITLE
Refactor coroutine scope usage in BunkerConnectRequestScreen

### DIFF
--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/BunkerConnectRequestScreen.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/BunkerConnectRequestScreen.kt
@@ -38,7 +38,6 @@ import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -73,6 +72,7 @@ import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -86,7 +86,6 @@ fun BunkerConnectRequestScreen(
     onAccept: (List<Permission>?, Int, Boolean?, RememberType, Long, Account) -> Unit,
     onReject: (RememberType) -> Unit,
 ) {
-    val scope = rememberCoroutineScope()
     val localPermissions = remember {
         val snapshot = mutableStateListOf<Permission>()
         permissions?.forEach {
@@ -122,10 +121,11 @@ fun BunkerConnectRequestScreen(
     val appName = remember { mutableStateOf(bunkerRequest.name) }
 
     LaunchedEffect(selectedAccountIndex) {
-        scope.launch(Dispatchers.IO) {
-            val account = accounts[selectedAccountIndex]
-            appName.value = bunkerRequest.name.ifBlank { Amber.instance.getDatabase(account.npub).dao().getBySecret((bunkerRequest.request as BunkerRequestConnect).secret ?: "")?.application?.name ?: bunkerRequest.localKey.toShortenHex() }
+        val selectedAccount = accounts[selectedAccountIndex]
+        val name = withContext(Dispatchers.IO) {
+            bunkerRequest.name.ifBlank { Amber.instance.getDatabase(selectedAccount.npub).dao().getBySecret((bunkerRequest.request as BunkerRequestConnect).secret ?: "")?.application?.name ?: bunkerRequest.localKey.toShortenHex() }
         }
+        appName.value = name
     }
 
     // Fetch trust scores for connection relays
@@ -135,8 +135,8 @@ fun BunkerConnectRequestScreen(
                 val url = relay.url
                 if (!trustScores.containsKey(url)) {
                     loadingScores[url] = true
-                    scope.launch(Dispatchers.IO) {
-                        val score = TrustScoreService.getScore(url)
+                    launch {
+                        val score = withContext(Dispatchers.IO) { TrustScoreService.getScore(url) }
                         trustScores[url] = score
                         loadingScores[url] = false
                     }


### PR DESCRIPTION
## Summary
Refactored `BunkerConnectRequestScreen` to remove the manual `rememberCoroutineScope()` and instead leverage the implicit coroutine scope provided by `LaunchedEffect` and other composition-aware coroutine builders. This simplifies the code and aligns with Compose best practices.

## Key Changes
- Removed `rememberCoroutineScope()` call and the `scope` variable
- Removed unused import of `rememberCoroutineScope`
- Added import of `withContext` from `kotlinx.coroutines`
- Refactored `LaunchedEffect(selectedAccountIndex)` block:
  - Moved account lookup outside the coroutine launch
  - Used `withContext(Dispatchers.IO)` for the database query instead of `scope.launch(Dispatchers.IO)`
  - Assigned the result directly to `appName.value` after the effect completes
- Refactored trust score loading in the relay loop:
  - Changed from `scope.launch(Dispatchers.IO)` to `launch` (implicit scope from `LaunchedEffect`)
  - Wrapped `TrustScoreService.getScore()` with `withContext(Dispatchers.IO)` instead of launching on IO dispatcher

## Implementation Details
The changes maintain the same threading behavior while improving code clarity:
- Database and network operations still execute on `Dispatchers.IO`
- State updates (`appName.value`, `trustScores`, `loadingScores`) still occur on the main thread
- The refactoring eliminates the need for manual scope management by using composition-aware coroutine builders, which automatically handle cancellation when the composable leaves the composition

https://claude.ai/code/session_01QDo1cRXWgg8f186R3VWXVk