### PR TITLE
feat: add export/share button to the Logs screen

### DIFF
--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/LogsScreen.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/LogsScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.core.content.FileProvider
 import androidx.paging.Pager
 import androidx.paging.PagingConfig
 import androidx.paging.compose.collectAsLazyPagingItems
@@ -32,6 +33,7 @@ import com.greenart7c3.nostrsigner.R
 import com.greenart7c3.nostrsigner.models.Account
 import com.greenart7c3.nostrsigner.models.TimeUtils
 import com.greenart7c3.nostrsigner.ui.components.AmberButton
+import java.io.File
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
@@ -86,12 +88,21 @@ fun LogsScreen(
                                         TimeUtils.formatLongToCustomDateTimeWithSeconds(log.time)
                                     "$time | ${log.url} | ${log.type} | ${log.message}"
                                 }
+                            val logsFile = File(context.cacheDir, "amber-logs.txt")
+                            logsFile.writeText(logsText)
+                            val logsUri =
+                                FileProvider.getUriForFile(
+                                    context,
+                                    "${context.packageName}.fileprovider",
+                                    logsFile,
+                                )
 
                             withContext(Dispatchers.Main) {
                                 val shareIntent =
                                     Intent(Intent.ACTION_SEND).apply {
                                         type = "text/plain"
-                                        putExtra(Intent.EXTRA_TEXT, logsText)
+                                        putExtra(Intent.EXTRA_STREAM, logsUri)
+                                        addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
                                     }
 
                                 context.startActivity(

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/LogsScreen.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/LogsScreen.kt
@@ -1,11 +1,13 @@
 package com.greenart7c3.nostrsigner.ui
 
+import android.content.Intent
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -17,6 +19,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -30,7 +33,9 @@ import com.greenart7c3.nostrsigner.models.Account
 import com.greenart7c3.nostrsigner.models.TimeUtils
 import com.greenart7c3.nostrsigner.ui.components.AmberButton
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 @Composable
 fun LogsScreen(
@@ -38,6 +43,7 @@ fun LogsScreen(
     account: Account,
 ) {
     val scope = rememberCoroutineScope()
+    val context = LocalContext.current
     val pager =
         Pager(
             PagingConfig(
@@ -58,15 +64,57 @@ fun LogsScreen(
         contentPadding = paddingValues,
     ) {
         item {
-            AmberButton(
-                modifier = Modifier.padding(bottom = 8.dp),
-                onClick = {
-                    scope.launch(Dispatchers.IO) {
-                        Amber.instance.getLogDatabase(account.npub).dao().clearLogs()
-                    }
-                },
-                text = stringResource(R.string.clear_logs),
-            )
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = 8.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                AmberButton(
+                    modifier = Modifier.weight(1f),
+                    onClick = {
+                        scope.launch(Dispatchers.IO) {
+                            val logs =
+                                Amber.instance
+                                    .getLogDatabase(account.npub)
+                                    .dao()
+                                    .getLogs()
+                                    .first()
+                            val logsText =
+                                logs.joinToString("\n") { log ->
+                                    val time =
+                                        TimeUtils.formatLongToCustomDateTimeWithSeconds(log.time)
+                                    "$time | ${log.url} | ${log.type} | ${log.message}"
+                                }
+
+                            withContext(Dispatchers.Main) {
+                                val shareIntent =
+                                    Intent(Intent.ACTION_SEND).apply {
+                                        type = "text/plain"
+                                        putExtra(Intent.EXTRA_TEXT, logsText)
+                                    }
+
+                                context.startActivity(
+                                    Intent.createChooser(
+                                        shareIntent,
+                                        context.getString(R.string.export_logs),
+                                    ),
+                                )
+                            }
+                        }
+                    },
+                    text = stringResource(R.string.export_logs),
+                )
+                AmberButton(
+                    modifier = Modifier.weight(1f),
+                    onClick = {
+                        scope.launch(Dispatchers.IO) {
+                            Amber.instance.getLogDatabase(account.npub).dao().clearLogs()
+                        }
+                    },
+                    text = stringResource(R.string.clear_logs),
+                )
+            }
         }
         items(lazyPagingItems.itemCount) { index ->
             val log = lazyPagingItems[index]

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -240,6 +240,7 @@
     <string name="event_kind_10013">Private outbox relay list</string>
     <string name="save">Save</string>
     <string name="logs">Logs</string>
+    <string name="export_logs">Export logs</string>
     <string name="clear_logs">Clear logs</string>
     <string name="default_relays">Default relays</string>
     <string name="requests">requests</string>


### PR DESCRIPTION
## Summary

The Logs screen gets an "Export logs" action that writes the current account's logs to a cache file and shares it via a `content://` FileProvider URI, so users can get logs off the device for diagnosis. Previously the screen only offered "Clear logs" and read-only paging.

## Why this matters

#468 is an active connection-debugging thread where the reporter asked to send the in-app logs and @greenart7c3 confirmed on 2026-06-12 that export was not implemented ("ia falar pra você exportar aí lembrei que nao implementei isso"). Sharing through a FileProvider URI rather than `EXTRA_TEXT` matters because logs near the 1000-entry cap, with embedded event/bunker JSON, can exceed Android's Binder transaction limit and fail the share — the file-based path avoids that.

## Testing

Manual: exported logs from an account with a full log buffer; the share sheet opens and the receiving app gets the complete log file. New `R.string` added for the action label.

Fixes #468
