### PR TITLE
Fix LazyColumn duplicate key crash from racy bunker request dedup

### DIFF
--- a/app/src/main/java/com/greenart7c3/nostrsigner/service/BunkerRequestUtils.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/service/BunkerRequestUtils.kt
@@ -41,14 +41,20 @@ import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 object BunkerRequestUtils {
     val state = MutableStateFlow<ImmutableList<AmberBunkerRequest>>(persistentListOf())
 
     fun addRequest(request: AmberBunkerRequest) {
-        if (state.value.any { it.request.id == request.request.id }) return
-        state.tryEmit((state.value + request).toPersistentList())
+        state.update { current ->
+            if (current.any { it.request.id == request.request.id }) {
+                current
+            } else {
+                (current + request).toPersistentList()
+            }
+        }
     }
 
     fun clearRequests() {
@@ -56,7 +62,9 @@ object BunkerRequestUtils {
     }
 
     fun remove(id: String) {
-        state.tryEmit(state.value.filter { it.request.id != id }.toPersistentList())
+        state.update { current ->
+            current.filter { it.request.id != id }.toPersistentList()
+        }
     }
 
     fun getBunkerRequests(): List<AmberBunkerRequest> = state.value

--- a/app/src/test/java/com/greenart7c3/nostrsigner/service/BunkerRequestUtilsTest.kt
+++ b/app/src/test/java/com/greenart7c3/nostrsigner/service/BunkerRequestUtilsTest.kt
@@ -6,6 +6,9 @@ import com.greenart7c3.nostrsigner.models.SignerType
 import com.vitorpamplona.quartz.nip46RemoteSigner.BunkerRequest
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.joinAll
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -266,6 +269,18 @@ class BunkerRequestUtilsTest {
         val request = createAmberBunkerRequest("id1")
         BunkerRequestUtils.addRequest(request)
         BunkerRequestUtils.addRequest(request)
+        assertEquals(1, BunkerRequestUtils.getBunkerRequests().size)
+    }
+
+    @Test
+    fun `addRequest is safe under concurrent duplicate ids`() = runBlocking {
+        // The same NIP-46 request id can be delivered concurrently by multiple
+        // relays. A TOCTOU race in addRequest used to let duplicates through,
+        // producing duplicate LazyColumn keys and crashing the UI.
+        val request = createAmberBunkerRequest("17856")
+        (1..200).map {
+            launch(Dispatchers.Default) { BunkerRequestUtils.addRequest(request) }
+        }.joinAll()
         assertEquals(1, BunkerRequestUtils.getBunkerRequests().size)
     }
 


### PR DESCRIPTION
The check-then-emit in BunkerRequestUtils.addRequest was not atomic, so
concurrent NIP-46 requests with the same id (delivered by multiple relays)
could both pass the duplicate check and be appended, producing duplicate
request ids in the state and crashing the bunker LazyColumn with
'Key already used'.

Make addRequest and remove atomic via MutableStateFlow.update {}, mirroring
the existing IntentUtils.addAll pattern, and add a concurrency regression test.

https://claude.ai/code/session_01ViM4xaupBbYA8rNNwW49Ub