### PR TITLE
Add data extraction rules for backup and device transfer

### DIFF
--- a/app/src/main/res/xml/backup_rules.xml
+++ b/app/src/main/res/xml/backup_rules.xml
@@ -1,13 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?><!--
-   Sample backup rules file; uncomment and customize as necessary.
+   Backup rules used for fullBackupContent on devices older than API 31.
    See https://developer.android.com/guide/topics/data/autobackup
    for details.
-   Note: This file is ignored for devices older that API 31
-   See https://developer.android.com/about/versions/12/backup-restore
+
+   Amber sets android:allowBackup="false", so backups are already disabled.
+   These explicit excludes are defense-in-depth: even if backups were ever
+   enabled, the signer's secret material (encrypted keys, per-account
+   SharedPreferences, Room databases and DataStore files) must never leave
+   the device.
 -->
 <full-backup-content>
-    <!--
-   <include domain="sharedpref" path="."/>
-   <exclude domain="sharedpref" path="device.xml"/>
--->
+    <!-- Encrypted keys / settings live in SharedPreferences (prefs, prefs_<npub>). -->
+    <exclude domain="sharedpref" path="." />
+    <!-- Per-account apps/permissions, logs and history Room databases (amber_db_<npub>, etc.). -->
+    <exclude domain="database" path="." />
+    <!-- DataStore preferences (secure_datastore_<npub>, app_datastore). -->
+    <exclude domain="file" path="datastore" />
 </full-backup-content>

--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,19 +1,27 @@
 <?xml version="1.0" encoding="utf-8"?><!--
-   Sample data extraction rules file; uncomment and customize as necessary.
+   Data extraction rules for cloud backup and device-to-device transfer
+   on API 31+.
    See https://developer.android.com/about/versions/12/backup-restore#xml-changes
    for details.
+
+   Amber sets android:allowBackup="false", so cloud backups are already
+   disabled. These explicit excludes are defense-in-depth: the signer's
+   secret material (encrypted keys, per-account SharedPreferences, Room
+   databases and DataStore files) must never leave the device through
+   either cloud backup or device transfer.
 -->
 <data-extraction-rules>
     <cloud-backup>
-        <!-- TODO: Use <include> and <exclude> to control what is backed up.
-        <include .../>
-        <exclude .../>
-        -->
+        <!-- Encrypted keys / settings live in SharedPreferences (prefs, prefs_<npub>). -->
+        <exclude domain="sharedpref" path="." />
+        <!-- Per-account apps/permissions, logs and history Room databases (amber_db_<npub>, etc.). -->
+        <exclude domain="database" path="." />
+        <!-- DataStore preferences (secure_datastore_<npub>, app_datastore). -->
+        <exclude domain="file" path="datastore" />
     </cloud-backup>
-    <!--
     <device-transfer>
-        <include .../>
-        <exclude .../>
+        <exclude domain="sharedpref" path="." />
+        <exclude domain="database" path="." />
+        <exclude domain="file" path="datastore" />
     </device-transfer>
-    -->
 </data-extraction-rules>


### PR DESCRIPTION
## Summary

Implement explicit data extraction rules to prevent sensitive cryptographic material and per-account data from being backed up or transferred between devices, even though `android:allowBackup="false"` is already set.

## Changes

- **`data_extraction_rules.xml`** (API 31+ backup/transfer rules):
  - Replaced placeholder comments with actual exclusion rules
  - Exclude all SharedPreferences (encrypted keys and settings in `prefs` and `prefs_<npub>`)
  - Exclude all Room databases (per-account app permissions, logs, and history in `amber_db_<npub>`, etc.)
  - Exclude DataStore files (secure and app preferences in `secure_datastore_<npub>` and `app_datastore`)
  - Applied same exclusions to both `cloud-backup` and `device-transfer` sections
  - Updated header comments to clarify purpose and defense-in-depth rationale

- **`backup_rules.xml`** (pre-API 31 backup rules):
  - Replaced placeholder comments with actual exclusion rules
  - Added same three exclusion categories (SharedPreferences, databases, DataStore)
  - Updated header comments to explain the file's purpose and defense-in-depth approach

## Implementation Details

These rules implement defense-in-depth protection: even though the app disables backups via `android:allowBackup="false"`, the explicit exclusions ensure that if backups were ever enabled, the signer's secret material (encrypted keys, per-account settings, and account-specific databases) would never leave the device through cloud backup or device-to-device transfer.

https://claude.ai/code/session_01CX7WR4DwXfEyMW55r9jLjn