### PR TITLE
Load account data off main thread to prevent jank

### DIFF
--- a/app/src/main/java/com/greenart7c3/nostrsigner/Amber.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/Amber.kt
@@ -607,12 +607,14 @@ class Amber :
                     }
 
                     override fun onSuccess(request: ImageRequest, result: SuccessResult) {
-                        AmberLog.d(
-                            TAG,
-                            "Coil: loaded ${request.data} from ${result.dataSource}" +
-                                " | mem=${memCache.size / 1024}/${memCache.maxSize / 1024} KB" +
-                                " | disk=${diskCache.size / 1024}/${diskCache.maxSize / 1024} KB",
-                        )
+                        applicationIOScope.launch {
+                            AmberLog.d(
+                                TAG,
+                                "Coil: loaded ${request.data} from ${result.dataSource}" +
+                                    " | mem=${memCache.size / 1024}/${memCache.maxSize / 1024} KB" +
+                                    " | disk=${diskCache.size / 1024}/${diskCache.maxSize / 1024} KB",
+                            )
+                        }
                     }
 
                     override fun onError(request: ImageRequest, result: ErrorResult) {

--- a/app/src/main/java/com/greenart7c3/nostrsigner/LocalPreferences.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/LocalPreferences.kt
@@ -504,6 +504,12 @@ object LocalPreferences {
         }
     }
 
