### PR TITLE
Add benchmark flavor with distinct launcher name

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -175,6 +175,20 @@ android {
     }
 }
 
+// The benchmark flavor is built as a release APK, where the release build type's
+// resValue sets app_name to "Amber". Build-type resValues take precedence over
+// product-flavor resValues, so override app_name here via the variant API (the
+// highest-priority tier) to give the side-by-side benchmark install its own
+// launcher name.
+androidComponents {
+    onVariants(selector().withFlavor("version" to "benchmark")) { variant ->
+        variant.resValues.put(
+            variant.makeResValueKey("string", "app_name"),
+            com.android.build.api.variant.ResValue("@string/app_name_benchmark"),
+        )
+    }
+}
+
 composeCompiler {
     reportsDestination.set(layout.buildDirectory.dir("compose_compiler"))
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,7 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <string name="app_name_release" translatable="false">Amber</string>
     <string name="app_name_debug" translatable="false">Amber Debug</string>
+    <string name="app_name_benchmark" translatable="false">Amber Benchmark</string>
     <!-- Settings screen sections -->
     <string name="settings_section_account">Account &amp; keys</string>
     <string name="settings_section_network">Network</string>


### PR DESCRIPTION
## Summary
Adds support for a benchmark build flavor that installs side-by-side with release builds by giving it a distinct launcher name ("Amber Benchmark").

## Changes
- **Build configuration**: Added `androidComponents` block in `build.gradle.kts` to override the `app_name` resource for the benchmark flavor variant, ensuring it uses `@string/app_name_benchmark` instead of the release build type's "Amber"
- **String resources**: Added `app_name_benchmark` string resource with value "Amber Benchmark" to `strings.xml`

## Implementation details
The benchmark flavor is built as a release APK (for performance testing), but the release build type's `resValue` sets `app_name` to "Amber". Since build-type `resValues` take precedence over product-flavor `resValues`, the variant API (highest-priority tier) is used to override `app_name` specifically for the benchmark variant, allowing it to coexist with the release build on the same device with its own launcher entry point.

https://claude.ai/code/session_018WzuueL183J65rqDgrb9fL