### PR TITLE
Use default relays for new relay-delivered bunker connections

### DIFF
--- a/app/src/main/java/com/greenart7c3/nostrsigner/service/BunkerRequestUtils.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/service/BunkerRequestUtils.kt
@@ -314,7 +314,17 @@ object BunkerRequestUtils {
             if (bunkerRequest.request is BunkerRequestConnect) {
                 savedApplication?.application?.deleteAfter = deleteAfter
             }
-            val relays = savedApplication?.application?.relays?.ifEmpty { defaultRelays } ?: bunkerRequest.relays.ifEmpty { defaultRelays }
+            // For a brand-new connection, only honor bunkerRequest.relays when they came
+            // from a nostrconnect:// URI (client-specified). Relay-delivered bunker
+            // requests carry just the single relay that delivered the event, which may be
+            // a write-restricted indexer/profile relay — fall back to the configured
+            // default relays instead.
+            val newConnectionRelays = if (bunkerRequest.isNostrConnectUri) {
+                bunkerRequest.relays.ifEmpty { defaultRelays }
+            } else {
+                defaultRelays
+            }
+            val relays = savedApplication?.application?.relays?.ifEmpty { defaultRelays } ?: newConnectionRelays
             val secret = if (bunkerRequest.request is BunkerRequestConnect) bunkerRequest.request.secret ?: "" else ""
 
             var application =
@@ -529,7 +539,15 @@ object BunkerRequestUtils {
         Amber.instance.applicationIOScope.launch(Dispatchers.IO) {
             val savedApplication = Amber.instance.dao(account.npub).getByKey(key)
             val defaultRelays = Amber.instance.settings.defaultRelays
-            val relays = savedApplication?.application?.relays?.ifEmpty { defaultRelays } ?: bunkerRequest.relays.ifEmpty { defaultRelays }
+            // Mirror sendResult: a brand-new connection only honors bunkerRequest.relays
+            // for nostrconnect:// URIs. Relay-delivered requests fall back to the
+            // configured default relays rather than the single delivering relay.
+            val newConnectionRelays = if (bunkerRequest.isNostrConnectUri) {
+                bunkerRequest.relays.ifEmpty { defaultRelays }
+            } else {
+                defaultRelays
+            }
+            val relays = savedApplication?.application?.relays?.ifEmpty { defaultRelays } ?: newConnectionRelays
 
             val secret = if (bunkerRequest.request is BunkerRequestConnect) bunkerRequest.request.secret ?: "" else ""
 

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/actions/EditRelaysDialog.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/actions/EditRelaysDialog.kt
@@ -14,8 +14,10 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.ContentPaste
@@ -68,6 +70,7 @@ import com.greenart7c3.nostrsigner.ui.CenterCircularProgressIndicator
 import com.greenart7c3.nostrsigner.ui.RelayCard
 import com.greenart7c3.nostrsigner.ui.ToastManager
 import com.greenart7c3.nostrsigner.ui.components.AmberButton
+import com.greenart7c3.nostrsigner.ui.components.SectionLabel
 import com.greenart7c3.nostrsigner.ui.components.TrustScoreBadge
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.core.toHexKey
@@ -590,23 +593,30 @@ fun ActiveRelaysScreen(
     account: Account,
 ) {
     val scope = rememberCoroutineScope()
-    val relays2 =
-        remember {
-            mutableStateListOf<NormalizedRelayUrl>()
-        }
+    // Relays configured as defaults — these are used for every new connection.
+    val defaultRelays = remember { mutableStateListOf<NormalizedRelayUrl>() }
+    // Relays that existing connections still use but that are not part of the
+    // default set. Shown separately so it is clear they come from individual app
+    // connections, not from the default relay settings.
+    val connectionRelays = remember { mutableStateListOf<NormalizedRelayUrl>() }
     val trustScores = remember { mutableStateMapOf<String, Int?>() }
     val loadingScores = remember { mutableStateMapOf<String, Boolean>() }
 
     LaunchedEffect(Unit) {
         withContext(Dispatchers.IO) {
-            relays2.addAll(Amber.instance.getSavedRelays(account) + Amber.instance.settings.defaultRelays)
+            val defaults = Amber.instance.settings.defaultRelays
+            val saved = Amber.instance.getSavedRelays(account)
+            defaultRelays.clear()
+            defaultRelays.addAll(defaults.distinct())
+            connectionRelays.clear()
+            connectionRelays.addAll(saved.filterNot { it in defaults })
         }
     }
 
-    // Fetch trust scores for all relays
-    LaunchedEffect(relays2.toList()) {
+    // Fetch trust scores for every relay shown
+    LaunchedEffect(defaultRelays.toList(), connectionRelays.toList()) {
         if (!BuildFlavorChecker.isOfflineFlavor()) {
-            relays2.forEach { relay ->
+            (defaultRelays + connectionRelays).forEach { relay ->
                 val url = relay.url
                 if (!trustScores.containsKey(url)) {
                     loadingScores[url] = true
@@ -622,73 +632,103 @@ fun ActiveRelaysScreen(
 
     Column(
         modifier = modifier
-            .fillMaxSize(),
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState()),
     ) {
-        relays2.forEach { relay ->
+        SectionLabel(stringResource(R.string.default_relays))
+        Text(
+            text = stringResource(R.string.active_relays_default_description),
+            fontSize = 14.sp,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        defaultRelays.forEach { relay ->
+            ActiveRelayRow(relay, trustScores, loadingScores, navController)
+        }
+
+        if (connectionRelays.isNotEmpty()) {
+            SectionLabel(stringResource(R.string.relays_used_by_connections))
+            Text(
+                text = stringResource(R.string.active_relays_connections_description),
+                fontSize = 14.sp,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            connectionRelays.forEach { relay ->
+                ActiveRelayRow(relay, trustScores, loadingScores, navController)
+            }
+        }
+    }
+}
+
+@SuppressLint("StateFlowValueCalledInComposition")
+@Composable
+private fun ActiveRelayRow(
+    relay: NormalizedRelayUrl,
+    trustScores: Map<String, Int?>,
+    loadingScores: Map<String, Boolean>,
+    navController: NavController,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 4.dp)
+            .clickable {
+                navController.navigate(
+                    "RelayLogScreen/${
+                        Base64
+                            .getEncoder()
+                            .encodeToString(relay.url.toByteArray())
+                    }",
+                )
+            },
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(
+            verticalArrangement = Arrangement.Center,
+        ) {
+            val isConnected by remember(relay) {
+                Amber.instance.client.connectedRelaysFlow().map { status ->
+                    relay in status
+                }
+            }.collectAsStateWithLifecycle(relay in Amber.instance.client.connectedRelaysFlow().value)
+
             Row(
                 modifier = Modifier
-                    .fillMaxSize()
-                    .padding(vertical = 4.dp)
-                    .clickable {
-                        navController.navigate(
-                            "RelayLogScreen/${
-                                Base64
-                                    .getEncoder()
-                                    .encodeToString(relay.url.toByteArray())
-                            }",
-                        )
-                    },
+                    .fillMaxWidth()
+                    .padding(top = 16.dp),
+                horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                Column(
-                    verticalArrangement = Arrangement.Center,
-                ) {
-                    val isConnected by remember(relay) {
-                        Amber.instance.client.connectedRelaysFlow().map { status ->
-                            relay in status
-                        }
-                    }.collectAsStateWithLifecycle(relay in Amber.instance.client.connectedRelaysFlow().value)
-
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(top = 16.dp),
-                        horizontalArrangement = Arrangement.SpaceBetween,
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        Text(
-                            modifier = Modifier.weight(1f),
-                            text = relay.url,
-                            fontSize = 24.sp,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
-                            color = if (isConnected) Color.Unspecified else Color.Gray,
-                        )
-                        TrustScoreBadge(
-                            score = trustScores[relay.url],
-                            isLoading = loadingScores[relay.url] == true,
-                        )
-                    }
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.SpaceBetween,
-                    ) {
-                        Text(
-                            modifier = Modifier.padding(top = 4.dp, bottom = 16.dp),
-                            text = if (isConnected) "${Amber.instance.relayStats.get(relay).pingInMs}ms ping" else "Unavailable",
-                            fontSize = 16.sp,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
-                            color = if (isConnected) Color.Unspecified else Color.Gray,
-                        )
-                    }
-
-                    Spacer(Modifier.weight(1f))
-                    HorizontalDivider(
-                        color = MaterialTheme.colorScheme.primary,
-                    )
-                }
+                Text(
+                    modifier = Modifier.weight(1f),
+                    text = relay.url,
+                    fontSize = 24.sp,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    color = if (isConnected) Color.Unspecified else Color.Gray,
+                )
+                TrustScoreBadge(
+                    score = trustScores[relay.url],
+                    isLoading = loadingScores[relay.url] == true,
+                )
             }
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                Text(
+                    modifier = Modifier.padding(top = 4.dp, bottom = 16.dp),
+                    text = if (isConnected) "${Amber.instance.relayStats.get(relay).pingInMs}ms ping" else "Unavailable",
+                    fontSize = 16.sp,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    color = if (isConnected) Color.Unspecified else Color.Gray,
+                )
+            }
+
+            Spacer(Modifier.weight(1f))
+            HorizontalDivider(
+                color = MaterialTheme.colorScheme.primary,
+            )
         }
     }
 }

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/actions/EditRelaysDialog.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/actions/EditRelaysDialog.kt
@@ -14,10 +14,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.ContentPaste
@@ -632,8 +630,7 @@ fun ActiveRelaysScreen(
 
     Column(
         modifier = modifier
-            .fillMaxSize()
-            .verticalScroll(rememberScrollState()),
+            .fillMaxSize(),
     ) {
         SectionLabel(stringResource(R.string.default_relays))
         Text(

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -446,6 +446,9 @@
     <string name="is_requiring_to_sign_these_events_related_to_permission">%1$s يطلب توقيع هذه الأحداث المتعلقة بإذن %2$s.</string>
     <string name="relay_filter_failed">لا يدعم Relay استرداد أحداث Bunker. هل تريد إضافته على أي حال؟</string>
     <string name="active_relays">Relays النشطة</string>
+    <string name="active_relays_default_description">تُستخدم مع كل اتصال تطبيق جديد.</string>
+    <string name="relays_used_by_connections">Relays الاتصالات</string>
+    <string name="active_relays_connections_description">Relays التي لا تزال الاتصالات الحالية تستخدمها ولكنها ليست ضمن مجموعتك الافتراضية. عدّل اتصالاً لتغيير الـ relays التي يستخدمها.</string>
     <string name="default_profile_relays">Relays الملف الشخصي الافتراضية</string>
     <string name="manage_the_relays_used_to_fetch_your_profile_data">أدِر Relays المستخدمة لجلب بيانات ملفك الشخصي</string>
     <string name="manage_the_relays_used_for_communicating_with_external_applications">أدِر Relays المستخدمة للتواصل مع التطبيقات الخارجية</string>

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -446,6 +446,9 @@
     <string name="is_requiring_to_sign_these_events_related_to_permission">%1$s %2$s অনুমতি সংক্রান্ত এই ইভেন্টগুলো সাইন করতে বলছে।</string>
     <string name="relay_filter_failed">Relay Bunker ইভেন্ট পুনরুদ্ধার সমর্থন করে না। আপনি কি তবুও এটি যোগ করতে চান?</string>
     <string name="active_relays">সক্রিয় relay</string>
+    <string name="active_relays_default_description">প্রতিটি নতুন অ্যাপ সংযোগের জন্য ব্যবহৃত হয়।</string>
+    <string name="relays_used_by_connections">সংযোগের relay</string>
+    <string name="active_relays_connections_description">যে relay গুলো বিদ্যমান সংযোগগুলো এখনও ব্যবহার করে কিন্তু আপনার ডিফল্ট সেটে নেই। কোন relay ব্যবহার করা হবে তা পরিবর্তন করতে একটি সংযোগ সম্পাদনা করুন।</string>
     <string name="default_profile_relays">ডিফল্ট প্রোফাইল relay</string>
     <string name="manage_the_relays_used_to_fetch_your_profile_data">আপনার প্রোফাইল ডেটা আনতে ব্যবহৃত relay পরিচালনা করুন</string>
     <string name="manage_the_relays_used_for_communicating_with_external_applications">বাহ্যিক অ্যাপ্লিকেশনের সাথে যোগাযোগের জন্য ব্যবহৃত relay পরিচালনা করুন</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -446,6 +446,9 @@
     <string name="is_requiring_to_sign_these_events_related_to_permission">%1$s požaduje podpis těchto událostí souvisejících s oprávněním %2$s.</string>
     <string name="relay_filter_failed">Relay nepodporuje načítání událostí bunkeru. Chcete ji přesto přidat?</string>
     <string name="active_relays">Aktivní relay</string>
+    <string name="active_relays_default_description">Použito pro každé nové připojení aplikace.</string>
+    <string name="relays_used_by_connections">Relay připojení</string>
+    <string name="active_relays_connections_description">Relay, které stávající připojení stále používají, ale nejsou ve vaší výchozí sadě. Upravte připojení a změňte relay, které používá.</string>
     <string name="default_profile_relays">Výchozí relay profilu</string>
     <string name="manage_the_relays_used_to_fetch_your_profile_data">Spravujte relay používané k načítání dat vašeho profilu</string>
     <string name="manage_the_relays_used_for_communicating_with_external_applications">Spravujte relay používané pro komunikaci s externími aplikacemi</string>

--- a/app/src/main/res/values-cy-rGB/strings.xml
+++ b/app/src/main/res/values-cy-rGB/strings.xml
@@ -446,6 +446,9 @@
     <string name="is_requiring_to_sign_these_events_related_to_permission">Mae %1$s yn gofyn am lofnodi\'r digwyddiadau hyn sy\'n ymwneud â chaniatâd %2$s.</string>
     <string name="relay_filter_failed">Nid yw\'r relay yn cefnogi adalw digwyddiadau Bunker. A hoffech ei ychwanegu beth bynnag?</string>
     <string name="active_relays">Relays gweithredol</string>
+    <string name="active_relays_default_description">Defnyddir ar gyfer pob cysylltiad app newydd.</string>
+    <string name="relays_used_by_connections">Relays cysylltiadau</string>
+    <string name="active_relays_connections_description">Relays y mae cysylltiadau presennol yn dal i\'w defnyddio ond nad ydynt yn eich set ddiofyn. Golygwch gysylltiad i newid y relays y mae\'n eu defnyddio.</string>
     <string name="default_profile_relays">Relays proffil rhagosodedig</string>
     <string name="manage_the_relays_used_to_fetch_your_profile_data">Rheoli\'r relays a ddefnyddir i nôl data eich proffil</string>
     <string name="manage_the_relays_used_for_communicating_with_external_applications">Rheoli\'r relays a ddefnyddir i gyfathrebu â chymwysiadau allanol</string>

--- a/app/src/main/res/values-da-rDK/strings.xml
+++ b/app/src/main/res/values-da-rDK/strings.xml
@@ -446,6 +446,9 @@
     <string name="is_requiring_to_sign_these_events_related_to_permission">%1$s kræver underskrivelse af disse begivenheder relateret til %2$s-tilladelse.</string>
     <string name="relay_filter_failed">Relay understøtter ikke hentning af Bunker-begivenheder. Vil du tilføje det alligevel?</string>
     <string name="active_relays">Aktive relays</string>
+    <string name="active_relays_default_description">Bruges til hver ny app-forbindelse.</string>
+    <string name="relays_used_by_connections">Forbindelsesrelays</string>
+    <string name="active_relays_connections_description">Relays som eksisterende forbindelser stadig bruger, men som ikke er i dit standardsæt. Rediger en forbindelse for at ændre de relays, den bruger.</string>
     <string name="default_profile_relays">Standard profilrelays</string>
     <string name="manage_the_relays_used_to_fetch_your_profile_data">Administrer de relays, der bruges til at hente dine profildata</string>
     <string name="manage_the_relays_used_for_communicating_with_external_applications">Administrer de relays, der bruges til kommunikation med eksterne applikationer</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -443,6 +443,9 @@
     <string name="is_requiring_to_sign_these_events_related_to_permission">%1$s fordert die Signierung dieser Ereignisse im Zusammenhang mit der Berechtigung %2$s an.</string>
     <string name="relay_filter_failed">Der Relay unterstützt das Abrufen von Bunker-Ereignissen nicht. Möchtest du ihn trotzdem hinzufügen?</string>
     <string name="active_relays">Aktive Relays</string>
+    <string name="active_relays_default_description">Wird für jede neue App-Verbindung verwendet.</string>
+    <string name="relays_used_by_connections">Verbindungs-Relays</string>
+    <string name="active_relays_connections_description">Relays, die bestehende Verbindungen noch verwenden, die aber nicht in deinem Standardsatz enthalten sind. Bearbeite eine Verbindung, um die von ihr verwendeten Relays zu ändern.</string>
     <string name="default_profile_relays">Standard-Profil-Relays</string>
     <string name="manage_the_relays_used_to_fetch_your_profile_data">Verwalte die Relays, die zum Abrufen deiner Profildaten verwendet werden</string>
     <string name="manage_the_relays_used_for_communicating_with_external_applications">Verwalte die Relays, die zur Kommunikation mit externen Anwendungen verwendet werden</string>

--- a/app/src/main/res/values-el-rGR/strings.xml
+++ b/app/src/main/res/values-el-rGR/strings.xml
@@ -446,6 +446,9 @@
     <string name="is_requiring_to_sign_these_events_related_to_permission">Το %1$s ζητά να υπογράψετε αυτά τα συμβάντα που σχετίζονται με την άδεια %2$s.</string>
     <string name="relay_filter_failed">Το relay δεν υποστηρίζει ανάκτηση συμβάντων Bunker. Θέλετε να το προσθέσετε παρόλα αυτά;</string>
     <string name="active_relays">Ενεργά relay</string>
+    <string name="active_relays_default_description">Χρησιμοποιείται για κάθε νέα σύνδεση εφαρμογής.</string>
+    <string name="relays_used_by_connections">Relay συνδέσεων</string>
+    <string name="active_relays_connections_description">Relay που οι υπάρχουσες συνδέσεις εξακολουθούν να χρησιμοποιούν αλλά δεν βρίσκονται στο προεπιλεγμένο σας σύνολο. Επεξεργαστείτε μια σύνδεση για να αλλάξετε τα relay που χρησιμοποιεί.</string>
     <string name="default_profile_relays">Προεπιλεγμένα relay προφίλ</string>
     <string name="manage_the_relays_used_to_fetch_your_profile_data">Διαχείριση των relay που χρησιμοποιούνται για την ανάκτηση δεδομένων προφίλ σας</string>
     <string name="manage_the_relays_used_for_communicating_with_external_applications">Διαχείριση των relay που χρησιμοποιούνται για επικοινωνία με εξωτερικές εφαρμογές</string>

--- a/app/src/main/res/values-en-rGB/strings.xml
+++ b/app/src/main/res/values-en-rGB/strings.xml
@@ -422,6 +422,9 @@
     <string name="is_requiring_to_sign_these_events_related_to_permission">%1$s is requiring to sign these events related to %2$s permission.</string>
     <string name="relay_filter_failed">Relay does not support retrieving Bunker events. Would you like to add it anyway?</string>
     <string name="active_relays">Active relays</string>
+    <string name="active_relays_default_description">Used for every new app connection.</string>
+    <string name="relays_used_by_connections">Connection relays</string>
+    <string name="active_relays_connections_description">Relays that existing connections still use but that are not in your default set. Edit a connection to change the relays it uses.</string>
     <string name="default_profile_relays">Default profile relays</string>
     <string name="manage_the_relays_used_to_fetch_your_profile_data">Manage the relays used to fetch your profile data</string>
     <string name="manage_the_relays_used_for_communicating_with_external_applications">Manage the relays used for communicating with external applications</string>

--- a/app/src/main/res/values-eo/strings.xml
+++ b/app/src/main/res/values-eo/strings.xml
@@ -446,6 +446,9 @@
     <string name="is_requiring_to_sign_these_events_related_to_permission">%1$s postulas subskribi tiujn ĉi eventojn rilatajn al la permeso %2$s.</string>
     <string name="relay_filter_failed">Relay ne subtenas preni Bunker-eventojn. Ĉu vi volas aldoni ĝin tamen?</string>
     <string name="active_relays">Aktivaj relay-oj</string>
+    <string name="active_relays_default_description">Uzata por ĉiu nova konekto de aplikaĵo.</string>
+    <string name="relays_used_by_connections">Relay-oj de konektoj</string>
+    <string name="active_relays_connections_description">Relay-oj kiujn ekzistantaj konektoj ankoraŭ uzas sed kiuj ne estas en via defaŭlta aro. Redaktu konekton por ŝanĝi la relay-ojn kiujn ĝi uzas.</string>
     <string name="default_profile_relays">Defaŭltaj profilaj relay-oj</string>
     <string name="manage_the_relays_used_to_fetch_your_profile_data">Administri la relay-ojn uzatajn por alporti viajn profildatumojn</string>
     <string name="manage_the_relays_used_for_communicating_with_external_applications">Administri la relay-ojn uzatajn por komuniki kun eksteraj aplikaĵoj</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -446,6 +446,9 @@
     <string name="is_requiring_to_sign_these_events_related_to_permission">%1$s está solicitando firmar estos eventos relacionados con el permiso %2$s.</string>
     <string name="relay_filter_failed">El relay no permite recuperar eventos de Bunker. ¿Deseas añadirlo de todas formas?</string>
     <string name="active_relays">Relays activos</string>
+    <string name="active_relays_default_description">Se usa para cada nueva conexión de aplicación.</string>
+    <string name="relays_used_by_connections">Relays de conexiones</string>
+    <string name="active_relays_connections_description">Relays que las conexiones existentes aún usan pero que no están en tu conjunto predeterminado. Edita una conexión para cambiar los relays que utiliza.</string>
     <string name="default_profile_relays">Relays de perfil predeterminados</string>
     <string name="manage_the_relays_used_to_fetch_your_profile_data">Gestiona los relays usados para obtener los datos de tu perfil</string>
     <string name="manage_the_relays_used_for_communicating_with_external_applications">Gestiona los relays usados para comunicarse con aplicaciones externas</string>

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -422,6 +422,9 @@
     <string name="is_requiring_to_sign_these_events_related_to_permission">%1$s está solicitando firmar estos eventos relacionados con el permiso %2$s.</string>
     <string name="relay_filter_failed">El relay no admite la recuperación de eventos Bunker. ¿Deseas agregarlo de todas formas?</string>
     <string name="active_relays">Relays activos</string>
+    <string name="active_relays_default_description">Se usa para cada nueva conexión de aplicación.</string>
+    <string name="relays_used_by_connections">Relays de conexiones</string>
+    <string name="active_relays_connections_description">Relays que las conexiones existentes aún usan pero que no están en tu conjunto predeterminado. Edita una conexión para cambiar los relays que utiliza.</string>
     <string name="default_profile_relays">Relays de perfil predeterminados</string>
     <string name="manage_the_relays_used_to_fetch_your_profile_data">Administra los relays usados para obtener los datos de tu perfil</string>
     <string name="manage_the_relays_used_for_communicating_with_external_applications">Administra los relays usados para comunicarse con aplicaciones externas</string>

--- a/app/src/main/res/values-es-rUS/strings.xml
+++ b/app/src/main/res/values-es-rUS/strings.xml
@@ -446,6 +446,9 @@
     <string name="is_requiring_to_sign_these_events_related_to_permission">%1$s está solicitando firmar estos eventos relacionados con el permiso %2$s.</string>
     <string name="relay_filter_failed">El relay no soporta la recuperación de eventos de Bunker. ¿Deseas agregarlo de todas formas?</string>
     <string name="active_relays">Relays activos</string>
+    <string name="active_relays_default_description">Se usa para cada nueva conexión de aplicación.</string>
+    <string name="relays_used_by_connections">Relays de conexiones</string>
+    <string name="active_relays_connections_description">Relays que las conexiones existentes aún usan pero que no están en tu conjunto predeterminado. Edita una conexión para cambiar los relays que utiliza.</string>
     <string name="default_profile_relays">Relays de perfil predeterminados</string>
     <string name="manage_the_relays_used_to_fetch_your_profile_data">Administra los relays utilizados para obtener los datos de tu perfil</string>
     <string name="manage_the_relays_used_for_communicating_with_external_applications">Administra los relays utilizados para comunicarse con aplicaciones externas</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -446,6 +446,9 @@
     <string name="is_requiring_to_sign_these_events_related_to_permission">%1$s solicita firmar estos eventos relacionados con el permiso %2$s.</string>
     <string name="relay_filter_failed">El relay no admite la recuperación de eventos de Bunker. ¿Deseas añadirlo de todas formas?</string>
     <string name="active_relays">Relays activos</string>
+    <string name="active_relays_default_description">Se usa para cada nueva conexión de aplicación.</string>
+    <string name="relays_used_by_connections">Relays de conexiones</string>
+    <string name="active_relays_connections_description">Relays que las conexiones existentes aún usan pero que no están en tu conjunto predeterminado. Edita una conexión para cambiar los relays que utiliza.</string>
     <string name="default_profile_relays">Relays de perfil predeterminados</string>
     <string name="manage_the_relays_used_to_fetch_your_profile_data">Gestiona los relays usados para obtener los datos de tu perfil</string>
     <string name="manage_the_relays_used_for_communicating_with_external_applications">Gestiona los relays usados para comunicarse con aplicaciones externas</string>

--- a/app/src/main/res/values-et-rEE/strings.xml
+++ b/app/src/main/res/values-et-rEE/strings.xml
@@ -422,6 +422,9 @@
     <string name="is_requiring_to_sign_these_events_related_to_permission">%1$s nõuab nende sündmuste allkirjastamist, mis on seotud %2$s õigusega.</string>
     <string name="relay_filter_failed">Relay ei toeta bunkeri sündmuste toomist. Kas soovid selle ikkagi lisada?</string>
     <string name="active_relays">Aktiivsed relayd</string>
+    <string name="active_relays_default_description">Kasutatakse iga uue rakenduse ühenduse jaoks.</string>
+    <string name="relays_used_by_connections">Ühenduste relayd</string>
+    <string name="active_relays_connections_description">Relayd, mida olemasolevad ühendused endiselt kasutavad, kuid mis ei ole sinu vaikekomplektis. Muuda ühendust, et muuta selle kasutatavaid relaysid.</string>
     <string name="default_profile_relays">Vaikimisi profiilirelayd</string>
     <string name="manage_the_relays_used_to_fetch_your_profile_data">Halda relay\'i, mida kasutatakse sinu profiiliandmete toomiseks</string>
     <string name="manage_the_relays_used_for_communicating_with_external_applications">Halda relay\'i, mida kasutatakse väliste rakendustega suhtlemiseks</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -446,6 +446,9 @@
     <string name="is_requiring_to_sign_these_events_related_to_permission">%1$s می‌خواهد این رویدادهای مرتبط با مجوز %2$s را امضا کنید.</string>
     <string name="relay_filter_failed">Relay از بازیابی رویدادهای Bunker پشتیبانی نمی‌کند. آیا می‌خواهید آن را به هر حال اضافه کنید؟</string>
     <string name="active_relays">relay های فعال</string>
+    <string name="active_relays_default_description">برای هر اتصال جدید برنامه استفاده می‌شود.</string>
+    <string name="relays_used_by_connections">relay های اتصال</string>
+    <string name="active_relays_connections_description">relay هایی که اتصالات موجود هنوز از آن‌ها استفاده می‌کنند اما در مجموعه پیش‌فرض شما نیستند. برای تغییر relay هایی که یک اتصال استفاده می‌کند، آن را ویرایش کنید.</string>
     <string name="default_profile_relays">relay های پروفایل پیش‌فرض</string>
     <string name="manage_the_relays_used_to_fetch_your_profile_data">مدیریت relay هایی که برای دریافت داده‌های پروفایل شما استفاده می‌شوند</string>
     <string name="manage_the_relays_used_for_communicating_with_external_applications">مدیریت relay هایی که برای ارتباط با برنامه‌های خارجی استفاده می‌شوند</string>

--- a/app/src/main/res/values-fi-rFI/strings.xml
+++ b/app/src/main/res/values-fi-rFI/strings.xml
@@ -422,6 +422,9 @@
     <string name="is_requiring_to_sign_these_events_related_to_permission">%1$s pyytää allekirjoittamaan nämä tapahtumat, jotka liittyvät %2$s-käyttöoikeuteen.</string>
     <string name="relay_filter_failed">Relay ei tue bunker-tapahtumien hakemista. Haluatko silti lisätä sen?</string>
     <string name="active_relays">Aktiiviset relays</string>
+    <string name="active_relays_default_description">Käytetään jokaisessa uudessa sovellusyhteydessä.</string>
+    <string name="relays_used_by_connections">Yhteyksien relayt</string>
+    <string name="active_relays_connections_description">Relayt, joita olemassa olevat yhteydet yhä käyttävät mutta jotka eivät ole oletusjoukossasi. Muokkaa yhteyttä muuttaaksesi sen käyttämiä relayta.</string>
     <string name="default_profile_relays">Oletusprofiilin relays</string>
     <string name="manage_the_relays_used_to_fetch_your_profile_data">Hallinnoi profiilitietojesi hakemiseen käytettäviä relaita</string>
     <string name="manage_the_relays_used_for_communicating_with_external_applications">Hallinnoi ulkoisten sovellusten kanssa viestintään käytettäviä relaita</string>

--- a/app/src/main/res/values-fo-rFO/strings.xml
+++ b/app/src/main/res/values-fo-rFO/strings.xml
@@ -446,6 +446,9 @@
     <string name="is_requiring_to_sign_these_events_related_to_permission">%1$s biður um at undirskirva hesar hendingar í sambandi við %2$s-loyvi.</string>
     <string name="relay_filter_failed">Relay stuðlar ikki við at inna Bunker-hendingar. Vil tú leggja hann aftrat líkavæl?</string>
     <string name="active_relays">Virkar relays</string>
+    <string name="active_relays_default_description">Brúkt fyri hvørja nýggja app-sambinding.</string>
+    <string name="relays_used_by_connections">Sambindingar-relays</string>
+    <string name="active_relays_connections_description">Relays sum verandi sambindingar enn brúka, men sum ikki eru í tínum standardsetti. Rætta eina sambinding fyri at broyta tey relays hon brúkar.</string>
     <string name="default_profile_relays">Sjálvfaldnar profílrelays</string>
     <string name="manage_the_relays_used_to_fetch_your_profile_data">Stýr relaysslunum, sum eru nýttar til at inna profilgøgn tín</string>
     <string name="manage_the_relays_used_for_communicating_with_external_applications">Stýr relaysslunum, sum eru nýttar til samskifti við uttanhýsis forrit</string>

--- a/app/src/main/res/values-fr-rCA/strings.xml
+++ b/app/src/main/res/values-fr-rCA/strings.xml
@@ -446,6 +446,9 @@
     <string name="is_requiring_to_sign_these_events_related_to_permission">%1$s demande de signer ces événements liés à la permission %2$s.</string>
     <string name="relay_filter_failed">Le relay ne prend pas en charge la récupération des événements bunker. Voulez-vous l\'ajouter quand même?</string>
     <string name="active_relays">Relays actifs</string>
+    <string name="active_relays_default_description">Utilisés pour chaque nouvelle connexion d\'application.</string>
+    <string name="relays_used_by_connections">Relays de connexion</string>
+    <string name="active_relays_connections_description">Relays que les connexions existantes utilisent encore mais qui ne font pas partie de votre ensemble par défaut. Modifiez une connexion pour changer les relays qu\'elle utilise.</string>
     <string name="default_profile_relays">Relays de profil par défaut</string>
     <string name="manage_the_relays_used_to_fetch_your_profile_data">Gérer les relays utilisés pour récupérer vos données de profil</string>
     <string name="manage_the_relays_used_for_communicating_with_external_applications">Gérer les relays utilisés pour communiquer avec les applications externes</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -443,6 +443,9 @@
     <string name="is_requiring_to_sign_these_events_related_to_permission">%1$s demande de signer ces événements liés à la permission %2$s.</string>
     <string name="relay_filter_failed">Le relay ne prend pas en charge la récupération des événements Bunker. Voulez-vous quand même l\'ajouter ?</string>
     <string name="active_relays">Relays actifs</string>
+    <string name="active_relays_default_description">Utilisés pour chaque nouvelle connexion d\'application.</string>
+    <string name="relays_used_by_connections">Relays de connexion</string>
+    <string name="active_relays_connections_description">Relays que les connexions existantes utilisent encore mais qui ne font pas partie de votre ensemble par défaut. Modifiez une connexion pour changer les relays qu\'elle utilise.</string>
     <string name="default_profile_relays">Relays de profil par défaut</string>
     <string name="manage_the_relays_used_to_fetch_your_profile_data">Gérez les relays utilisés pour récupérer les données de votre profil</string>
     <string name="manage_the_relays_used_for_communicating_with_external_applications">Gérez les relays utilisés pour communiquer avec les applications externes</string>

--- a/app/src/main/res/values-gu-rIN/strings.xml
+++ b/app/src/main/res/values-gu-rIN/strings.xml
@@ -446,6 +446,9 @@
     <string name="is_requiring_to_sign_these_events_related_to_permission">%1$s સસ %2$s સસ સસ સસ સસ.</string>
     <string name="relay_filter_failed">Relay Bunker સસ સસ. સસ સસ?</string>
     <string name="active_relays">સસ relays</string>
+    <string name="active_relays_default_description">દરેક નવા એપ કનેક્શન માટે વપરાય છે.</string>
+    <string name="relays_used_by_connections">કનેક્શન relays</string>
+    <string name="active_relays_connections_description">એવા relays જે હાલના કનેક્શન હજુ પણ વાપરે છે પરંતુ જે તમારા ડિફૉલ્ટ સેટમાં નથી. કનેક્શન જે relays વાપરે છે તે બદલવા માટે તે કનેક્શન સંપાદિત કરો.</string>
     <string name="default_profile_relays">સસ સસ relays</string>
     <string name="manage_the_relays_used_to_fetch_your_profile_data">સસ સસ relays સસ</string>
     <string name="manage_the_relays_used_for_communicating_with_external_applications">સસ સસ relays સસ</string>

--- a/app/src/main/res/values-hi-rIN/strings.xml
+++ b/app/src/main/res/values-hi-rIN/strings.xml
@@ -446,6 +446,9 @@
     <string name="is_requiring_to_sign_these_events_related_to_permission">%1$s %2$s अनुमति से संबंधित इन इवेंट को साइन करने के लिए कह रहा है।</string>
     <string name="relay_filter_failed">Relay Bunker इवेंट प्राप्त करने का समर्थन नहीं करता। क्या फिर भी आप इसे जोड़ना चाहते हैं?</string>
     <string name="active_relays">सक्रिय relay</string>
+    <string name="active_relays_default_description">हर नए ऐप कनेक्शन के लिए उपयोग किया जाता है।</string>
+    <string name="relays_used_by_connections">कनेक्शन relay</string>
+    <string name="active_relays_connections_description">ऐसे relay जिन्हें मौजूदा कनेक्शन अभी भी उपयोग करते हैं लेकिन जो आपके डिफ़ॉल्ट सेट में नहीं हैं। किसी कनेक्शन द्वारा उपयोग किए जाने वाले relay बदलने के लिए उस कनेक्शन को संपादित करें।</string>
     <string name="default_profile_relays">डिफ़ॉल्ट प्रोफ़ाइल relay</string>
     <string name="manage_the_relays_used_to_fetch_your_profile_data">आपके प्रोफ़ाइल डेटा लाने के लिए उपयोग की जाने वाली relay प्रबंधित करें</string>
     <string name="manage_the_relays_used_for_communicating_with_external_applications">बाहरी एप्लिकेशन के साथ संचार के लिए उपयोग की जाने वाली relay प्रबंधित करें</string>

--- a/app/src/main/res/values-hr-rHR/strings.xml
+++ b/app/src/main/res/values-hr-rHR/strings.xml
@@ -422,6 +422,9 @@
     <string name="is_requiring_to_sign_these_events_related_to_permission">%1$s zahtijeva potpisivanje ovih događaja koji se odnose na dozvolu %2$s.</string>
     <string name="relay_filter_failed">Relay ne podržava dohvaćanje Bunker događaja. Želite li ga svejedno dodati?</string>
     <string name="active_relays">Aktivni relays</string>
+    <string name="active_relays_default_description">Koriste se za svaku novu vezu aplikacije.</string>
+    <string name="relays_used_by_connections">Relays za veze</string>
+    <string name="active_relays_connections_description">Relays koje postojeće veze i dalje koriste, ali koji nisu u vašem zadanom skupu. Uredite vezu kako biste promijenili relays koje koristi.</string>
     <string name="default_profile_relays">Zadani profilni relays</string>
     <string name="manage_the_relays_used_to_fetch_your_profile_data">Upravljajte relayima koji se koriste za dohvaćanje podataka profila</string>
     <string name="manage_the_relays_used_for_communicating_with_external_applications">Upravljajte relayima koji se koriste za komunikaciju s vanjskim aplikacijama</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -422,6 +422,9 @@
     <string name="is_requiring_to_sign_these_events_related_to_permission">%1$s aláírást kér a %2$s engedélyhez kapcsolódó eseményekre.</string>
     <string name="relay_filter_failed">A relay nem támogatja a Bunker események lekérését. Szeretné mégis hozzáadni?</string>
     <string name="active_relays">Aktív relay-ek</string>
+    <string name="active_relays_default_description">Minden új alkalmazáskapcsolathoz használatos.</string>
+    <string name="relays_used_by_connections">Kapcsolati relay-ek</string>
+    <string name="active_relays_connections_description">Olyan relay-ek, amelyeket a meglévő kapcsolatok még használnak, de nem szerepelnek az alapértelmezett készletedben. Szerkessz egy kapcsolatot az általa használt relay-ek módosításához.</string>
     <string name="default_profile_relays">Alapértelmezett profil relay-ek</string>
     <string name="manage_the_relays_used_to_fetch_your_profile_data">A profil adatok lekéréséhez használt relay-ek kezelése</string>
     <string name="manage_the_relays_used_for_communicating_with_external_applications">A külső alkalmazásokkal való kommunikációhoz használt relay-ek kezelése</string>

--- a/app/src/main/res/values-in-rID/strings.xml
+++ b/app/src/main/res/values-in-rID/strings.xml
@@ -446,6 +446,9 @@
     <string name="is_requiring_to_sign_these_events_related_to_permission">%1$s memerlukan penandatanganan event yang terkait dengan izin %2$s.</string>
     <string name="relay_filter_failed">Relay tidak mendukung pengambilan event Bunker. Apakah Anda ingin menambahkannya tetap saja?</string>
     <string name="active_relays">Relay aktif</string>
+    <string name="active_relays_default_description">Digunakan untuk setiap koneksi aplikasi baru.</string>
+    <string name="relays_used_by_connections">Relay koneksi</string>
+    <string name="active_relays_connections_description">Relay yang masih digunakan oleh koneksi yang ada tetapi tidak termasuk dalam set bawaan Anda. Edit koneksi untuk mengubah relay yang digunakannya.</string>
     <string name="default_profile_relays">Relay profil default</string>
     <string name="manage_the_relays_used_to_fetch_your_profile_data">Kelola relay yang digunakan untuk mengambil data profil Anda</string>
     <string name="manage_the_relays_used_for_communicating_with_external_applications">Kelola relay yang digunakan untuk berkomunikasi dengan aplikasi eksternal</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -446,6 +446,9 @@
     <string name="is_requiring_to_sign_these_events_related_to_permission">%1$s memerlukan penandatanganan event yang terkait dengan izin %2$s.</string>
     <string name="relay_filter_failed">Relay tidak mendukung pengambilan event Bunker. Apakah Anda tetap ingin menambahkannya?</string>
     <string name="active_relays">Relay aktif</string>
+    <string name="active_relays_default_description">Digunakan untuk setiap koneksi aplikasi baru.</string>
+    <string name="relays_used_by_connections">Relay koneksi</string>
+    <string name="active_relays_connections_description">Relay yang masih digunakan oleh koneksi yang ada tetapi tidak termasuk dalam set bawaan Anda. Edit koneksi untuk mengubah relay yang digunakannya.</string>
     <string name="default_profile_relays">Relay profil default</string>
     <string name="manage_the_relays_used_to_fetch_your_profile_data">Kelola relay yang digunakan untuk mengambil data profil Anda</string>
     <string name="manage_the_relays_used_for_communicating_with_external_applications">Kelola relay yang digunakan untuk berkomunikasi dengan aplikasi eksternal</string>

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -446,6 +446,9 @@
     <string name="is_requiring_to_sign_these_events_related_to_permission">%1$s richiede di firmare questi eventi relativi al permesso %2$s.</string>
     <string name="relay_filter_failed">Il relay non supporta il recupero degli eventi Bunker. Vuoi aggiungerlo comunque?</string>
     <string name="active_relays">Relay attivi</string>
+    <string name="active_relays_default_description">Usati per ogni nuova connessione dell\'app.</string>
+    <string name="relays_used_by_connections">Relay di connessione</string>
+    <string name="active_relays_connections_description">Relay che le connessioni esistenti utilizzano ancora ma che non fanno parte del tuo set predefinito. Modifica una connessione per cambiare i relay che utilizza.</string>
     <string name="default_profile_relays">Relay profilo predefiniti</string>
     <string name="manage_the_relays_used_to_fetch_your_profile_data">Gestisci i relay usati per recuperare i dati del tuo profilo</string>
     <string name="manage_the_relays_used_for_communicating_with_external_applications">Gestisci i relay usati per comunicare con le applicazioni esterne</string>

--- a/app/src/main/res/values-iw-rIL/strings.xml
+++ b/app/src/main/res/values-iw-rIL/strings.xml
@@ -422,6 +422,9 @@
     <string name="is_requiring_to_sign_these_events_related_to_permission">%1$s דורש לחתום על אירועים אלה הקשורים להרשאת %2$s.</string>
     <string name="relay_filter_failed">ה-relay אינו תומך באחזור אירועי Bunker. האם להוסיף אותו בכל זאת?</string>
     <string name="active_relays">Relays פעילים</string>
+    <string name="active_relays_default_description">בשימוש עבור כל חיבור אפליקציה חדש.</string>
+    <string name="relays_used_by_connections">Relays של חיבורים</string>
+    <string name="active_relays_connections_description">Relays שחיבורים קיימים עדיין משתמשים בהם אך אינם נמצאים בערכת ברירת המחדל שלך. ערוך חיבור כדי לשנות את ה-relays שבהם הוא משתמש.</string>
     <string name="default_profile_relays">Relays ברירת מחדל לפרופיל</string>
     <string name="manage_the_relays_used_to_fetch_your_profile_data">נהל את ה-relays המשמשים לאחזור נתוני הפרופיל שלך</string>
     <string name="manage_the_relays_used_for_communicating_with_external_applications">נהל את ה-relays המשמשים לתקשורת עם אפליקציות חיצוניות</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -422,6 +422,9 @@
     <string name="is_requiring_to_sign_these_events_related_to_permission">%1$s が %2$s 権限に関連するイベントへの署名を求めています。</string>
     <string name="relay_filter_failed">Relay が Bunker イベントの取得をサポートしていません。それでも追加しますか？</string>
     <string name="active_relays">アクティブな relay</string>
+    <string name="active_relays_default_description">すべての新しいアプリ接続に使用されます。</string>
+    <string name="relays_used_by_connections">接続用 relay</string>
+    <string name="active_relays_connections_description">既存の接続が引き続き使用しているが、デフォルトのセットには含まれていない relay です。接続が使用する relay を変更するには、その接続を編集してください。</string>
     <string name="default_profile_relays">デフォルトプロフィール relay</string>
     <string name="manage_the_relays_used_to_fetch_your_profile_data">プロフィールデータの取得に使用する relay を管理</string>
     <string name="manage_the_relays_used_for_communicating_with_external_applications">外部アプリケーションとの通信に使用する relay を管理</string>

--- a/app/src/main/res/values-kk-rKZ/strings.xml
+++ b/app/src/main/res/values-kk-rKZ/strings.xml
@@ -446,6 +446,9 @@
     <string name="is_requiring_to_sign_these_events_related_to_permission">%1$s %2$s рұқсатына қатысты мына оқиғаларға қол қоюды сұрайды.</string>
     <string name="relay_filter_failed">Relay Bunker оқиғаларын алуды қолдамайды. Дегенмен оны қосқыңыз келе ме?</string>
     <string name="active_relays">Белсенді relay-лар</string>
+    <string name="active_relays_default_description">Әрбір жаңа қолданба қосылымы үшін қолданылады.</string>
+    <string name="relays_used_by_connections">Қосылым relay-лары</string>
+    <string name="active_relays_connections_description">Бар қосылымдар әлі де қолданатын, бірақ әдепкі жиынтығыңызда жоқ relay-лар. Қосылым қолданатын relay-ларды өзгерту үшін сол қосылымды өңдеңіз.</string>
     <string name="default_profile_relays">Профильдің әдепкі relay-лары</string>
     <string name="manage_the_relays_used_to_fetch_your_profile_data">Профиль деректерін алу үшін пайдаланылатын relay-ларды басқарыңыз</string>
     <string name="manage_the_relays_used_for_communicating_with_external_applications">Сыртқы қолданбалармен байланысу үшін пайдаланылатын relay-ларды басқарыңыз</string>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -446,6 +446,9 @@
     <string name="is_requiring_to_sign_these_events_related_to_permission">%1$s이(가) %2$s 권한과 관련된 이벤트에 서명을 요청하고 있습니다.</string>
     <string name="relay_filter_failed">이 relay는 Bunker 이벤트 검색을 지원하지 않습니다. 그래도 추가하시겠습니까?</string>
     <string name="active_relays">활성 relay</string>
+    <string name="active_relays_default_description">모든 새 앱 연결에 사용됩니다.</string>
+    <string name="relays_used_by_connections">연결 relay</string>
+    <string name="active_relays_connections_description">기존 연결이 여전히 사용하지만 기본 설정에는 포함되지 않은 relay입니다. 연결이 사용하는 relay를 변경하려면 해당 연결을 편집하세요.</string>
     <string name="default_profile_relays">기본 프로필 relay</string>
     <string name="manage_the_relays_used_to_fetch_your_profile_data">프로필 데이터를 가져오는 데 사용되는 relay를 관리합니다</string>
     <string name="manage_the_relays_used_for_communicating_with_external_applications">외부 애플리케이션과 통신하는 데 사용되는 relay를 관리합니다</string>

--- a/app/src/main/res/values-ks-rIN/strings.xml
+++ b/app/src/main/res/values-ks-rIN/strings.xml
@@ -422,6 +422,9 @@
     <string name="is_requiring_to_sign_these_events_related_to_permission">%1$s %2$s اجازت سے متعلق اِن ایونٹاں پر دستخط کرنے کیتے کہہ رہیا اِچھ۔</string>
     <string name="relay_filter_failed">Relay، Bunker ایونٹ حاصل کرنے دی حمایت نہیں کردی۔ کیا تُسی پھر بھی اِسے شامل کرنا چاہندے ہو؟</string>
     <string name="active_relays">فعال relays</string>
+    <string name="active_relays_default_description">ہر نئے ایپ کنکشن خاطرٕ استعمال کرنہٕ یوان چھُ۔</string>
+    <string name="relays_used_by_connections">کنکشن relays</string>
+    <string name="active_relays_connections_description">تِم relays یم موجوٗد کنکشن وُنہِ تام استعمال کران چھِ مگر یم توٚہنٛدِس ڈیفالٹ سیٹس منٛز نہٕ چھِ۔ کنکشنہٕ ہنٛد استعمال کرنہٕ آمت relays بدلاونہٕ خاطرٕ سُہ کنکشن ایڈٹ کریو۔</string>
     <string name="default_profile_relays">ڈیفالٹ پروفائل relays</string>
     <string name="manage_the_relays_used_to_fetch_your_profile_data">اپنا پروفائل ڈیٹا حاصل کرنے کیتے استعمال شدہ relays منظم کرو</string>
     <string name="manage_the_relays_used_for_communicating_with_external_applications">بیرونی ایپلی کیشناں سے رابطے کیتے استعمال شدہ relays منظم کرو</string>

--- a/app/src/main/res/values-ku-rTR/strings.xml
+++ b/app/src/main/res/values-ku-rTR/strings.xml
@@ -446,6 +446,9 @@
     <string name="is_requiring_to_sign_these_events_related_to_permission">%1$s dixwaze ku ev bûyerên ku bi destûrnameyê %2$s ve girêdayî ne îmze biken.</string>
     <string name="relay_filter_failed">Relay piştgiriya vekişandina bûyerên Bunker nake. Ma dixwazî wî bi her awayî zêde bikî?</string>
     <string name="active_relays">Relay-ên çalak</string>
+    <string name="active_relays_default_description">Ji bo her girêdana sepanê ya nû tê bikaranîn.</string>
+    <string name="relays_used_by_connections">Relay-ên girêdanê</string>
+    <string name="active_relays_connections_description">Relay-ên ku girêdanên heyî hîn jî bikar tînin lê ne di koma we ya berdest de ne. Girêdanekê biguherîne da ku relay-ên ku ew bikar tîne biguherî.</string>
     <string name="default_profile_relays">Relay-ên profîla xwerû</string>
     <string name="manage_the_relays_used_to_fetch_your_profile_data">Relay-ên ku ji bo vekişandina daneyên profîla te têne bikar anîn birêve bibe</string>
     <string name="manage_the_relays_used_for_communicating_with_external_applications">Relay-ên ku ji bo ragihandina bi sepanên derveyî têne bikar anîn birêve bibe</string>

--- a/app/src/main/res/values-lt-rLT/strings.xml
+++ b/app/src/main/res/values-lt-rLT/strings.xml
@@ -446,6 +446,9 @@
     <string name="is_requiring_to_sign_these_events_related_to_permission">%1$s prašo pasirašyti šiuos įvykius, susijusius su %2$s leidimu.</string>
     <string name="relay_filter_failed">Relay nepalaiko Bunker įvykių gavimo. Ar vis tiek norite jį pridėti?</string>
     <string name="active_relays">Aktyvūs relay</string>
+    <string name="active_relays_default_description">Naudojama kiekvienam naujam programos prisijungimui.</string>
+    <string name="relays_used_by_connections">Prisijungimo relay</string>
+    <string name="active_relays_connections_description">Relay, kuriuos vis dar naudoja esami prisijungimai, bet kurių nėra jūsų numatytajame rinkinyje. Norėdami pakeisti naudojamus relay, redaguokite prisijungimą.</string>
     <string name="default_profile_relays">Numatytieji profilio relay</string>
     <string name="manage_the_relays_used_to_fetch_your_profile_data">Valdykite relay, naudojamus jūsų profilio duomenims gauti</string>
     <string name="manage_the_relays_used_for_communicating_with_external_applications">Valdykite relay, naudojamus bendravimui su išorinėmis programomis</string>

--- a/app/src/main/res/values-ne-rNP/strings.xml
+++ b/app/src/main/res/values-ne-rNP/strings.xml
@@ -446,6 +446,9 @@
     <string name="is_requiring_to_sign_these_events_related_to_permission">%1$s ले %2$s अनुमतिसँग सम्बन्धित यी इभेन्टहरूमा हस्ताक्षर गर्न माग गर्दैछ।</string>
     <string name="relay_filter_failed">Relay ले Bunker इभेन्टहरू पुनःप्राप्त गर्न समर्थन गर्दैन। के तपाईं यसलाई फेरि पनि थप्न चाहनुहुन्छ?</string>
     <string name="active_relays">सक्रिय relays</string>
+    <string name="active_relays_default_description">प्रत्येक नयाँ एप जडानका लागि प्रयोग गरिन्छ।</string>
+    <string name="relays_used_by_connections">जडान relays</string>
+    <string name="active_relays_connections_description">यस्ता relays जुन अवस्थित जडानहरूले अझै प्रयोग गर्छन् तर तपाईंको पूर्वनिर्धारित सेटमा छैनन्। प्रयोग गरिने relays परिवर्तन गर्न जडान सम्पादन गर्नुहोस्।</string>
     <string name="default_profile_relays">पूर्वनिर्धारित प्रोफाइल relays</string>
     <string name="manage_the_relays_used_to_fetch_your_profile_data">तपाईंको प्रोफाइल डेटा प्राप्त गर्न प्रयोग हुने relays व्यवस्थापन गर्नुहोस्</string>
     <string name="manage_the_relays_used_for_communicating_with_external_applications">बाह्य एप्लिकेसनहरूसँग सञ्चार गर्न प्रयोग हुने relays व्यवस्थापन गर्नुहोस्</string>

--- a/app/src/main/res/values-nl-rBE/strings.xml
+++ b/app/src/main/res/values-nl-rBE/strings.xml
@@ -446,6 +446,9 @@
     <string name="is_requiring_to_sign_these_events_related_to_permission">%1$s vraagt om deze events te ondertekenen die verband houden met de machtiging %2$s.</string>
     <string name="relay_filter_failed">Relay ondersteunt het ophalen van bunker-events niet. Wil je het toch toevoegen?</string>
     <string name="active_relays">Actieve relays</string>
+    <string name="active_relays_default_description">Gebruikt voor elke nieuwe app-verbinding.</string>
+    <string name="relays_used_by_connections">Verbindingsrelays</string>
+    <string name="active_relays_connections_description">Relays die bestaande verbindingen nog gebruiken maar die niet in je standaardset zitten. Bewerk een verbinding om de relays die ze gebruikt te wijzigen.</string>
     <string name="default_profile_relays">Standaard profielrelays</string>
     <string name="manage_the_relays_used_to_fetch_your_profile_data">Beheer de relays die gebruikt worden om je profielgegevens op te halen</string>
     <string name="manage_the_relays_used_for_communicating_with_external_applications">Beheer de relays die gebruikt worden voor communicatie met externe applicaties</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -446,6 +446,9 @@
     <string name="is_requiring_to_sign_these_events_related_to_permission">%1$s vraagt deze events te ondertekenen die gerelateerd zijn aan de machtiging %2$s.</string>
     <string name="relay_filter_failed">Relay ondersteunt het ophalen van bunker-events niet. Wil je het toch toevoegen?</string>
     <string name="active_relays">Actieve relays</string>
+    <string name="active_relays_default_description">Gebruikt voor elke nieuwe app-verbinding.</string>
+    <string name="relays_used_by_connections">Verbindingsrelays</string>
+    <string name="active_relays_connections_description">Relays die bestaande verbindingen nog gebruiken maar die niet in je standaardset zitten. Bewerk een verbinding om de relays die ze gebruikt te wijzigen.</string>
     <string name="default_profile_relays">Standaard profielrelays</string>
     <string name="manage_the_relays_used_to_fetch_your_profile_data">Beheer de relays die worden gebruikt om je profielgegevens op te halen</string>
     <string name="manage_the_relays_used_for_communicating_with_external_applications">Beheer de relays die worden gebruikt voor communicatie met externe applicaties</string>

--- a/app/src/main/res/values-pcm-rNG/strings.xml
+++ b/app/src/main/res/values-pcm-rNG/strings.xml
@@ -422,6 +422,9 @@
     <string name="is_requiring_to_sign_these_events_related_to_permission">%1$s dey require make you sign dis events wey related to %2$s permission.</string>
     <string name="relay_filter_failed">Relay no support retrieving Bunker events. You wan add am anyway?</string>
     <string name="active_relays">Active relays</string>
+    <string name="active_relays_default_description">Dem dey use am for every new app connection.</string>
+    <string name="relays_used_by_connections">Connection relays</string>
+    <string name="active_relays_connections_description">Relays wey connections wey don dey before still dey use but wey no dey inside your default set. Edit one connection to change the relays wey e dey use.</string>
     <string name="default_profile_relays">Default profile relays</string>
     <string name="manage_the_relays_used_to_fetch_your_profile_data">Manage di relays wey dey used to fetch your profile data</string>
     <string name="manage_the_relays_used_for_communicating_with_external_applications">Manage di relays wey dey used for communicating with external applications</string>

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -422,6 +422,9 @@
     <string name="is_requiring_to_sign_these_events_related_to_permission">%1$s prosi o podpisanie zdarzeń powiązanych z uprawnieniem %2$s.</string>
     <string name="relay_filter_failed">Relay nie obsługuje pobierania zdarzeń Bunker. Czy chcesz mimo to go dodać?</string>
     <string name="active_relays">Aktywne relay</string>
+    <string name="active_relays_default_description">Używane przy każdym nowym połączeniu aplikacji.</string>
+    <string name="relays_used_by_connections">Relay połączeń</string>
+    <string name="active_relays_connections_description">Relay, których nadal używają istniejące połączenia, ale które nie znajdują się w Twoim domyślnym zestawie. Edytuj połączenie, aby zmienić używane przez nie relay.</string>
     <string name="default_profile_relays">Domyślne relay profilu</string>
     <string name="manage_the_relays_used_to_fetch_your_profile_data">Zarządzaj relay używanymi do pobierania danych profilu</string>
     <string name="manage_the_relays_used_for_communicating_with_external_applications">Zarządzaj relay używanymi do komunikacji z zewnętrznymi aplikacjami</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -441,6 +441,9 @@
     <string name="is_requiring_to_sign_these_events_related_to_permission">%1$s precisa assinar estes eventos relacionados à permissão %2$s.</string>
     <string name="relay_filter_failed">Relay não suporta a busca de eventos do Bunker. Você gostaria de adicioná-lo mesmo assim?</string>
     <string name="active_relays">Relays ativos</string>
+    <string name="active_relays_default_description">Usados em toda nova conexão de aplicativo.</string>
+    <string name="relays_used_by_connections">Relays de conexão</string>
+    <string name="active_relays_connections_description">Relays que as conexões existentes ainda usam, mas que não estão no seu conjunto padrão. Edite uma conexão para alterar os relays que ela usa.</string>
     <string name="default_profile_relays">Relays de perfil padrão</string>
     <string name="manage_the_relays_used_to_fetch_your_profile_data">Gerenciar os relays usados para obter seus dados de perfil</string>
     <string name="manage_the_relays_used_for_communicating_with_external_applications">Gerenciar os relays usados para comunicação com aplicativos externos</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -446,6 +446,9 @@
     <string name="is_requiring_to_sign_these_events_related_to_permission">%1$s está a solicitar a assinatura destes eventos relacionados com a permissão %2$s.</string>
     <string name="relay_filter_failed">O relay não suporta a recuperação de eventos Bunker. Deseja adicioná-lo mesmo assim?</string>
     <string name="active_relays">Relays ativos</string>
+    <string name="active_relays_default_description">Usados em cada nova ligação de aplicação.</string>
+    <string name="relays_used_by_connections">Relays de ligação</string>
+    <string name="active_relays_connections_description">Relays que as ligações existentes ainda utilizam, mas que não estão no seu conjunto predefinido. Edite uma ligação para alterar os relays que esta utiliza.</string>
     <string name="default_profile_relays">Relays de perfil predefinidos</string>
     <string name="manage_the_relays_used_to_fetch_your_profile_data">Gira os relays utilizados para obter os dados do seu perfil</string>
     <string name="manage_the_relays_used_for_communicating_with_external_applications">Gira os relays utilizados para comunicar com aplicações externas</string>

--- a/app/src/main/res/values-ru-rUA/strings.xml
+++ b/app/src/main/res/values-ru-rUA/strings.xml
@@ -446,6 +446,9 @@
     <string name="is_requiring_to_sign_these_events_related_to_permission">%1$s требует подписать события, связанные с разрешением %2$s.</string>
     <string name="relay_filter_failed">Relay не поддерживает получение событий Bunker. Всё равно добавить?</string>
     <string name="active_relays">Активные relay</string>
+    <string name="active_relays_default_description">Используется для каждого нового подключения приложения.</string>
+    <string name="relays_used_by_connections">Relay подключений</string>
+    <string name="active_relays_connections_description">Relay, которые по-прежнему используются существующими подключениями, но которых нет в вашем наборе по умолчанию. Измените подключение, чтобы изменить используемые им relay.</string>
     <string name="default_profile_relays">Relay профиля по умолчанию</string>
     <string name="manage_the_relays_used_to_fetch_your_profile_data">Управляйте relay, используемыми для получения данных вашего профиля</string>
     <string name="manage_the_relays_used_for_communicating_with_external_applications">Управляйте relay, используемыми для связи с внешними приложениями</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -446,6 +446,9 @@
     <string name="is_requiring_to_sign_these_events_related_to_permission">%1$s запрашивает подпись событий, связанных с разрешением %2$s.</string>
     <string name="relay_filter_failed">Relay-сервер не поддерживает получение событий Bunker. Добавить его всё равно?</string>
     <string name="active_relays">Активные relay-серверы</string>
+    <string name="active_relays_default_description">Используется для каждого нового подключения приложения.</string>
+    <string name="relays_used_by_connections">Relay-серверы подключений</string>
+    <string name="active_relays_connections_description">Relay-серверы, которые по-прежнему используются существующими подключениями, но которых нет в вашем наборе по умолчанию. Измените подключение, чтобы изменить используемые им relay-серверы.</string>
     <string name="default_profile_relays">Relay-серверы профиля по умолчанию</string>
     <string name="manage_the_relays_used_to_fetch_your_profile_data">Управление relay-серверами для получения данных профиля</string>
     <string name="manage_the_relays_used_for_communicating_with_external_applications">Управление relay-серверами для связи с внешними приложениями</string>

--- a/app/src/main/res/values-sa-rIN/strings.xml
+++ b/app/src/main/res/values-sa-rIN/strings.xml
@@ -446,6 +446,9 @@
     <string name="is_requiring_to_sign_these_events_related_to_permission">%1$s इन घटनाओं को हस्ताक्षरयितुमिच्छति जाः %2$s अनुमति-सम्बद्धाः सन्ति।</string>
     <string name="relay_filter_failed">Relay Bunker-घटनाः प्राप्तुं समर्थः नास्ति। क्या भवान् तथापि योजयितुमिच्छति?</string>
     <string name="active_relays">सक्रिय-relays</string>
+    <string name="active_relays_default_description">प्रत्येकस्मै नूतनाय अनुप्रयोगसम्बन्धाय उपयुज्यते।</string>
+    <string name="relays_used_by_connections">सम्बन्ध-relays</string>
+    <string name="active_relays_connections_description">यानि relays विद्यमानाः सम्बन्धाः अद्यापि उपयुञ्जते किन्तु यानि भवतः पूर्वनिर्धारितसमुच्चये न सन्ति। उपयुज्यमानानि relays परिवर्तयितुं सम्बन्धं सम्पादयतु।</string>
     <string name="default_profile_relays">पूर्वनिर्धारित-प्रोफ़ाइल-relays</string>
     <string name="manage_the_relays_used_to_fetch_your_profile_data">भवतः प्रोफ़ाइल-दत्तांश-आहरणार्थं उपयुक्त-relays प्रबन्धयतु</string>
     <string name="manage_the_relays_used_for_communicating_with_external_applications">बाह्य-अनुप्रयोगैः संचारार्थं उपयुक्त-relays प्रबन्धयतु</string>

--- a/app/src/main/res/values-sl-rSI/strings.xml
+++ b/app/src/main/res/values-sl-rSI/strings.xml
@@ -446,6 +446,9 @@
     <string name="is_requiring_to_sign_these_events_related_to_permission">%1$s zahteva podpis teh dogodkov, povezanih z dovoljenjem %2$s.</string>
     <string name="relay_filter_failed">Relay strežnik ne podpira pridobivanja Bunker dogodkov. Ali ga želite vseeno dodati?</string>
     <string name="active_relays">Aktivni relay strežniki</string>
+    <string name="active_relays_default_description">Uporabljeno za vsako novo povezavo aplikacije.</string>
+    <string name="relays_used_by_connections">Relay strežniki povezav</string>
+    <string name="active_relays_connections_description">Relay strežniki, ki jih obstoječe povezave še vedno uporabljajo, vendar niso v vašem privzetem naboru. Uredite povezavo, da spremenite relay strežnike, ki jih uporablja.</string>
     <string name="default_profile_relays">Privzeti relay strežniki profila</string>
     <string name="manage_the_relays_used_to_fetch_your_profile_data">Upravljajte relay strežnike, ki se uporabljajo za pridobivanje podatkov vašega profila</string>
     <string name="manage_the_relays_used_for_communicating_with_external_applications">Upravljajte relay strežnike, ki se uporabljajo za komunikacijo z zunanjimi aplikacijami</string>

--- a/app/src/main/res/values-so-rSO/strings.xml
+++ b/app/src/main/res/values-so-rSO/strings.xml
@@ -446,6 +446,9 @@
     <string name="is_requiring_to_sign_these_events_related_to_permission">%1$s waxay codsanaysaa inaad saxiixdo dhacdooyinkan la xiriira fasaxa %2$s.</string>
     <string name="relay_filter_failed">Relay-ku ma taageerayo keenista dhacdooyinka Bunker. Ma rabtaa inaad ku dartid si kastaba?</string>
     <string name="active_relays">Relay-yada firfircoon</string>
+    <string name="active_relays_default_description">Loo isticmaalo xiriir kasta oo cusub oo app.</string>
+    <string name="relays_used_by_connections">Relay-yada xiriirka</string>
+    <string name="active_relays_connections_description">Relay-yada ay xiriirrada jira wali isticmaalaan laakiin aan ku jirin koobkaaga caadiga ah. Wax ka beddel xiriir si aad u beddesho relay-yada uu isticmaalo.</string>
     <string name="default_profile_relays">Relay-yada profile-ka caadiga ah</string>
     <string name="manage_the_relays_used_to_fetch_your_profile_data">Maamul relay-yada la isticmaalo si loo keeno xogta profile-kaaga</string>
     <string name="manage_the_relays_used_for_communicating_with_external_applications">Maamul relay-yada la isticmaalo xiriirka barnaamijyada dibadda</string>

--- a/app/src/main/res/values-sr-rSP/strings.xml
+++ b/app/src/main/res/values-sr-rSP/strings.xml
@@ -422,6 +422,9 @@
     <string name="is_requiring_to_sign_these_events_related_to_permission">%1$s zahteva potpisivanje ovih događaja vezanih za dozvolu %2$s.</string>
     <string name="relay_filter_failed">Relay ne podržava preuzimanje Bunker događaja. Želite li ga svejedno dodati?</string>
     <string name="active_relays">Aktivni relay-i</string>
+    <string name="active_relays_default_description">Koristi se za svako novo povezivanje aplikacije.</string>
+    <string name="relays_used_by_connections">Relay-i veze</string>
+    <string name="active_relays_connections_description">Relay-i koje postojeće veze i dalje koriste, ali koji nisu u vašem podrazumevanom skupu. Izmenite vezu da biste promenili relay-e koje ona koristi.</string>
     <string name="default_profile_relays">Podrazumevani relay-i profila</string>
     <string name="manage_the_relays_used_to_fetch_your_profile_data">Upravljajte relay-ima koji se koriste za preuzimanje podataka profila</string>
     <string name="manage_the_relays_used_for_communicating_with_external_applications">Upravljajte relay-ima koji se koriste za komunikaciju sa spoljnim aplikacijama</string>

--- a/app/src/main/res/values-ss-rZA/strings.xml
+++ b/app/src/main/res/values-ss-rZA/strings.xml
@@ -446,6 +446,9 @@
     <string name="is_requiring_to_sign_these_events_related_to_permission">%1$s udinga kusayina tizigameko letihlobene ne-%2$s imvume.</string>
     <string name="relay_filter_failed">Irelay ayisekeli kukhokhela tizigameko te-Bunker. Ufuna kuyengeta noma kunjalo?</string>
     <string name="active_relays">Tirelay tesebentako</string>
+    <string name="active_relays_default_description">Tisetjentiselwa kuko konkhe kuchumana lokusha kwe-app.</string>
+    <string name="relays_used_by_connections">Tirelay tekuchumana</string>
+    <string name="active_relays_connections_description">Tirelay lesisetjentiswa kuchumana lokukhona kodvwa lokungekho kusethi yakho lebekiwe. Hlela kuchumana kute ushintje tirelay letikusebentisako.</string>
     <string name="default_profile_relays">Tirelay tejwayelekile teprofile</string>
     <string name="manage_the_relays_used_to_fetch_your_profile_data">Phatha tirelay tokulanda idatha yeprofile yakho</string>
     <string name="manage_the_relays_used_for_communicating_with_external_applications">Phatha tirelay tokukhulumana netihlelo tangaphandle</string>

--- a/app/src/main/res/values-sv-rSE/strings.xml
+++ b/app/src/main/res/values-sv-rSE/strings.xml
@@ -422,6 +422,9 @@
     <string name="is_requiring_to_sign_these_events_related_to_permission">%1$s begär att signera dessa händelser relaterade till %2$s behörighet.</string>
     <string name="relay_filter_failed">Reläet stöder inte hämtning av bunker-händelser. Vill du lägga till det ändå?</string>
     <string name="active_relays">Aktiva reläer</string>
+    <string name="active_relays_default_description">Används för varje ny appanslutning.</string>
+    <string name="relays_used_by_connections">Anslutningsreläer</string>
+    <string name="active_relays_connections_description">Reläer som befintliga anslutningar fortfarande använder men som inte finns i din standarduppsättning. Redigera en anslutning för att ändra vilka reläer den använder.</string>
     <string name="default_profile_relays">Standardprofilreläer</string>
     <string name="manage_the_relays_used_to_fetch_your_profile_data">Hantera reläerna som används för att hämta din profildata</string>
     <string name="manage_the_relays_used_for_communicating_with_external_applications">Hantera reläerna som används för kommunikation med externa applikationer</string>

--- a/app/src/main/res/values-sw-rKE/strings.xml
+++ b/app/src/main/res/values-sw-rKE/strings.xml
@@ -440,6 +440,9 @@
     <string name="is_requiring_to_sign_these_events_related_to_permission">%1$s inahitaji kuidhinisha matukio haya yanayohusiana na ruhusa ya %2$s.</string>
     <string name="relay_filter_failed">Relay haisaidii kupata matukio ya Bunker. Je, ungependa kuiongeza hata hivyo?</string>
     <string name="active_relays">Relay zinazofanya kazi</string>
+    <string name="active_relays_default_description">Hutumika kwa kila muunganisho mpya wa programu.</string>
+    <string name="relays_used_by_connections">Relay za miunganisho</string>
+    <string name="active_relays_connections_description">Relay ambazo miunganisho iliyopo bado inazitumia lakini haziko katika seti yako chaguo-msingi. Hariri muunganisho ili kubadilisha relay zinazotumika.</string>
     <string name="default_profile_relays">Relay za chaguo-msingi za wasifu</string>
     <string name="manage_the_relays_used_to_fetch_your_profile_data">Simamia relay zinazotumika kupata data ya wasifu wako</string>
     <string name="manage_the_relays_used_for_communicating_with_external_applications">Simamia relay zinazotumika kuwasiliana na programu za nje</string>

--- a/app/src/main/res/values-sw-rTZ/strings.xml
+++ b/app/src/main/res/values-sw-rTZ/strings.xml
@@ -446,6 +446,9 @@
     <string name="is_requiring_to_sign_these_events_related_to_permission">%1$s inahitaji uweke saini matukio haya yanayohusiana na ruhusa ya %2$s.</string>
     <string name="relay_filter_failed">Relay haisaidii kupata matukio ya Bunker. Je, ungependa kuiongeza hata hivyo?</string>
     <string name="active_relays">Relay zinazofanya kazi</string>
+    <string name="active_relays_default_description">Hutumika kwa kila muunganisho mpya wa programu.</string>
+    <string name="relays_used_by_connections">Relay za miunganisho</string>
+    <string name="active_relays_connections_description">Relay ambazo miunganisho iliyopo bado inazitumia lakini haziko katika seti yako chaguo-msingi. Hariri muunganisho ili kubadilisha relay zinazotumika.</string>
     <string name="default_profile_relays">Relay za chaguomsingi za wasifu</string>
     <string name="manage_the_relays_used_to_fetch_your_profile_data">Simamia relay zinazotumika kupata data ya wasifu wako</string>
     <string name="manage_the_relays_used_for_communicating_with_external_applications">Simamia relay zinazotumika kuwasiliana na programu za nje</string>

--- a/app/src/main/res/values-sw/strings.xml
+++ b/app/src/main/res/values-sw/strings.xml
@@ -446,6 +446,9 @@
     <string name="is_requiring_to_sign_these_events_related_to_permission">%1$s inahitaji kusaini matukio haya yanayohusiana na ruhusa ya %2$s.</string>
     <string name="relay_filter_failed">Relay haiungi mkono kupata matukio ya Bunker. Je, ungependa kuiongeza hata hivyo?</string>
     <string name="active_relays">Relay zinazofanya kazi</string>
+    <string name="active_relays_default_description">Hutumika kwa kila muunganisho mpya wa programu.</string>
+    <string name="relays_used_by_connections">Relay za miunganisho</string>
+    <string name="active_relays_connections_description">Relay ambazo miunganisho iliyopo bado inazitumia lakini haziko katika seti yako chaguo-msingi. Hariri muunganisho ili kubadilisha relay zinazotumika.</string>
     <string name="default_profile_relays">Relay za wasifu wa msingi</string>
     <string name="manage_the_relays_used_to_fetch_your_profile_data">Simamia relay zinazotumika kupata data ya wasifu wako</string>
     <string name="manage_the_relays_used_for_communicating_with_external_applications">Simamia relay zinazotumika kuwasiliana na programu za nje</string>

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -446,6 +446,9 @@
     <string name="is_requiring_to_sign_these_events_related_to_permission">%1$s %2$s அனுமதி தொடர்பான இந்த நிகழ்வுகளில் கையொப்பமிட கோருகிறது.</string>
     <string name="relay_filter_failed">Relay Bunker நிகழ்வுகளை மீட்டெடுப்பதை ஆதரிக்கவில்லை. இருந்தாலும் சேர்க்க விரும்புகிறீர்களா?</string>
     <string name="active_relays">செயலில் உள்ள relays</string>
+    <string name="active_relays_default_description">ஒவ்வொரு புதிய பயன்பாட்டு இணைப்பிற்கும் பயன்படுத்தப்படுகிறது.</string>
+    <string name="relays_used_by_connections">இணைப்பு relays</string>
+    <string name="active_relays_connections_description">ஏற்கனவே உள்ள இணைப்புகள் இன்னும் பயன்படுத்தும் ஆனால் உங்கள் இயல்புநிலை தொகுப்பில் இல்லாத relays. ஒரு இணைப்பு பயன்படுத்தும் relays-ஐ மாற்ற அந்த இணைப்பைத் திருத்தவும்.</string>
     <string name="default_profile_relays">இயல்புநிலை சுயவிவர relays</string>
     <string name="manage_the_relays_used_to_fetch_your_profile_data">உங்கள் சுயவிவர தரவை பெற பயன்படுத்தப்படும் relays ஐ நிர்வகிக்கவும்</string>
     <string name="manage_the_relays_used_for_communicating_with_external_applications">வெளிப்புற பயன்பாடுகளுடன் தொடர்பு கொள்ள பயன்படுத்தப்படும் relays ஐ நிர்வகிக்கவும்</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -422,6 +422,9 @@
     <string name="is_requiring_to_sign_these_events_related_to_permission">%1$s กำลังขอลงนามอีเวนต์เหล่านี้ที่เกี่ยวข้องกับสิทธิ์ %2$s</string>
     <string name="relay_filter_failed">Relay ไม่รองรับการดึงอีเวนต์ Bunker คุณต้องการเพิ่มไว้อยู่ดีหรือไม่?</string>
     <string name="active_relays">Relay ที่ใช้งานอยู่</string>
+    <string name="active_relays_default_description">ใช้สำหรับการเชื่อมต่อแอปใหม่ทุกครั้ง</string>
+    <string name="relays_used_by_connections">Relay ของการเชื่อมต่อ</string>
+    <string name="active_relays_connections_description">Relay ที่การเชื่อมต่อที่มีอยู่ยังคงใช้อยู่ แต่ไม่อยู่ในชุดค่าเริ่มต้นของคุณ แก้ไขการเชื่อมต่อเพื่อเปลี่ยน relay ที่ใช้</string>
     <string name="default_profile_relays">Relay โปรไฟล์เริ่มต้น</string>
     <string name="manage_the_relays_used_to_fetch_your_profile_data">จัดการ relay ที่ใช้สำหรับดึงข้อมูลโปรไฟล์ของคุณ</string>
     <string name="manage_the_relays_used_for_communicating_with_external_applications">จัดการ relay ที่ใช้สำหรับการสื่อสารกับแอปพลิเคชันภายนอก</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -442,6 +442,9 @@
     <string name="is_requiring_to_sign_these_events_related_to_permission">%1$s, %2$s izniyle ilgili bu etkinlikleri imzalamanızı istiyor.</string>
     <string name="relay_filter_failed">Relay, Bunker etkinliklerini almayı desteklemiyor. Yine de eklemek ister misiniz?</string>
     <string name="active_relays">Aktif relay\'ler</string>
+    <string name="active_relays_default_description">Her yeni uygulama bağlantısı için kullanılır.</string>
+    <string name="relays_used_by_connections">Bağlantı relay\'leri</string>
+    <string name="active_relays_connections_description">Mevcut bağlantıların hâlâ kullandığı ancak varsayılan kümenizde olmayan relay\'ler. Bir bağlantının kullandığı relay\'leri değiştirmek için bağlantıyı düzenleyin.</string>
     <string name="default_profile_relays">Varsayılan profil relay\'leri</string>
     <string name="manage_the_relays_used_to_fetch_your_profile_data">Profil verilerinizi getirmek için kullanılan relay\'leri yönetin</string>
     <string name="manage_the_relays_used_for_communicating_with_external_applications">Harici uygulamalarla iletişim için kullanılan relay\'leri yönetin</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -422,6 +422,9 @@
     <string name="is_requiring_to_sign_these_events_related_to_permission">%1$s вимагає підписати ці події, пов\'язані з дозволом %2$s.</string>
     <string name="relay_filter_failed">Relay-сервер не підтримує отримання подій Bunker. Все одно додати його?</string>
     <string name="active_relays">Активні relay-сервери</string>
+    <string name="active_relays_default_description">Використовується для кожного нового підключення застосунку.</string>
+    <string name="relays_used_by_connections">Relay-сервери підключень</string>
+    <string name="active_relays_connections_description">Relay-сервери, які наявні підключення досі використовують, але яких немає у вашому типовому наборі. Відредагуйте підключення, щоб змінити relay-сервери, які воно використовує.</string>
     <string name="default_profile_relays">Relay-сервери профілю за замовчуванням</string>
     <string name="manage_the_relays_used_to_fetch_your_profile_data">Керуйте relay-серверами, що використовуються для отримання даних вашого профілю</string>
     <string name="manage_the_relays_used_for_communicating_with_external_applications">Керуйте relay-серверами, що використовуються для зв\'язку з зовнішніми застосунками</string>

--- a/app/src/main/res/values-ur-rIN/strings.xml
+++ b/app/src/main/res/values-ur-rIN/strings.xml
@@ -446,6 +446,9 @@
     <string name="is_requiring_to_sign_these_events_related_to_permission">%1$s %2$s اجازت سے متعلق ان ایونٹس پر دستخط کرنے کا تقاضا کر رہا ہے۔</string>
     <string name="relay_filter_failed">Relay Bunker ایونٹس بازیاب کرنے کی حمایت نہیں کرتا۔ کیا آپ پھر بھی اسے شامل کرنا چاہتے ہیں؟</string>
     <string name="active_relays">فعال relays</string>
+    <string name="active_relays_default_description">ہر نئے ایپ کنکشن کے لیے استعمال ہوتا ہے۔</string>
+    <string name="relays_used_by_connections">کنکشن relays</string>
+    <string name="active_relays_connections_description">وہ relays جو موجودہ کنکشن اب بھی استعمال کرتے ہیں لیکن جو آپ کے پہلے سے طے شدہ سیٹ میں نہیں ہیں۔ کسی کنکشن کے استعمال کردہ relays کو تبدیل کرنے کے لیے اسے ترمیم کریں۔</string>
     <string name="default_profile_relays">پہلے سے طے شدہ پروفائل relays</string>
     <string name="manage_the_relays_used_to_fetch_your_profile_data">آپ کا پروفائل ڈیٹا لانے کے لیے استعمال ہونے والے relays کا انتظام کریں</string>
     <string name="manage_the_relays_used_for_communicating_with_external_applications">بیرونی ایپلیکیشنز سے مواصلات کے لیے استعمال ہونے والے relays کا انتظام کریں</string>

--- a/app/src/main/res/values-uz-rUZ/strings.xml
+++ b/app/src/main/res/values-uz-rUZ/strings.xml
@@ -446,6 +446,9 @@
     <string name="is_requiring_to_sign_these_events_related_to_permission">%1$s %2$s ruxsatiga oid ushbu voqealarni imzolashni talab qilmoqda.</string>
     <string name="relay_filter_failed">Relay Bunker voqealarini olishni qo\'llab-quvvatlamaydi. Baribir qo\'shmoqchimisiz?</string>
     <string name="active_relays">Faol relay-lar</string>
+    <string name="active_relays_default_description">Har bir yangi ilova ulanishi uchun ishlatiladi.</string>
+    <string name="relays_used_by_connections">Ulanish relay-lari</string>
+    <string name="active_relays_connections_description">Mavjud ulanishlar hali ham foydalanayotgan, lekin sizning standart to\'plamingizda bo\'lmagan relay-lar. Ulanish foydalanadigan relay-larni o\'zgartirish uchun uni tahrirlang.</string>
     <string name="default_profile_relays">Standart profil relay-lari</string>
     <string name="manage_the_relays_used_to_fetch_your_profile_data">Profil ma\'lumotlarini olish uchun ishlatiladigan relay-larni boshqarish</string>
     <string name="manage_the_relays_used_for_communicating_with_external_applications">Tashqi ilovalar bilan muloqot qilish uchun ishlatiladigan relay-larni boshqarish</string>

--- a/app/src/main/res/values-vi-rVN/strings.xml
+++ b/app/src/main/res/values-vi-rVN/strings.xml
@@ -422,6 +422,9 @@
     <string name="is_requiring_to_sign_these_events_related_to_permission">%1$s đang yêu cầu ký các sự kiện liên quan đến quyền %2$s.</string>
     <string name="relay_filter_failed">Relay không hỗ trợ truy xuất sự kiện Bunker. Bạn có muốn thêm nó không?</string>
     <string name="active_relays">Relay đang hoạt động</string>
+    <string name="active_relays_default_description">Được dùng cho mọi kết nối ứng dụng mới.</string>
+    <string name="relays_used_by_connections">Relay kết nối</string>
+    <string name="active_relays_connections_description">Các relay mà những kết nối hiện có vẫn đang dùng nhưng không nằm trong bộ mặc định của bạn. Chỉnh sửa một kết nối để thay đổi các relay mà nó sử dụng.</string>
     <string name="default_profile_relays">Relay hồ sơ mặc định</string>
     <string name="manage_the_relays_used_to_fetch_your_profile_data">Quản lý các relay dùng để tải dữ liệu hồ sơ của bạn</string>
     <string name="manage_the_relays_used_for_communicating_with_external_applications">Quản lý các relay dùng để giao tiếp với các ứng dụng bên ngoài</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -427,6 +427,9 @@
     <string name="is_requiring_to_sign_these_events_related_to_permission">%1$s 正在请求签署与 %2$s 权限相关的事件。</string>
     <string name="relay_filter_failed">Relay 不支持检索 Bunker 事件，是否仍要添加？</string>
     <string name="active_relays">活跃 relay</string>
+    <string name="active_relays_default_description">用于每个新的应用连接。</string>
+    <string name="relays_used_by_connections">连接 relay</string>
+    <string name="active_relays_connections_description">现有连接仍在使用但不在你默认集合中的 relay。编辑某个连接以更改它使用的 relay。</string>
     <string name="default_profile_relays">默认个人资料 relay</string>
     <string name="manage_the_relays_used_to_fetch_your_profile_data">管理用于获取您个人资料数据的 relay</string>
     <string name="manage_the_relays_used_for_communicating_with_external_applications">管理用于与外部应用通信的 relay</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -446,6 +446,9 @@
     <string name="is_requiring_to_sign_these_events_related_to_permission">%1$s 正在要求簽署與 %2$s 權限相關的事件。</string>
     <string name="relay_filter_failed">Relay 不支援取得 Bunker 事件。您仍然要新增嗎？</string>
     <string name="active_relays">使用中的 relays</string>
+    <string name="active_relays_default_description">用於每個新的應用程式連線。</string>
+    <string name="relays_used_by_connections">連線 relay</string>
+    <string name="active_relays_connections_description">現有連線仍在使用但不在你預設集合中的 relay。編輯某個連線即可變更它使用的 relay。</string>
     <string name="default_profile_relays">預設個人資料 relays</string>
     <string name="manage_the_relays_used_to_fetch_your_profile_data">管理用於獲取個人資料資料的 relays</string>
     <string name="manage_the_relays_used_for_communicating_with_external_applications">管理用於與外部應用程式通訊的 relays</string>

--- a/app/src/main/res/values-zh-rMO/strings.xml
+++ b/app/src/main/res/values-zh-rMO/strings.xml
@@ -446,6 +446,9 @@
     <string name="is_requiring_to_sign_these_events_related_to_permission">%1$s 請求簽署與 %2$s 權限相關的這些事件。</string>
     <string name="relay_filter_failed">Relay 不支持獲取 Bunker 事件，是否仍要添加？</string>
     <string name="active_relays">活躍 relays</string>
+    <string name="active_relays_default_description">用於每個新的應用程式連線。</string>
+    <string name="relays_used_by_connections">連線 relay</string>
+    <string name="active_relays_connections_description">現有連線仍在使用但不在你預設集合中的 relay。編輯某個連線即可變更它使用的 relay。</string>
     <string name="default_profile_relays">默認個人資料 relays</string>
     <string name="manage_the_relays_used_to_fetch_your_profile_data">管理用於獲取個人資料數據的 relay</string>
     <string name="manage_the_relays_used_for_communicating_with_external_applications">管理用於與外部應用通信的 relay</string>

--- a/app/src/main/res/values-zh-rSG/strings.xml
+++ b/app/src/main/res/values-zh-rSG/strings.xml
@@ -446,6 +446,9 @@
     <string name="is_requiring_to_sign_these_events_related_to_permission">%1$s 正在请求签署与 %2$s 权限相关的这些事件。</string>
     <string name="relay_filter_failed">Relay 不支持检索 Bunker 事件。是否仍要添加？</string>
     <string name="active_relays">活跃 relay</string>
+    <string name="active_relays_default_description">用于每个新的应用连接。</string>
+    <string name="relays_used_by_connections">连接 relay</string>
+    <string name="active_relays_connections_description">现有连接仍在使用但不在你默认集合中的 relay。编辑某个连接以更改它使用的 relay。</string>
     <string name="default_profile_relays">默认个人资料 relay</string>
     <string name="manage_the_relays_used_to_fetch_your_profile_data">管理用于获取个人资料数据的 relay</string>
     <string name="manage_the_relays_used_for_communicating_with_external_applications">管理用于与外部应用通信的 relay</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -446,6 +446,9 @@
     <string name="is_requiring_to_sign_these_events_related_to_permission">%1$s 正在要求簽署與 %2$s 權限相關的事件。</string>
     <string name="relay_filter_failed">Relay 不支援擷取 Bunker 事件，是否仍要新增？</string>
     <string name="active_relays">目前使用的 relay</string>
+    <string name="active_relays_default_description">用於每個新的應用程式連線。</string>
+    <string name="relays_used_by_connections">連線 relay</string>
+    <string name="active_relays_connections_description">現有連線仍在使用但不在你預設集合中的 relay。編輯某個連線即可變更它使用的 relay。</string>
     <string name="default_profile_relays">預設個人資料 relay</string>
     <string name="manage_the_relays_used_to_fetch_your_profile_data">管理用於擷取個人資料的 relay</string>
     <string name="manage_the_relays_used_for_communicating_with_external_applications">管理用於與外部應用程式通訊的 relay</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -427,6 +427,9 @@
     <string name="is_requiring_to_sign_these_events_related_to_permission">%1$s 需要签署与权限「%2$s」相关的事件。</string>
     <string name="relay_filter_failed">中继不支持检索 Bunker 事件。依旧继续添加？</string>
     <string name="active_relays">活动中继</string>
+    <string name="active_relays_default_description">用于每个新的应用连接。</string>
+    <string name="relays_used_by_connections">连接中继</string>
+    <string name="active_relays_connections_description">现有连接仍在使用但不在你默认集合中的中继。编辑某个连接以更改它使用的中继。</string>
     <string name="default_profile_relays">默认用户资料中继</string>
     <string name="manage_the_relays_used_to_fetch_your_profile_data">管理用于获取个人资料的中继</string>
     <string name="manage_the_relays_used_for_communicating_with_external_applications">管理用于外部应用通讯的中继</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -468,6 +468,9 @@
     <string name="is_requiring_to_sign_these_events_related_to_permission">%1$s is requiring to sign these events related to %2$s permission.</string>
     <string name="relay_filter_failed">Relay does not support retrieving Bunker events. Would you like to add it anyway?</string>
     <string name="active_relays">Active relays</string>
+    <string name="active_relays_default_description">Used for every new app connection.</string>
+    <string name="relays_used_by_connections">Connection relays</string>
+    <string name="active_relays_connections_description">Relays that existing connections still use but that are not in your default set. Edit a connection to change the relays it uses.</string>
     <string name="default_profile_relays">Default profile relays</string>
     <string name="manage_the_relays_used_to_fetch_your_profile_data">Manage the relays used to fetch your profile data</string>
     <string name="manage_the_relays_used_for_communicating_with_external_applications">Manage the relays used for communicating with external applications</string>


### PR DESCRIPTION
A new bunker connection created from a relay-delivered NIP-46 request was
persisted with whatever single relay happened to deliver the event
(bunkerRequest.relays = the delivering relay). When that relay was a
write-restricted indexer/profile relay, the connection's responses could
no longer be published with the per-connection session key, breaking the
connection.

For a brand-new connection, only honor bunkerRequest.relays when they came
from a nostrconnect:// URI (client-specified). Relay-delivered requests now
fall back to the configured default relays. Existing/saved connections and
the nostrconnect path are unchanged.

https://claude.ai/code/session_01R2Wuj6ipCN2wVa29qGNXQn