+    fun getProfileUrl(context: Context, npub: String): String {
+        sharedPrefs(context, npub).apply {
+            return getString(PrefKeys.PROFILE_URL.key, "") ?: ""
+        }
+    }
+
     fun updateProxy(
         context: Context,
         useProxy: Boolean,

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/AccountScreen.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/AccountScreen.kt
@@ -3,10 +3,12 @@ package com.greenart7c3.nostrsigner.ui
 import android.annotation.SuppressLint
 import androidx.compose.animation.Crossfade
 import androidx.compose.animation.core.tween
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material.icons.Icons
@@ -16,6 +18,7 @@ import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonColors
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -64,6 +67,14 @@ fun AccountScreen(
             label = "AccountScreen",
         ) { state ->
             when (state) {
+                is AccountState.Loading -> {
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        CircularProgressIndicator()
+                    }
+                }
                 is AccountState.LoggedOff -> {
                     val newNavController = rememberNavController()
                     MainLoginPage(accountStateViewModel, NavHostControllerWrapper(newNavController))

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/AccountState.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/AccountState.kt
@@ -3,6 +3,8 @@ package com.greenart7c3.nostrsigner.ui
 import com.greenart7c3.nostrsigner.models.Account
 
 sealed class AccountState {
+    data object Loading : AccountState()
+
     data object LoggedOff : AccountState()
 
     class LoggedIn(val account: Account, val route: String?) : AccountState()

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/AccountStateViewModel.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/AccountStateViewModel.kt
@@ -35,7 +35,7 @@ sealed interface RestorePromptState {
 
 @Stable
 class AccountStateViewModel(npub: String?) : ViewModel() {
-    private val _accountContent = MutableStateFlow<AccountState>(AccountState.LoggedOff)
+    private val _accountContent = MutableStateFlow<AccountState>(AccountState.Loading)
     val accountContent = _accountContent.asStateFlow()
     private var observerJob: Job? = null
 
@@ -50,28 +50,32 @@ class AccountStateViewModel(npub: String?) : ViewModel() {
         npub: String?,
         forceLogout: Boolean = false,
     ) {
-        var currentUser = npub ?: LocalPreferences.currentAccount(Amber.instance)
-        val allAccounts = LocalPreferences.allSavedAccounts(Amber.instance)
-        if (currentUser != null && !LocalPreferences.containsAccount(Amber.instance, currentUser) && allAccounts.any { it.npub == currentUser }) {
-            currentUser = LocalPreferences.currentAccount(Amber.instance)
-        }
-        if (forceLogout) {
-            currentUser = null
-        }
-        LocalPreferences.loadFromEncryptedStorageSync(Amber.instance, currentUser)?.let {
-            startUI(it, route)
-            Amber.instance.applicationIOScope.launch {
+        // Loading the account decrypts keys via the Android KeyStore, which is a slow
+        // blocking call. Run it off the main thread to avoid StrictMode violations and jank.
+        Amber.instance.applicationIOScope.launch {
+            var currentUser = npub ?: LocalPreferences.currentAccount(Amber.instance)
+            val allAccounts = LocalPreferences.allSavedAccounts(Amber.instance)
+            if (currentUser != null && !LocalPreferences.containsAccount(Amber.instance, currentUser) && allAccounts.any { it.npub == currentUser }) {
+                currentUser = LocalPreferences.currentAccount(Amber.instance)
+            }
+            if (forceLogout) {
+                currentUser = null
+            }
+            LocalPreferences.loadFromEncryptedStorageSync(Amber.instance, currentUser)?.let {
+                startUI(it, route)
                 Amber.instance.profileSubscription.updateFilter()
             }
-        }
-        if (currentUser == null) {
-            _accountContent.update { AccountState.LoggedOff }
+            if (currentUser == null) {
+                _accountContent.update { AccountState.LoggedOff }
+            }
         }
     }
 
     private fun prepareLogoutOrSwitch() {
         observerJob?.cancel()
-        _accountContent.update { AccountState.LoggedOff }
+        // Show the loading state while the next account decrypts off the main thread,
+        // so the login page does not flash during an account switch.
+        _accountContent.update { AccountState.Loading }
     }
 
     fun logOff(npub: String) {

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/actions/AccountsBottomSheet.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/actions/AccountsBottomSheet.kt
@@ -1,18 +1,23 @@
 package com.greenart7c3.nostrsigner.ui.actions
 
 import android.content.ClipData
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.outlined.Person
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -26,6 +31,8 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.ClipEntry
 import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.platform.LocalContext
@@ -34,6 +41,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.dp
+import coil3.compose.SubcomposeAsyncImage
+import com.greenart7c3.nostrsigner.BuildFlavorChecker
 import com.greenart7c3.nostrsigner.LocalPreferences
 import com.greenart7c3.nostrsigner.R
 import com.greenart7c3.nostrsigner.models.Account
@@ -42,7 +51,10 @@ import com.greenart7c3.nostrsigner.ui.AccountStateViewModel
 import com.greenart7c3.nostrsigner.ui.NavHostControllerWrapper
 import com.greenart7c3.nostrsigner.ui.components.ActiveMarker
 import com.greenart7c3.nostrsigner.ui.navigation.Route
+import com.greenart7c3.nostrsigner.ui.theme.fromHex
 import com.greenart7c3.nostrsigner.ui.verticalScrollbar
+import com.vitorpamplona.quartz.nip01Core.core.toHexKey
+import com.vitorpamplona.quartz.nip19Bech32.bech32.bechToBytes
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -89,6 +101,8 @@ fun AccountsBottomSheet(
                 }
                 accounts.forEach { acc ->
                     val name = LocalPreferences.getAccountName(context, acc.npub)
+                    val profileUrl = LocalPreferences.getProfileUrl(context, acc.npub)
+                    val borderColor = Color.fromHex(acc.npub.bechToBytes().toHexKey().slice(0..5))
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()
@@ -106,6 +120,37 @@ fun AccountsBottomSheet(
                                 modifier = Modifier.weight(1f),
                                 verticalAlignment = Alignment.CenterVertically,
                             ) {
+                                if (profileUrl.isNotBlank() && !BuildFlavorChecker.isOfflineFlavor()) {
+                                    SubcomposeAsyncImage(
+                                        model = profileUrl,
+                                        contentDescription = stringResource(R.string.account_picture),
+                                        modifier = Modifier
+                                            .padding(end = 8.dp)
+                                            .clip(RoundedCornerShape(50))
+                                            .height(40.dp)
+                                            .width(40.dp),
+                                        error = {
+                                            Icon(
+                                                Icons.Outlined.Person,
+                                                stringResource(R.string.account_picture),
+                                                modifier = Modifier
+                                                    .border(1.dp, borderColor, CircleShape)
+                                                    .height(40.dp)
+                                                    .width(40.dp),
+                                            )
+                                        },
+                                    )
+                                } else {
+                                    Icon(
+                                        Icons.Outlined.Person,
+                                        stringResource(R.string.account_picture),
+                                        modifier = Modifier
+                                            .padding(end = 8.dp)
+                                            .border(1.dp, borderColor, CircleShape)
+                                            .height(40.dp)
+                                            .width(40.dp),
+                                    )
+                                }
                                 Column(modifier = Modifier.weight(1f)) {
                                     if (name.isNotBlank()) {
                                         Text(name)

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/actions/AccountsBottomSheet.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/actions/AccountsBottomSheet.kt
@@ -28,6 +28,9 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.produceState
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -55,7 +58,9 @@ import com.greenart7c3.nostrsigner.ui.theme.fromHex
 import com.greenart7c3.nostrsigner.ui.verticalScrollbar
 import com.vitorpamplona.quartz.nip01Core.core.toHexKey
 import com.vitorpamplona.quartz.nip19Bech32.bech32.bechToBytes
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -100,9 +105,19 @@ fun AccountsBottomSheet(
                     Text(stringResource(R.string.select_account), fontWeight = FontWeight.Bold)
                 }
                 accounts.forEach { acc ->
-                    val name = LocalPreferences.getAccountName(context, acc.npub)
-                    val profileUrl = LocalPreferences.getProfileUrl(context, acc.npub)
-                    val borderColor = Color.fromHex(acc.npub.bechToBytes().toHexKey().slice(0..5))
+                    // Reading the name/picture from SharedPreferences touches disk, so do it
+                    // off the main thread instead of synchronously during composition.
+                    val accountInfo by produceState("" to "", acc.npub) {
+                        value = withContext(Dispatchers.IO) {
+                            LocalPreferences.getAccountName(context, acc.npub) to
+                                LocalPreferences.getProfileUrl(context, acc.npub)
+                        }
+                    }
+                    val name = accountInfo.first
+                    val profileUrl = accountInfo.second
+                    val borderColor = remember(acc.npub) {
+                        Color.fromHex(acc.npub.bechToBytes().toHexKey().slice(0..5))
+                    }
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()


### PR DESCRIPTION
## Summary
Moves blocking I/O operations (SharedPreferences reads and Android KeyStore decryption) off the main thread to prevent UI jank and StrictMode violations during account loading and switching.

## Key Changes

- **AccountStateViewModel**: Moved `loadFromEncryptedStorageSync()` call to `applicationIOScope` (IO dispatcher) instead of running synchronously on the main thread. Added `AccountState.Loading` state to show a loading spinner while account data decrypts in the background.

- **AccountsBottomSheet**: Replaced synchronous `LocalPreferences.getAccountName()` call with `produceState` + `withContext(Dispatchers.IO)` to load account names and profile URLs off the main thread during composition.

- **AccountScreen**: Added UI support for the new `AccountState.Loading` state, displaying a `CircularProgressIndicator` centered on screen.

- **LocalPreferences**: Added `getProfileUrl()` helper function to retrieve cached profile picture URLs from SharedPreferences.

- **AccountsBottomSheet UI enhancements**: 
  - Display profile pictures (via Coil's `SubcomposeAsyncImage`) when available and not in offline flavor
  - Fall back to a bordered person icon with a color derived from the account's npub
  - Properly handle loading and error states

- **Amber.kt**: Wrapped Coil logging in `applicationIOScope.launch` to avoid blocking the main thread with cache size calculations.

## Implementation Details

The changes follow the pattern established in the codebase: use `Amber.instance.applicationIOScope` for all background I/O, and leverage Compose's `produceState` for off-main-thread data loading during composition. The `AccountState.Loading` state prevents the login page from flashing during account switches by showing a loading indicator instead of immediately transitioning to `LoggedOff`.

https://claude.ai/code/session_01SU4R7ZmhASbtL9nU3t1wiN