### PR TITLE
Suppress duplicate relay status notifications

### DIFF
--- a/app/src/main/java/com/greenart7c3/nostrsigner/relays/AmberRelayStat.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/relays/AmberRelayStat.kt
@@ -221,6 +221,7 @@ class AmberRelayStats(
                             .setSummaryText(appContext.getString(R.string.status_detail)),
                     )
                     .setPriority(NotificationCompat.PRIORITY_MIN)
+                    .setOnlyAlertOnce(true)
                     .setSmallIcon(R.drawable.ic_notification)
                     .setContentIntent(contentPendingIntent)
                     .addAction(R.drawable.ic_notification, appContext.getString(R.string.reconnect), reconnectPendingIntent)


### PR DESCRIPTION
## Summary
Prevent relay status notifications from alerting the user multiple times by adding `setOnlyAlertOnce(true)` to the notification builder.

## Changes
- Added `setOnlyAlertOnce(true)` to the relay status notification in `AmberRelayStats`
  - This ensures the notification only alerts once when first posted, rather than alerting again on subsequent updates
  - Reduces notification spam while maintaining the persistent status indicator

## Details
The relay status notification is updated frequently as connection state changes. Without `setOnlyAlertOnce(true)`, each update would trigger a new alert (sound/vibration), creating a poor user experience. This flag preserves the notification's visibility while suppressing redundant alerts.

https://claude.ai/code/session_01UDridG2rFN2kncn1HxZ1oq