### PR TITLE
Build both free and offline flavors in unsigned release workflow

### DIFF
--- a/.github/workflows/unsigned-release.yml
+++ b/.github/workflows/unsigned-release.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Build AAB and APKs
         run: |
-          ./gradlew bundleRelease assembleRelease --stacktrace
+          ./gradlew bundleFreeRelease bundleOfflineRelease assembleFreeRelease assembleOfflineRelease --stacktrace
 
       - name: Upload all APKs as artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
Updates the unsigned release workflow to build both the `free` and `offline` build flavors, ensuring both variants are tested and available as release artifacts.

## Changes
- Modified the gradle build command in the unsigned release workflow to build AABs and APKs for both `free` and `offline` flavors
- Changed from `bundleRelease assembleRelease` to `bundleFreeRelease bundleOfflineRelease assembleFreeRelease assembleOfflineRelease`

## Details
This aligns the CI/CD pipeline with the project's dual-flavor architecture. The `free` flavor includes full networking capabilities (OkHttp, Coil, relay connectivity), while the `offline` flavor has no network stack. Building both variants in the release workflow ensures both are properly tested and available for distribution.

https://claude.ai/code/session_01G9KKAb95KjKV8gL2FaXTks