### PR TITLE
Fix navigation crash when opening application permissions

### DIFF
--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/ApplicationsScreen.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/ApplicationsScreen.kt
@@ -2,6 +2,7 @@ package com.greenart7c3.nostrsigner.ui
 
 import android.content.Context
 import android.content.Intent
+import android.util.Log
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -175,7 +176,17 @@ fun ApplicationsScreen(
                             .fillMaxSize()
                             .padding(vertical = 4.dp)
                             .clickable {
-                                navController.navigate("Permission/${applicationWithHistory.key}")
+                                // Only navigate when we are still on the Applications screen. A second
+                                // tap (or a tap landing while the NavHost graph is being recreated) can
+                                // otherwise fire navigate() against a graph that no longer contains the
+                                // Permission destination, crashing with IllegalArgumentException.
+                                if (navController.currentDestination?.route == Route.Applications.route) {
+                                    runCatching {
+                                        navController.navigate("Permission/${applicationWithHistory.key}")
+                                    }.onFailure {
+                                        Log.e("ApplicationsScreen", "Failed to open permissions for ${applicationWithHistory.key}", it)
+                                    }
+                                }
                             },
                         verticalAlignment = Alignment.CenterVertically,
                     ) {


### PR DESCRIPTION
Tapping an application row could throw IllegalArgumentException
("Navigation destination that matches route Permission/... cannot be
found") when the navigate() call landed after the Applications screen
was no longer the current destination — e.g. a rapid second tap, or a
tap arriving while the NavHost graph is being recreated by the
localRoute LaunchedEffect.

Guard the navigation so it only fires while still on the Applications
route, and wrap it in runCatching as a safety net so a transient
navigation state can no longer crash the app.