### PR TITLE
Fix overlapping feedback type selector with long labels

### DIFF
--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/FeedbackScreen.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/FeedbackScreen.kt
@@ -2,20 +2,25 @@ package com.greenart7c3.nostrsigner.ui
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.SegmentedButton
-import androidx.compose.material3.SegmentedButtonDefaults
-import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -35,6 +40,7 @@ import com.greenart7c3.nostrsigner.ui.components.AmberButton
 import kotlin.coroutines.cancellation.CancellationException
 import kotlinx.coroutines.launch
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun FeedbackScreen(
     modifier: Modifier = Modifier,
@@ -64,15 +70,15 @@ fun FeedbackScreen(
                     style = MaterialTheme.typography.labelLarge,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
-                SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
-                    FeedbackType.entries.forEachIndexed { index, type ->
-                        SegmentedButton(
-                            selected = feedbackType == type,
+                FlowRow(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    FeedbackType.entries.forEach { type ->
+                        val selected = feedbackType == type
+                        FilterChip(
+                            selected = selected,
                             onClick = { feedbackType = type },
-                            shape = SegmentedButtonDefaults.itemShape(
-                                index = index,
-                                count = FeedbackType.entries.size,
-                            ),
                             label = {
                                 Text(
                                     text = stringResource(
@@ -82,6 +88,17 @@ fun FeedbackScreen(
                                         },
                                     ),
                                 )
+                            },
+                            leadingIcon = if (selected) {
+                                {
+                                    Icon(
+                                        imageVector = Icons.Filled.Check,
+                                        contentDescription = null,
+                                        modifier = Modifier.size(FilterChipDefaults.IconSize),
+                                    )
+                                }
+                            } else {
+                                null
                             },
                         )
                     }


### PR DESCRIPTION
Replace the SingleChoiceSegmentedButtonRow on the feedback screen with a
FlowRow of FilterChips. The segmented button forced each option to equal
width, so longer localized labels (e.g. pt-BR "Solicitação de
aprimoramento") wrapped to multiple lines and the items rendered with
overlapping/uneven shapes. FilterChips size to their label and wrap onto a
new line when needed, fixing the layout across all locales.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RWQxxD3jxwfMbXABqvVTc5