### PR TITLE
Remove relay.damus.io from default relay lists

### DIFF
--- a/app/src/main/java/com/greenart7c3/nostrsigner/Amber.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/Amber.kt
@@ -649,7 +649,6 @@ class Amber :
     ): Boolean {
         val relays = setOfNotNull(
             RelayUrlNormalizer.normalizeOrNull("wss://nos.lol/"),
-            RelayUrlNormalizer.normalizeOrNull("wss://relay.damus.io/"),
         )
 
         val repositoryEvent = GitRepositoryEvent(

--- a/app/src/main/java/com/greenart7c3/nostrsigner/service/ApplicationBackup.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/service/ApplicationBackup.kt
@@ -36,7 +36,6 @@ private const val PAYLOAD_VERSION = 1
 private val AGGREGATOR_RELAY = RelayUrlNormalizer.normalizeOrNull("wss://aggr.nostr.land/")
 private val INBOX_FALLBACK_RELAYS = listOfNotNull(
     RelayUrlNormalizer.normalizeOrNull("wss://nos.lol/"),
-    RelayUrlNormalizer.normalizeOrNull("wss://relay.damus.io/"),
 )
 
 data class BackupPermission(

--- a/app/src/main/java/com/greenart7c3/nostrsigner/service/ZapstoreUpdater.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/service/ZapstoreUpdater.kt
@@ -40,7 +40,6 @@ private const val EOSE_TIMEOUT_MS = 15_000L
 private const val RELEASE_KIND = 30063
 private val UPDATE_RELAY_URLS = listOf(
     "wss://relay.zapstore.dev",
-    "wss://relay.damus.io",
     "wss://nos.lol",
 )
 private const val APP_IDENTIFIER = "com.greenart7c3.nostrsigner"


### PR DESCRIPTION
## Summary
Removes `wss://relay.damus.io/` from the default relay configuration across three files where it was used as a fallback or update relay.

## Changes
- **Amber.kt**: Removed `relay.damus.io` from the default relays used for Git repository events
- **ApplicationBackup.kt**: Removed `relay.damus.io` from inbox fallback relays used during backup operations
- **ZapstoreUpdater.kt**: Removed `relay.damus.io` from the update relay URLs list

## Details
The relay was previously included as a secondary option alongside `nos.lol` and other relays for critical operations like backup/restore and app updates. This change consolidates the relay list to remove the Damus relay as a default fallback, likely due to reliability or operational concerns.

https://claude.ai/code/session_01SbHwhreLtpQwvhqgALBANG