### PR TITLE
Release v6.2.2: Security, UX, and stability improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,36 @@ Download it with [Zapstore](https://zapstore.dev/apps/com.greenart7c3.nostrsigne
 
 If you like my work consider making a [donation](https://greenart7c3.com)
 
+## Verifying the release
+
+In order to verify the release, you'll need to have `gpg` or `gpg2` installed on your system. Once you've obtained a copy (and hopefully verified that as well), you'll first need to import the keys that have signed this release if you haven't done so already:
+
+``` bash
+gpg --keyserver hkps://keys.openpgp.org --recv-keys 44F0AAEB77F373747E3D5444885822EED3A26A6D
+```
+
+Once you have his PGP key you can verify the release (assuming `manifest-v6.2.2.txt` and `manifest-v6.2.2.txt.sig` are in the current directory) with:
+
+``` bash
+gpg --verify manifest-v6.2.2.txt.sig manifest-v6.2.2.txt
+```
+
+You should see the following if the verification was successful:
+
+``` bash
+gpg: Signature made Fri 13 Sep 2024 08:06:52 AM -03
+gpg:                using RSA key 44F0AAEB77F373747E3D5444885822EED3A26A6D
+gpg: Good signature from "greenart7c3 <greenart7c3@proton.me>"
+```
+
+That will verify the signature on the main manifest page which ensures integrity and authenticity of the binaries you've downloaded locally. Next, depending on your operating system you should then re-calculate the sha256 sum of the binary, and compare that with the following hashes:
+
+``` bash
+cat manifest-v6.2.2.txt
+```
+
+One can use the `shasum -a 256 <file name here>` tool in order to re-compute the `sha256` hash of the target binary for your operating system. The produced hash should be compared with the hashes listed above and they should match exactly.
+
 ## Amber 6.2.1
 
 - Reduce battery drain from relay reconnects and websocket pings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,26 @@
+## Amber 6.2.2
+
+- Show native app icons and NIP-46 client metadata on the request screens and app list
+- Persist client metadata on every connect and capture the native app icon and name at connect/accept time
+- Add support for event kind 30618
+- Add an export/share button to the Logs screen
+- Separate default and connection relays in the Active relays screen, and use default relays for new relay-delivered bunker connections
+- Stop logging decrypted NIP-46 request/response bodies and store encrypt/decrypt payloads as ciphertext, decrypting on demand
+- Gate all logcat output behind BuildConfig.DEBUG
+- Force always-ask for null-package (browser) callers
+- Flag nsec, ncryptsec and seed words clipboard copies as sensitive and clear them after a delay
+- Add explicit backup/data-extraction excludes as defense-in-depth
+- Fix a crash from nested scrolling in the Active relays screen
+- Fix a LazyColumn duplicate key crash from racy bunker request dedup
+- Fix the release update check missing a file subscription on an EOSE race
+- Fix the overlapping feedback type selector with long labels
+- Warm up the Coil ImageLoader off the main thread
+- Update translations
+
+Download it with [Zapstore](https://zapstore.dev/apps/com.greenart7c3.nostrsigner), [Obtainium](https://github.com/ImranR98/Obtainium), [f-droid](https://f-droid.org/packages/com.greenart7c3.nostrsigner) or download it directly in the [releases page](https://github.com/greenart7c3/Amber/releases/tag/v6.2.2)
+
+If you like my work consider making a [donation](https://greenart7c3.com)
+
 ## Amber 6.2.1
 
 - Reduce battery drain from relay reconnects and websocket pings

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,8 +15,8 @@ android {
     defaultConfig {
         applicationId = "com.greenart7c3.nostrsigner"
         minSdk = 26
-        versionCode = 194
-        versionName = "6.2.1"
+        versionCode = 195
+        versionName = "6.2.2"
 
         buildConfigField("boolean", "IS_FDROID_BUILD", "false")
 


### PR DESCRIPTION
## Summary

This release introduces security hardening, improved user experience with app metadata display, and several bug fixes. Version bumped from 6.2.1 to 6.2.2 (versionCode 194 → 195).

## Key Changes

- **Security & Privacy**
  - Stop logging decrypted NIP-46 request/response bodies; store encrypt/decrypt payloads as ciphertext and decrypt on demand
  - Gate all logcat output behind `BuildConfig.DEBUG`
  - Flag nsec, ncryptsec, and seed words clipboard copies as sensitive with automatic clearing after a delay
  - Add explicit backup/data-extraction excludes as defense-in-depth
  - Force always-ask for null-package (browser) callers

- **User Experience**
  - Display native app icons and NIP-46 client metadata on request screens and app list
  - Persist client metadata on every connect and capture native app icon/name at connect/accept time
  - Add export/share button to the Logs screen
  - Separate default and connection relays in the Active relays screen; use default relays for new relay-delivered bunker connections
  - Warm up the Coil ImageLoader off the main thread

- **Protocol & Features**
  - Add support for event kind 30618

- **Bug Fixes**
  - Fix crash from nested scrolling in the Active relays screen
  - Fix LazyColumn duplicate key crash from racy bunker request dedup
  - Fix release update check missing a file subscription on an EOSE race
  - Fix overlapping feedback type selector with long labels

- **Localization**
  - Update translations

## Release Verification

Added comprehensive GPG signature verification instructions and SHA256 hash validation guidance in CHANGELOG.md for users to verify release authenticity and integrity.

https://claude.ai/code/session_01KjTLbAw3G8xsEXq8LhaKTu