### PR TITLE
Document biometric/PIN lock as UI-only, not a signing gate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,17 @@ Permissions are stored in `ApplicationEntity` + `ApplicationPermissionsEntity` (
 
 Before showing the approval UI, all three ingestion paths query the database; if a matching auto-accept rule exists, signing proceeds silently.
 
+### Biometric / PIN lock is UI-only
+
+The biometric/PIN prompt (`useAuth` / `usePin` in `AmberSettings`, configured in `SecurityScreen`) is **only an app-launch UI gate**, not a signing gate. It is rendered by `BiometricAuthScreen`, which is invoked exclusively from the two UI entry points — `MainActivity` and `SignerActivity` — to unlock the app's screens before any approval bottom sheet is shown.
+
+It does **not** protect the signing operations themselves:
+
+- **ContentProvider IPC** (`SignerProvider`) and **NIP-46 relay events** (`EventNotificationConsumer` → `BunkerRequestUtils`) never touch `BiometricAuthScreen`, `Biometrics`, `useAuth`, or `usePin`. They sign in the background based purely on the permission database.
+- When an auto-accept rule matches, all three paths sign silently **without** triggering the biometric/PIN prompt — including `nostrsigner://` intents, which auto-finish before the UI is interacted with.
+
+In other words, the lock controls who can open and navigate the app UI; it does not stand between a request and `Account.sign()`. Authorization for automatic signing is governed solely by the permission system (`rememberType` / `acceptUntil` / `kind`).
+
 ### Key files
 
 | File | Purpose |
@@ -75,3 +86,6 @@ Before showing the approval UI, all three ingestion paths query the database; if
 | `BunkerRequestUtils.kt` | NIP-46 protocol handling, relay responses |
 | `AccountStateViewModel.kt` | Auth state, account switching, toast notifications |
 | `ConnectivityService.kt` | Foreground service, network monitoring, relay reconnection |
+| `BiometricAuthScreen.kt` | UI-only app-launch lock (biometric/PIN); not a signing gate |
+| `Biometrics.kt` | Wraps `BiometricPrompt` / keyguard credential prompt |
+| `SecurityScreen.kt` | Toggles `useAuth` / `usePin` and the re-prompt interval |


### PR DESCRIPTION
## Summary

This PR adds comprehensive documentation to `CLAUDE.md` clarifying that the biometric/PIN lock feature is **exclusively a UI-level app-launch gate**, not a protection mechanism for signing operations themselves. This distinction is critical for understanding the security model and how the three request ingestion paths interact with authentication.

## Changes

- **New section: "Biometric / PIN lock is UI-only"** — Explains that `BiometricAuthScreen` is invoked only from `MainActivity` and `SignerActivity` to gate access to the app's screens before any approval UI is shown
- **Clarifies signing paths are unprotected by biometric/PIN** — Documents that ContentProvider IPC (`SignerProvider`) and NIP-46 relay events (`EventNotificationConsumer` → `BunkerRequestUtils`) bypass the biometric prompt entirely and sign based purely on the permission database
- **Explains auto-accept behavior** — Notes that when an auto-accept rule matches, all three paths (including `nostrsigner://` intents) sign silently without triggering the biometric/PIN prompt
- **Emphasizes permission system as the authorization boundary** — Clarifies that `rememberType`, `acceptUntil`, and `kind` rules govern automatic signing, not the biometric lock
- **Updated key files table** — Adds three new entries documenting `BiometricAuthScreen.kt`, `Biometrics.kt`, and `SecurityScreen.kt`

## Implementation Details

The documentation makes explicit that:
- The biometric/PIN lock controls **who can open and navigate the app UI**
- It does **not** stand between a request and `Account.sign()`
- Background signing paths (ContentProvider, NIP-46 relays) never interact with `BiometricAuthScreen`, `Biometrics`, `useAuth`, or `usePin`
- Authorization for automatic signing is governed **solely** by the permission system

This clarification helps future maintainers understand the threat model and avoid accidentally treating the biometric lock as a signing gate.

https://claude.ai/code/session_018rF3hwjVvtjJMZffdN7zpL