### PR TITLE
Add configurable profile fetch interval setting

### DIFF
--- a/app/src/main/java/com/greenart7c3/nostrsigner/LocalPreferences.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/LocalPreferences.kt
@@ -9,6 +9,7 @@ import androidx.core.content.edit
 import androidx.core.os.LocaleListCompat
 import com.greenart7c3.nostrsigner.models.Account
 import com.greenart7c3.nostrsigner.models.AmberSettings
+import com.greenart7c3.nostrsigner.models.ProfileFetchInterval
 import com.greenart7c3.nostrsigner.models.TorMode
 import com.greenart7c3.nostrsigner.models.UpdateChannel
 import com.greenart7c3.nostrsigner.models.UpdateCheckFrequency
@@ -71,6 +72,7 @@ private enum class SettingsKeys(val key: String) {
     RATE_LIMIT_ENABLED("rate_limit_enabled"),
     RATE_LIMIT_MAX_PER_WINDOW("rate_limit_max_per_window"),
     RATE_LIMIT_WINDOW_SECONDS("rate_limit_window_seconds"),
+    PROFILE_FETCH_INTERVAL("profile_fetch_interval"),
 }
 
 @Immutable
@@ -289,6 +291,13 @@ object LocalPreferences {
                 rateLimitEnabled = getBoolean(SettingsKeys.RATE_LIMIT_ENABLED.key, true),
                 rateLimitMaxPerWindow = getInt(SettingsKeys.RATE_LIMIT_MAX_PER_WINDOW.key, 5),
                 rateLimitWindowSeconds = getInt(SettingsKeys.RATE_LIMIT_WINDOW_SECONDS.key, 30),
+                profileFetchInterval = try {
+                    ProfileFetchInterval.valueOf(
+                        getString(SettingsKeys.PROFILE_FETCH_INTERVAL.key, ProfileFetchInterval.FIFTEEN_MINUTES.name)!!,
+                    )
+                } catch (_: IllegalArgumentException) {
+                    ProfileFetchInterval.FIFTEEN_MINUTES
+                },
             )
         }
     }
