### PR TITLE
Prevent permission reuse for null-package deep-link callers

### DIFF
--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/IntentSingleEventHomeScreen.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/IntentSingleEventHomeScreen.kt
@@ -63,6 +63,12 @@ fun IntentSingleEventHomeScreen(
     val key = "$packageName"
 
     LaunchedEffect(Unit) {
+        // Browser deep-links (nostrsigner://) arrive with no calling package, so
+        // every web caller would otherwise share the single "null" key. Honoring a
+        // remembered grant for that shared identity would let a grant given to one
+        // website auto-approve any other website. Never load (and thus never honor)
+        // the shared "null" application: force always-ask for null-package callers.
+        if (packageName == null) return@LaunchedEffect
         launch(Dispatchers.IO) {
             applicationEntity = Amber.instance.getDatabase(account.npub).dao().getByKey(key)
         }


### PR DESCRIPTION
## Summary

Fixes a security issue where browser deep-links (`nostrsigner://` URIs) arriving with no calling package could reuse permission grants across different websites, allowing a grant given to one website to auto-approve requests from any other website.

## Changes

- Added an early return in `IntentSingleEventHomeScreen` when `packageName` is `null` to skip loading cached application permissions
- This forces the always-ask flow for all null-package callers, preventing the shared "null" identity from honoring cross-website permission grants

## Implementation Details

Browser deep-links arrive with no calling package information, which previously resulted in all web callers sharing a single `"null"` key in the application permissions database. By loading and honoring a remembered grant for that shared identity, a permission grant given to one website would inadvertently auto-approve requests from any other website.

The fix ensures that null-package callers always trigger the approval UI, preventing this unintended permission reuse while maintaining the normal permission caching behavior for properly-identified callers.

https://claude.ai/code/session_01Gac3VnX6fhYhSjQD6XiHdu