### PR TITLE
Send error response for invalid NIP-46 request methods

### DIFF
--- a/app/src/main/java/com/greenart7c3/nostrsigner/service/EventNotificationConsumer.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/service/EventNotificationConsumer.kt
@@ -229,12 +229,6 @@ class EventNotificationConsumer(private val applicationContext: Context) {
 
         val encryptedDataKind = getEncryptedDataKind(bunkerRequest, acc, relay.url)
 
-        val type = BunkerRequestUtils.getTypeFromBunker(bunkerRequest)
-        if (type == SignerType.INVALID) {
-            saveLog("Invalid request method ${bunkerRequest.method}", relay.url, acc.npub)
-            return
-        }
-
         var request = AmberBunkerRequest(
             request = bunkerRequest,
             localKey = event.pubKey,
@@ -249,6 +243,24 @@ class EventNotificationConsumer(private val applicationContext: Context) {
             isNostrConnectUri = false,
             signerPrivKey = connectionPrivKey,
         )
+
+        val type = BunkerRequestUtils.getTypeFromBunker(bunkerRequest)
+        if (type == SignerType.INVALID) {
+            saveLog("Invalid request method ${bunkerRequest.method}", relay.url, acc.npub)
+            // Don't fail silently: reply to the client with an error so it
+            // stops waiting for a response it will never otherwise receive.
+            val errorRelays = responseRelay.ifEmpty { Amber.instance.settings.defaultRelays }
+            BunkerRequestUtils.sendBunkerResponse(
+                applicationContext,
+                acc,
+                request,
+                BunkerResponse(bunkerRequest.id, "", "Unrecognized method: ${bunkerRequest.method}"),
+                errorRelays,
+                onLoading = {},
+                onDone = {},
+            )
+            return
+        }
 
         var amberEvent: AmberEvent? = null
 


### PR DESCRIPTION
## Summary
When an invalid NIP-46 request method is received, the signer now sends an error response to the client instead of silently dropping the request. This prevents clients from hanging indefinitely while waiting for a response that will never arrive.

## Changes
- Moved the invalid request type check to after the `AmberBunkerRequest` object is constructed, allowing us to send a proper error response
- Added `BunkerRequestUtils.sendBunkerResponse()` call with an error message when an unrecognized method is detected
- Uses the response relay from the request, falling back to default relays if not specified
- Includes a descriptive error message: "Unrecognized method: {method}"

## Implementation Details
The validation logic remains the same, but is now positioned after we have the necessary request context to formulate a proper NIP-46 error response. This follows the NIP-46 protocol requirement that clients should receive explicit responses rather than timeouts.

https://claude.ai/code/session_01TyihVhxC45JKhivKYkNTGk