@@ -561,6 +570,15 @@ object LocalPreferences {
         sharedPrefs(context).edit {
             apply {
                 putString(SettingsKeys.UPDATE_CHECK_FREQUENCY.key, frequency.name)
+            }
+        }
+        Amber.instance.settings = loadSettingsFromEncryptedStorage()
+    }
+
+    fun updateProfileFetchInterval(context: Context, interval: ProfileFetchInterval) {
+        sharedPrefs(context).edit {
+            apply {
+                putString(SettingsKeys.PROFILE_FETCH_INTERVAL.key, interval.name)
             }
         }
         Amber.instance.settings = loadSettingsFromEncryptedStorage()

--- a/app/src/main/java/com/greenart7c3/nostrsigner/models/AmberSettings.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/models/AmberSettings.kt
@@ -37,6 +37,7 @@ data class AmberSettings(
     val rateLimitEnabled: Boolean = true,
     val rateLimitMaxPerWindow: Int = 5,
     val rateLimitWindowSeconds: Int = 30,
+    val profileFetchInterval: ProfileFetchInterval = ProfileFetchInterval.FIFTEEN_MINUTES,
 ) {
     val useProxy: Boolean get() = torMode != TorMode.DISABLED
 }

--- a/app/src/main/java/com/greenart7c3/nostrsigner/models/ProfileFetchInterval.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/models/ProfileFetchInterval.kt
@@ -1,0 +1,12 @@
+package com.greenart7c3.nostrsigner.models
+
+import com.greenart7c3.nostrsigner.R
+
+enum class ProfileFetchInterval(val minutes: Long, val resourceId: Int) {
+    FIFTEEN_MINUTES(15, R.string.profile_fetch_interval_15_minutes),
+    THIRTY_MINUTES(30, R.string.profile_fetch_interval_30_minutes),
+    ONE_HOUR(60, R.string.profile_fetch_interval_1_hour),
+    THREE_HOURS(180, R.string.profile_fetch_interval_3_hours),
+    SIX_HOURS(360, R.string.profile_fetch_interval_6_hours),
+    ONE_DAY(1440, R.string.profile_fetch_interval_1_day),
+}

--- a/app/src/main/java/com/greenart7c3/nostrsigner/models/ProfileFetchInterval.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/models/ProfileFetchInterval.kt
@@ -3,10 +3,12 @@ package com.greenart7c3.nostrsigner.models
 import com.greenart7c3.nostrsigner.R
 
 enum class ProfileFetchInterval(val minutes: Long, val resourceId: Int) {
+    ALWAYS(0, R.string.profile_fetch_interval_always),
     FIFTEEN_MINUTES(15, R.string.profile_fetch_interval_15_minutes),
     THIRTY_MINUTES(30, R.string.profile_fetch_interval_30_minutes),
     ONE_HOUR(60, R.string.profile_fetch_interval_1_hour),
     THREE_HOURS(180, R.string.profile_fetch_interval_3_hours),
     SIX_HOURS(360, R.string.profile_fetch_interval_6_hours),
     ONE_DAY(1440, R.string.profile_fetch_interval_1_day),
+    NEVER(-1, R.string.profile_fetch_interval_never),
 }

--- a/app/src/main/java/com/greenart7c3/nostrsigner/service/ProfileSubscription.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/service/ProfileSubscription.kt
@@ -136,8 +136,8 @@ class ProfileSubscription(
         val lastMetaData = LocalPreferences.getLastMetadataUpdate(appContext, account.npub)
         val lastCheck = LocalPreferences.getLastCheck(appContext, account.npub)
         val oneDayAgo = TimeUtils.oneDayAgo()
-        val fifteenMinutesAgo = TimeUtils.fifteenMinutesAgo()
-        if ((lastMetaData == 0L || oneDayAgo > lastMetaData) && (lastCheck == 0L || fifteenMinutesAgo > lastCheck)) {
+        val fetchIntervalAgo = TimeUtils.now() - (Amber.instance.settings.profileFetchInterval.minutes * 60)
+        if ((lastMetaData == 0L || oneDayAgo > lastMetaData) && (lastCheck == 0L || fetchIntervalAgo > lastCheck)) {
             val subId = subIds[account.hexKey]!!
             val profileFilter = createProfileFilter(account)
             relaysPerSubId[subId] = profileFilter.keys.toMutableSet()

--- a/app/src/main/java/com/greenart7c3/nostrsigner/service/ProfileSubscription.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/service/ProfileSubscription.kt
@@ -25,6 +25,7 @@ import com.greenart7c3.nostrsigner.Amber
 import com.greenart7c3.nostrsigner.BuildFlavorChecker
 import com.greenart7c3.nostrsigner.LocalPreferences
 import com.greenart7c3.nostrsigner.models.Account
+import com.greenart7c3.nostrsigner.models.ProfileFetchInterval
 import com.vitorpamplona.quartz.nip01Core.crypto.verify
 import com.vitorpamplona.quartz.nip01Core.metadata.MetadataEvent
 import com.vitorpamplona.quartz.nip01Core.relay.client.NostrClient
@@ -128,16 +129,24 @@ class ProfileSubscription(
     suspend fun updateFilter(account: Account) {
         if (BuildFlavorChecker.isOfflineFlavor()) return
 
+        val interval = Amber.instance.settings.profileFetchInterval
+        if (interval == ProfileFetchInterval.NEVER) return
+
         accounts[account.hexKey] = account
 
         if (!subIds.containsKey(account.hexKey)) {
             subIds[account.hexKey] = UUID.randomUUID().toString()
         }
-        val lastMetaData = LocalPreferences.getLastMetadataUpdate(appContext, account.npub)
-        val lastCheck = LocalPreferences.getLastCheck(appContext, account.npub)
-        val oneDayAgo = TimeUtils.oneDayAgo()
-        val fetchIntervalAgo = TimeUtils.now() - (Amber.instance.settings.profileFetchInterval.minutes * 60)
-        if ((lastMetaData == 0L || oneDayAgo > lastMetaData) && (lastCheck == 0L || fetchIntervalAgo > lastCheck)) {
+        val shouldFetch = if (interval == ProfileFetchInterval.ALWAYS) {
+            true
+        } else {
+            val lastMetaData = LocalPreferences.getLastMetadataUpdate(appContext, account.npub)
+            val lastCheck = LocalPreferences.getLastCheck(appContext, account.npub)
+            val oneDayAgo = TimeUtils.oneDayAgo()
+            val fetchIntervalAgo = TimeUtils.now() - (interval.minutes * 60)
+            (lastMetaData == 0L || oneDayAgo > lastMetaData) && (lastCheck == 0L || fetchIntervalAgo > lastCheck)
+        }
+        if (shouldFetch) {
             val subId = subIds[account.hexKey]!!
             val profileFilter = createProfileFilter(account)
             relaysPerSubId[subId] = profileFilter.keys.toMutableSet()

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/DefaultProfileRelaysScreen.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/DefaultProfileRelaysScreen.kt
@@ -2,8 +2,10 @@ package com.greenart7c3.nostrsigner.ui
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.text.KeyboardActions
@@ -20,11 +22,13 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.platform.LocalContext
@@ -38,8 +42,11 @@ import com.greenart7c3.nostrsigner.BuildFlavorChecker
 import com.greenart7c3.nostrsigner.LocalPreferences
 import com.greenart7c3.nostrsigner.R
 import com.greenart7c3.nostrsigner.models.Account
+import com.greenart7c3.nostrsigner.models.ProfileFetchInterval
 import com.greenart7c3.nostrsigner.service.TrustScoreService
 import com.greenart7c3.nostrsigner.ui.actions.onAddRelay
+import com.greenart7c3.nostrsigner.ui.components.TitleExplainer
+import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
@@ -63,6 +70,7 @@ fun DefaultProfileRelaysScreen(
         }
     val trustScores = remember { mutableStateMapOf<String, Int?>() }
     val loadingScores = remember { mutableStateMapOf<String, Boolean>() }
+    var fetchInterval by remember { mutableStateOf(Amber.instance.settings.profileFetchInterval) }
 
     // Fetch trust scores for all relays
     LaunchedEffect(relays2.toList()) {
@@ -101,6 +109,26 @@ fun DefaultProfileRelaysScreen(
                     text = stringResource(R.string.manage_the_relays_used_to_fetch_your_profile_data),
                     modifier = Modifier.padding(bottom = 8.dp),
                 )
+
+                val fetchIntervalOptions = ProfileFetchInterval.entries.map {
+                    TitleExplainer(stringResource(it.resourceId))
+                }.toImmutableList()
+
+                SettingsRow(
+                    name = R.string.profile_fetch_interval,
+                    description = R.string.profile_fetch_interval_description,
+                    selectedItems = fetchIntervalOptions,
+                    selectedIndex = ProfileFetchInterval.entries.indexOf(fetchInterval),
+                    onSelect = { index ->
+                        val selected = ProfileFetchInterval.entries[index]
+                        fetchInterval = selected
+                        scope.launch(Dispatchers.IO) {
+                            LocalPreferences.updateProfileFetchInterval(context, selected)
+                        }
+                    },
+                )
+
+                Spacer(modifier = Modifier.height(8.dp))
 
                 OutlinedTextField(
                     modifier = Modifier

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -518,6 +518,16 @@
     <string name="stop_service">Dienst stoppen</string>
     <string name="start_service_on_boot">Dienst beim Start ausführen</string>
     <string name="start_service_on_boot_description">Wenn aktiviert, startet Amber seinen Hintergrunddienst automatisch nach dem Gerätestart, damit Remote-Anmeldungen und NIP-46-Anfragen weiterhin funktionieren.</string>
+    <string name="profile_fetch_interval">Profilabruf-Intervall</string>
+    <string name="profile_fetch_interval_description">Wie oft Amber die Relays auf aktualisierte Profilmetadaten (Name und Bild) prüft</string>
+    <string name="profile_fetch_interval_always">Immer (jedes Mal)</string>
+    <string name="profile_fetch_interval_15_minutes">Alle 15 Minuten</string>
+    <string name="profile_fetch_interval_30_minutes">Alle 30 Minuten</string>
+    <string name="profile_fetch_interval_1_hour">Jede Stunde</string>
+    <string name="profile_fetch_interval_3_hours">Alle 3 Stunden</string>
+    <string name="profile_fetch_interval_6_hours">Alle 6 Stunden</string>
+    <string name="profile_fetch_interval_1_day">Jeden Tag</string>
+    <string name="profile_fetch_interval_never">Nie (deaktiviert)</string>
     <string name="update_check_frequency">Prüfhäufigkeit</string>
     <string name="update_frequency_on_startup">Bei jedem App-Start</string>
     <string name="update_frequency_daily">Täglich</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -521,6 +521,16 @@
     <string name="stop_service">Detener servicio</string>
     <string name="start_service_on_boot">Iniciar servicio al arrancar</string>
     <string name="start_service_on_boot_description">Cuando está activado, Amber iniciará su servicio en segundo plano automáticamente tras el arranque del dispositivo, para que el inicio de sesión remoto y las solicitudes NIP-46 sigan funcionando.</string>
+    <string name="profile_fetch_interval">Intervalo de obtención de perfil</string>
+    <string name="profile_fetch_interval_description">Con qué frecuencia Amber consulta los relés en busca de metadatos de perfil actualizados (nombre e imagen)</string>
+    <string name="profile_fetch_interval_always">Siempre (cada vez)</string>
+    <string name="profile_fetch_interval_15_minutes">Cada 15 minutos</string>
+    <string name="profile_fetch_interval_30_minutes">Cada 30 minutos</string>
+    <string name="profile_fetch_interval_1_hour">Cada hora</string>
+    <string name="profile_fetch_interval_3_hours">Cada 3 horas</string>
+    <string name="profile_fetch_interval_6_hours">Cada 6 horas</string>
+    <string name="profile_fetch_interval_1_day">Cada día</string>
+    <string name="profile_fetch_interval_never">Nunca (deshabilitado)</string>
     <string name="update_check_frequency">Frecuencia de comprobación</string>
     <string name="update_frequency_on_startup">En cada inicio de la aplicación</string>
     <string name="update_frequency_daily">Diariamente</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -518,6 +518,16 @@
     <string name="stop_service">Arrêter le service</string>
     <string name="start_service_on_boot">Démarrer le service au démarrage</string>
     <string name="start_service_on_boot_description">Lorsqu\'il est activé, Amber démarre automatiquement son service en arrière-plan après le démarrage de l\'appareil afin que la connexion à distance et les requêtes NIP-46 continuent de fonctionner.</string>
+    <string name="profile_fetch_interval">Intervalle de récupération du profil</string>
+    <string name="profile_fetch_interval_description">À quelle fréquence Amber vérifie les relais pour des métadonnées de profil mises à jour (nom et image)</string>
+    <string name="profile_fetch_interval_always">Toujours (à chaque fois)</string>
+    <string name="profile_fetch_interval_15_minutes">Toutes les 15 minutes</string>
+    <string name="profile_fetch_interval_30_minutes">Toutes les 30 minutes</string>
+    <string name="profile_fetch_interval_1_hour">Toutes les heures</string>
+    <string name="profile_fetch_interval_3_hours">Toutes les 3 heures</string>
+    <string name="profile_fetch_interval_6_hours">Toutes les 6 heures</string>
+    <string name="profile_fetch_interval_1_day">Tous les jours</string>
+    <string name="profile_fetch_interval_never">Jamais (désactivé)</string>
     <string name="update_check_frequency">Fréquence de vérification</string>
     <string name="update_frequency_on_startup">À chaque démarrage</string>
     <string name="update_frequency_daily">Quotidien</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -521,6 +521,16 @@
     <string name="stop_service">Hentikan layanan</string>
     <string name="start_service_on_boot">Mulai layanan saat boot</string>
     <string name="start_service_on_boot_description">Jika diaktifkan, Amber akan memulai layanan latar belakangnya secara otomatis setelah perangkat boot sehingga login jarak jauh dan permintaan NIP-46 tetap berfungsi.</string>
+    <string name="profile_fetch_interval">Interval pengambilan profil</string>
+    <string name="profile_fetch_interval_description">Seberapa sering Amber memeriksa relay untuk metadata profil yang diperbarui (nama dan gambar)</string>
+    <string name="profile_fetch_interval_always">Selalu (setiap saat)</string>
+    <string name="profile_fetch_interval_15_minutes">Setiap 15 menit</string>
+    <string name="profile_fetch_interval_30_minutes">Setiap 30 menit</string>
+    <string name="profile_fetch_interval_1_hour">Setiap jam</string>
+    <string name="profile_fetch_interval_3_hours">Setiap 3 jam</string>
+    <string name="profile_fetch_interval_6_hours">Setiap 6 jam</string>
+    <string name="profile_fetch_interval_1_day">Setiap hari</string>
+    <string name="profile_fetch_interval_never">Tidak pernah (dinonaktifkan)</string>
     <string name="update_check_frequency">Frekuensi pemeriksaan</string>
     <string name="update_frequency_on_startup">Setiap kali aplikasi dibuka</string>
     <string name="update_frequency_daily">Harian</string>

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -521,6 +521,16 @@
     <string name="stop_service">Ferma servizio</string>
     <string name="start_service_on_boot">Avvia servizio all\'avvio</string>
     <string name="start_service_on_boot_description">Quando abilitato, Amber avvierà automaticamente il suo servizio in background dopo l\'avvio del dispositivo, così l\'accesso remoto e le richieste NIP-46 continueranno a funzionare.</string>
+    <string name="profile_fetch_interval">Intervallo di recupero del profilo</string>
+    <string name="profile_fetch_interval_description">Con quale frequenza Amber controlla i relay per i metadati del profilo aggiornati (nome e immagine)</string>
+    <string name="profile_fetch_interval_always">Sempre (ogni volta)</string>
+    <string name="profile_fetch_interval_15_minutes">Ogni 15 minuti</string>
+    <string name="profile_fetch_interval_30_minutes">Ogni 30 minuti</string>
+    <string name="profile_fetch_interval_1_hour">Ogni ora</string>
+    <string name="profile_fetch_interval_3_hours">Ogni 3 ore</string>
+    <string name="profile_fetch_interval_6_hours">Ogni 6 ore</string>
+    <string name="profile_fetch_interval_1_day">Ogni giorno</string>
+    <string name="profile_fetch_interval_never">Mai (disabilitato)</string>
     <string name="update_check_frequency">Frequenza di controllo</string>
     <string name="update_frequency_on_startup">Ad ogni avvio dell\'app</string>
     <string name="update_frequency_daily">Giornalmente</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -497,6 +497,16 @@
     <string name="stop_service">サービスを停止</string>
     <string name="start_service_on_boot">起動時にサービスを開始</string>
     <string name="start_service_on_boot_description">有効にすると、デバイス起動後に Amber がバックグラウンドサービスを自動的に開始し、リモートログインと NIP-46 リクエストが継続して機能します。</string>
+    <string name="profile_fetch_interval">プロフィール取得間隔</string>
+    <string name="profile_fetch_interval_description">Amberが更新されたプロフィールメタデータ(名前と画像)をリレーで確認する頻度</string>
+    <string name="profile_fetch_interval_always">常に(毎回)</string>
+    <string name="profile_fetch_interval_15_minutes">15分ごと</string>
+    <string name="profile_fetch_interval_30_minutes">30分ごと</string>
+    <string name="profile_fetch_interval_1_hour">1時間ごと</string>
+    <string name="profile_fetch_interval_3_hours">3時間ごと</string>
+    <string name="profile_fetch_interval_6_hours">6時間ごと</string>
+    <string name="profile_fetch_interval_1_day">1日ごと</string>
+    <string name="profile_fetch_interval_never">しない(無効)</string>
     <string name="update_check_frequency">確認頻度</string>
     <string name="update_frequency_on_startup">アプリ起動のたびに</string>
     <string name="update_frequency_daily">毎日</string>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -521,6 +521,16 @@
     <string name="stop_service">서비스 중지</string>
     <string name="start_service_on_boot">부팅 시 서비스 시작</string>
     <string name="start_service_on_boot_description">활성화하면 기기 부팅 후 Amber가 백그라운드 서비스를 자동으로 시작하여 원격 로그인 및 NIP-46 요청이 계속 작동합니다.</string>
+    <string name="profile_fetch_interval">프로필 가져오기 간격</string>
+    <string name="profile_fetch_interval_description">Amber가 업데이트된 프로필 메타데이터(이름 및 사진)를 릴레이에서 확인하는 빈도</string>
+    <string name="profile_fetch_interval_always">항상(매번)</string>
+    <string name="profile_fetch_interval_15_minutes">15분마다</string>
+    <string name="profile_fetch_interval_30_minutes">30분마다</string>
+    <string name="profile_fetch_interval_1_hour">1시간마다</string>
+    <string name="profile_fetch_interval_3_hours">3시간마다</string>
+    <string name="profile_fetch_interval_6_hours">6시간마다</string>
+    <string name="profile_fetch_interval_1_day">매일</string>
+    <string name="profile_fetch_interval_never">안 함(비활성화)</string>
     <string name="update_check_frequency">확인 빈도</string>
     <string name="update_frequency_on_startup">앱 시작 시마다</string>
     <string name="update_frequency_daily">매일</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -516,6 +516,16 @@
     <string name="stop_service">Parar serviço</string>
     <string name="start_service_on_boot">Iniciar serviço na inicialização</string>
     <string name="start_service_on_boot_description">Quando ativado, o Amber iniciará seu serviço em segundo plano automaticamente após o dispositivo ser ligado, para que o login remoto e as solicitações NIP-46 continuem funcionando.</string>
+    <string name="profile_fetch_interval">Intervalo de busca de perfil</string>
+    <string name="profile_fetch_interval_description">Com que frequência o Amber verifica os relays em busca de metadados de perfil atualizados (nome e foto)</string>
+    <string name="profile_fetch_interval_always">Sempre (todas as vezes)</string>
+    <string name="profile_fetch_interval_15_minutes">A cada 15 minutos</string>
+    <string name="profile_fetch_interval_30_minutes">A cada 30 minutos</string>
+    <string name="profile_fetch_interval_1_hour">A cada hora</string>
+    <string name="profile_fetch_interval_3_hours">A cada 3 horas</string>
+    <string name="profile_fetch_interval_6_hours">A cada 6 horas</string>
+    <string name="profile_fetch_interval_1_day">Todos os dias</string>
+    <string name="profile_fetch_interval_never">Nunca (desativado)</string>
     <string name="update_check_frequency">Frequência de verificação</string>
     <string name="update_frequency_on_startup">A cada início do app</string>
     <string name="update_frequency_daily">Diariamente</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -521,6 +521,16 @@
     <string name="stop_service">Остановить службу</string>
     <string name="start_service_on_boot">Запускать службу при загрузке</string>
     <string name="start_service_on_boot_description">При включении Amber будет автоматически запускать фоновую службу после загрузки устройства, чтобы удалённый вход и запросы NIP-46 продолжали работать.</string>
+    <string name="profile_fetch_interval">Интервал получения профиля</string>
+    <string name="profile_fetch_interval_description">Как часто Amber проверяет реле на наличие обновлённых метаданных профиля (имя и изображение)</string>
+    <string name="profile_fetch_interval_always">Всегда (каждый раз)</string>
+    <string name="profile_fetch_interval_15_minutes">Каждые 15 минут</string>
+    <string name="profile_fetch_interval_30_minutes">Каждые 30 минут</string>
+    <string name="profile_fetch_interval_1_hour">Каждый час</string>
+    <string name="profile_fetch_interval_3_hours">Каждые 3 часа</string>
+    <string name="profile_fetch_interval_6_hours">Каждые 6 часов</string>
+    <string name="profile_fetch_interval_1_day">Каждый день</string>
+    <string name="profile_fetch_interval_never">Никогда (отключено)</string>
     <string name="update_check_frequency">Частота проверки</string>
     <string name="update_frequency_on_startup">При каждом запуске</string>
     <string name="update_frequency_daily">Ежедневно</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -497,6 +497,16 @@
     <string name="stop_service">หยุดบริการ</string>
     <string name="start_service_on_boot">เริ่มบริการเมื่อเปิดเครื่อง</string>
     <string name="start_service_on_boot_description">เมื่อเปิดใช้งาน Amber จะเริ่มบริการพื้นหลังโดยอัตโนมัติหลังจากอุปกรณ์เปิดเครื่อง เพื่อให้การล็อกอินระยะไกลและคำขอ NIP-46 ยังคงทำงานได้</string>
+    <string name="profile_fetch_interval">ช่วงเวลาดึงข้อมูลโปรไฟล์</string>
+    <string name="profile_fetch_interval_description">ความถี่ที่ Amber ตรวจสอบรีเลย์เพื่อหาข้อมูลเมตาโปรไฟล์ที่อัปเดต (ชื่อและรูปภาพ)</string>
+    <string name="profile_fetch_interval_always">เสมอ (ทุกครั้ง)</string>
+    <string name="profile_fetch_interval_15_minutes">ทุก 15 นาที</string>
+    <string name="profile_fetch_interval_30_minutes">ทุก 30 นาที</string>
+    <string name="profile_fetch_interval_1_hour">ทุกชั่วโมง</string>
+    <string name="profile_fetch_interval_3_hours">ทุก 3 ชั่วโมง</string>
+    <string name="profile_fetch_interval_6_hours">ทุก 6 ชั่วโมง</string>
+    <string name="profile_fetch_interval_1_day">ทุกวัน</string>
+    <string name="profile_fetch_interval_never">ไม่ทำ (ปิดใช้งาน)</string>
     <string name="update_check_frequency">ความถี่การตรวจสอบ</string>
     <string name="update_frequency_on_startup">ทุกครั้งที่เปิดแอป</string>
     <string name="update_frequency_daily">ทุกวัน</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -518,7 +518,7 @@
     <string name="start_service_on_boot">Önyüklemede servisi başlat</string>
     <string name="start_service_on_boot_description">Etkinleştirildiğinde Amber, cihaz başladıktan sonra arka plan servisini otomatik olarak başlatır; böylece uzak oturum açma ve NIP-46 istekleri çalışmaya devam eder.</string>
     <string name="profile_fetch_interval">Profil getirme aralığı</string>
-    <string name="profile_fetch_interval_description">Amber'ın güncellenmiş profil meta verilerini (ad ve resim) röleler üzerinden ne sıklıkla kontrol ettiği</string>
+    <string name="profile_fetch_interval_description">Amber\'ın güncellenmiş profil meta verilerini (ad ve resim) röleler üzerinden ne sıklıkla kontrol ettiği</string>
     <string name="profile_fetch_interval_always">Her zaman (her seferinde)</string>
     <string name="profile_fetch_interval_15_minutes">Her 15 dakikada bir</string>
     <string name="profile_fetch_interval_30_minutes">Her 30 dakikada bir</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -517,6 +517,16 @@
     <string name="stop_service">Servisi durdur</string>
     <string name="start_service_on_boot">Önyüklemede servisi başlat</string>
     <string name="start_service_on_boot_description">Etkinleştirildiğinde Amber, cihaz başladıktan sonra arka plan servisini otomatik olarak başlatır; böylece uzak oturum açma ve NIP-46 istekleri çalışmaya devam eder.</string>
+    <string name="profile_fetch_interval">Profil getirme aralığı</string>
+    <string name="profile_fetch_interval_description">Amber'ın güncellenmiş profil meta verilerini (ad ve resim) röleler üzerinden ne sıklıkla kontrol ettiği</string>
+    <string name="profile_fetch_interval_always">Her zaman (her seferinde)</string>
+    <string name="profile_fetch_interval_15_minutes">Her 15 dakikada bir</string>
+    <string name="profile_fetch_interval_30_minutes">Her 30 dakikada bir</string>
+    <string name="profile_fetch_interval_1_hour">Her saat</string>
+    <string name="profile_fetch_interval_3_hours">Her 3 saatte bir</string>
+    <string name="profile_fetch_interval_6_hours">Her 6 saatte bir</string>
+    <string name="profile_fetch_interval_1_day">Her gün</string>
+    <string name="profile_fetch_interval_never">Asla (devre dışı)</string>
     <string name="update_check_frequency">Denetleme sıklığı</string>
     <string name="update_frequency_on_startup">Her uygulama başlangıcında</string>
     <string name="update_frequency_daily">Günlük</string>

--- a/app/src/main/res/values-vi-rVN/strings.xml
+++ b/app/src/main/res/values-vi-rVN/strings.xml
@@ -497,6 +497,16 @@
     <string name="stop_service">Dừng dịch vụ</string>
     <string name="start_service_on_boot">Khởi động dịch vụ khi bật máy</string>
     <string name="start_service_on_boot_description">Khi được bật, Amber sẽ tự động khởi động dịch vụ nền sau khi thiết bị khởi động để đăng nhập từ xa và các yêu cầu NIP-46 tiếp tục hoạt động.</string>
+    <string name="profile_fetch_interval">Khoảng thời gian lấy hồ sơ</string>
+    <string name="profile_fetch_interval_description">Tần suất Amber kiểm tra relay để tìm siêu dữ liệu hồ sơ đã cập nhật (tên và ảnh)</string>
+    <string name="profile_fetch_interval_always">Luôn luôn (mỗi lần)</string>
+    <string name="profile_fetch_interval_15_minutes">Mỗi 15 phút</string>
+    <string name="profile_fetch_interval_30_minutes">Mỗi 30 phút</string>
+    <string name="profile_fetch_interval_1_hour">Mỗi giờ</string>
+    <string name="profile_fetch_interval_3_hours">Mỗi 3 giờ</string>
+    <string name="profile_fetch_interval_6_hours">Mỗi 6 giờ</string>
+    <string name="profile_fetch_interval_1_day">Mỗi ngày</string>
+    <string name="profile_fetch_interval_never">Không bao giờ (đã tắt)</string>
     <string name="update_check_frequency">Tần suất kiểm tra</string>
     <string name="update_frequency_on_startup">Mỗi lần khởi động ứng dụng</string>
     <string name="update_frequency_daily">Hàng ngày</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -502,6 +502,16 @@
     <string name="stop_service">停止服务</string>
     <string name="start_service_on_boot">开启时启动服务</string>
     <string name="start_service_on_boot_description">启用后，Amber将在设备启动后自动启动后台服务，可以使远程登录和 NIP-46 请求继续保持运行。</string>
+    <string name="profile_fetch_interval">个人资料获取间隔</string>
+    <string name="profile_fetch_interval_description">Amber 检查中继以获取更新的个人资料元数据(名称和图片)的频率</string>
+    <string name="profile_fetch_interval_always">总是(每次)</string>
+    <string name="profile_fetch_interval_15_minutes">每 15 分钟</string>
+    <string name="profile_fetch_interval_30_minutes">每 30 分钟</string>
+    <string name="profile_fetch_interval_1_hour">每小时</string>
+    <string name="profile_fetch_interval_3_hours">每 3 小时</string>
+    <string name="profile_fetch_interval_6_hours">每 6 小时</string>
+    <string name="profile_fetch_interval_1_day">每天</string>
+    <string name="profile_fetch_interval_never">从不(已禁用)</string>
     <string name="update_check_frequency">检查频率</string>
     <string name="update_frequency_on_startup">每次应用启动时</string>
     <string name="update_frequency_daily">每天</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -546,12 +546,14 @@
     <string name="start_service_on_boot_description">When enabled, Amber will start its background service automatically after the device boots so remote login and NIP-46 requests keep working.</string>
     <string name="profile_fetch_interval">Profile fetch interval</string>
     <string name="profile_fetch_interval_description">How often Amber checks relays for updated profile metadata (name and picture)</string>
+    <string name="profile_fetch_interval_always">Always (every time)</string>
     <string name="profile_fetch_interval_15_minutes">Every 15 minutes</string>
     <string name="profile_fetch_interval_30_minutes">Every 30 minutes</string>
     <string name="profile_fetch_interval_1_hour">Every hour</string>
     <string name="profile_fetch_interval_3_hours">Every 3 hours</string>
     <string name="profile_fetch_interval_6_hours">Every 6 hours</string>
     <string name="profile_fetch_interval_1_day">Every day</string>
+    <string name="profile_fetch_interval_never">Never (disabled)</string>
     <string name="update_check_frequency">Check frequency</string>
     <string name="update_frequency_on_startup">Every app start</string>
     <string name="update_frequency_daily">Daily</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -544,6 +544,14 @@
     <string name="stop_service">Stop service</string>
     <string name="start_service_on_boot">Start service on boot</string>
     <string name="start_service_on_boot_description">When enabled, Amber will start its background service automatically after the device boots so remote login and NIP-46 requests keep working.</string>
+    <string name="profile_fetch_interval">Profile fetch interval</string>
+    <string name="profile_fetch_interval_description">How often Amber checks relays for updated profile metadata (name and picture)</string>
+    <string name="profile_fetch_interval_15_minutes">Every 15 minutes</string>
+    <string name="profile_fetch_interval_30_minutes">Every 30 minutes</string>
+    <string name="profile_fetch_interval_1_hour">Every hour</string>
+    <string name="profile_fetch_interval_3_hours">Every 3 hours</string>
+    <string name="profile_fetch_interval_6_hours">Every 6 hours</string>
+    <string name="profile_fetch_interval_1_day">Every day</string>
     <string name="update_check_frequency">Check frequency</string>
     <string name="update_frequency_on_startup">Every app start</string>
     <string name="update_frequency_daily">Daily</string>


### PR DESCRIPTION
## Summary
Adds a new user-configurable setting to control how frequently Amber checks relays for updated profile metadata (name and picture). This allows users to balance between keeping profile information fresh and reducing network traffic.

## Key Changes

- **New `ProfileFetchInterval` enum** (`models/ProfileFetchInterval.kt`): Defines eight fetch frequency options ranging from "Always" to "Never", with durations in minutes and associated string resource IDs for UI display.

- **Settings persistence**: 
  - Added `PROFILE_FETCH_INTERVAL` key to `LocalPreferences.SettingsKeys`
  - Implemented `updateProfileFetchInterval()` method to save the selected interval to shared preferences
  - Updated `AmberSettings` data class to include `profileFetchInterval` field
  - Added deserialization logic with fallback to `FIFTEEN_MINUTES` as default

- **UI integration** (`DefaultProfileRelaysScreen.kt`):
  - Added `SettingsRow` dropdown to allow users to select their preferred fetch interval
  - Integrated with the existing settings UI pattern using `TitleExplainer` components
  - Added state management for the selected interval with immediate persistence

- **Profile subscription logic** (`ProfileSubscription.kt`):
  - Modified `updateFilter()` to respect the configured interval
  - Added early return if interval is set to `NEVER`
  - Implemented dynamic fetch timing: `ALWAYS` fetches every time, other intervals use a calculated time threshold based on the selected duration
  - Replaced hardcoded 15-minute check with configurable `fetchIntervalAgo` calculation

- **Internationalization**: Added string resources for all eight interval options and descriptions in 14 languages (English, German, Spanish, French, Indonesian, Italian, Japanese, Korean, Portuguese, Russian, Thai, Turkish, Vietnamese, and Chinese).

## Implementation Details

The fetch interval is checked at the start of `ProfileSubscription.updateFilter()`, allowing the setting to take effect immediately without requiring an app restart. The `ALWAYS` option bypasses time-based checks entirely, while other intervals calculate the threshold dynamically using `TimeUtils.now() - (interval.minutes * 60)` to determine if a fetch is needed.

https://claude.ai/code/session_01MF4bzgFXPSoiaF6e4CeKN6