### PR TITLE
Make keyPair nullable in login/signup screens

### DIFF
--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/LoginScreen.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/LoginScreen.kt
@@ -415,7 +415,7 @@ fun SignUpPage(
     val percentage = (screenWidthDp * 0.93f)
     val verticalPadding = (screenWidthDp - percentage)
     var nickname by remember { mutableStateOf(TextFieldValue()) }
-    var keyPair by remember { mutableStateOf(KeyPair()) }
+    var keyPair by remember { mutableStateOf<KeyPair?>(null) }
     val state = rememberPagerState {
         2
     }
@@ -513,7 +513,7 @@ fun SignUpPage(
                                     .background(Color(0xFFFFDE9E)),
                             ) {
                                 Text(
-                                    text = keyPair.pubKey.toNpub(),
+                                    text = keyPair?.pubKey?.toNpub() ?: "",
                                     modifier = Modifier.padding(10.dp),
                                     color = Color.Black,
                                 )
@@ -823,7 +823,7 @@ fun LoginPage(
     }
     val scope = rememberCoroutineScope()
     val focusRequester = remember { FocusRequester() }
-    var keyPair by remember { mutableStateOf(KeyPair()) }
+    var keyPair by remember { mutableStateOf<KeyPair?>(null) }
     var isMnemonicMode by rememberSaveable { mutableStateOf(false) }
     var mnemonicWordCount by rememberSaveable { mutableIntStateOf(12) }
     var mnemonicWords by remember { mutableStateOf(List(12) { "" }) }
@@ -1427,10 +1427,12 @@ fun LoginPage(
                                         return@AmberButton
                                     }
 
+                                    val currentKeyPair = keyPair ?: return@AmberButton
+
                                     Amber.instance.applicationIOScope.launch {
                                         isLoading = true
                                         accountViewModel.startUI(
-                                            keyPair = keyPair,
+                                            keyPair = currentKeyPair,
                                             route = null,
                                             torMode = torMode,
                                             signPolicy = selectedOption,


### PR DESCRIPTION
## Summary
Changes the `keyPair` state variable from a non-nullable `KeyPair()` instance to a nullable `KeyPair?` type initialized to `null` in both the `SignUpPage` and `LoginPage` composables. This prevents premature key pair instantiation and ensures the key pair is only used after it has been properly initialized.

## Key Changes
- **SignUpPage**: Changed `keyPair` initialization from `mutableStateOf(KeyPair())` to `mutableStateOf<KeyPair?>(null)` and updated the display logic to use safe navigation (`keyPair?.pubKey?.toNpub() ?: ""`)
- **LoginPage**: Changed `keyPair` initialization from `mutableStateOf(KeyPair())` to `mutableStateOf<KeyPair?>(null)` and added a null-safety check before passing it to `accountViewModel.startUI()`

## Implementation Details
- The null-safety check in `LoginPage` uses a local `currentKeyPair` variable to ensure the key pair is non-null before being passed to the coroutine scope, preventing potential null pointer exceptions during account initialization
- Safe navigation operator (`?.`) is used in `SignUpPage` to handle the nullable key pair when displaying the public key, with an empty string fallback

https://claude.ai/code/session_0161evrQtujZDzAFLH9U9BgB