### PR TITLE
Add relay trust score strings for all supported languages

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -636,6 +636,8 @@
     <string name="trust_fair">Akzeptabel</string>
     <string name="trust_poor">Schlecht</string>
     <string name="trust_unknown">Unbekannt</string>
+    <string name="relay_trust_score">Relay-Vertrauenswerte</string>
+    <string name="relay_trust_score_description">Vertrauenswerte für Relays von trustedrelays.xyz abrufen und anzeigen</string>
     <string name="relays_used">Verwendete Relays</string>
     <string name="do_not_leave_the_app_until_the_key_is_generated">Verlasse die App nicht, bis der Schlüssel generiert wurde</string>
     <string name="status_detail">Statusdetails</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -639,6 +639,8 @@
     <string name="trust_fair">Regular</string>
     <string name="trust_poor">Deficiente</string>
     <string name="trust_unknown">Desconocido</string>
+    <string name="relay_trust_score">Puntuaciones de confianza de relays</string>
+    <string name="relay_trust_score_description">Obtener y mostrar las puntuaciones de confianza de los relays desde trustedrelays.xyz</string>
     <string name="relays_used">Relays utilizados</string>
     <string name="do_not_leave_the_app_until_the_key_is_generated">No salgas de la aplicación hasta que se genere la clave</string>
     <string name="status_detail">Detalle del estado</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -636,6 +636,8 @@
     <string name="trust_fair">Correct</string>
     <string name="trust_poor">Faible</string>
     <string name="trust_unknown">Inconnu</string>
+    <string name="relay_trust_score">Scores de confiance des relays</string>
+    <string name="relay_trust_score_description">Récupérer et afficher les scores de confiance des relays depuis trustedrelays.xyz</string>
     <string name="relays_used">Relays utilisés</string>
     <string name="do_not_leave_the_app_until_the_key_is_generated">Ne quittez pas l\'application tant que la clé n\'est pas générée</string>
     <string name="status_detail">Détail du statut</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -639,6 +639,8 @@
     <string name="trust_fair">Cukup</string>
     <string name="trust_poor">Buruk</string>
     <string name="trust_unknown">Tidak diketahui</string>
+    <string name="relay_trust_score">Skor kepercayaan relay</string>
+    <string name="relay_trust_score_description">Ambil dan tampilkan skor kepercayaan relay dari trustedrelays.xyz</string>
     <string name="relays_used">Relay yang digunakan</string>
     <string name="do_not_leave_the_app_until_the_key_is_generated">Jangan tinggalkan aplikasi hingga kunci dibuat</string>
     <string name="status_detail">Detail Status</string>

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -639,6 +639,8 @@
     <string name="trust_fair">Discreto</string>
     <string name="trust_poor">Scarso</string>
     <string name="trust_unknown">Sconosciuto</string>
+    <string name="relay_trust_score">Punteggi di affidabilità dei relay</string>
+    <string name="relay_trust_score_description">Recupera e mostra i punteggi di affidabilità dei relay da trustedrelays.xyz</string>
     <string name="relays_used">Relay usati</string>
     <string name="do_not_leave_the_app_until_the_key_is_generated">Non abbandonare l\'app fino alla generazione della chiave</string>
     <string name="status_detail">Dettaglio stato</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -615,6 +615,8 @@
     <string name="trust_fair">普通</string>
     <string name="trust_poor">低い</string>
     <string name="trust_unknown">不明</string>
+    <string name="relay_trust_score">Relay の信頼スコア</string>
+    <string name="relay_trust_score_description">trustedrelays.xyz から relay の信頼スコアを取得して表示します</string>
     <string name="relays_used">使用中の relay</string>
     <string name="do_not_leave_the_app_until_the_key_is_generated">キーが生成されるまでアプリを離れないでください</string>
     <string name="status_detail">ステータス詳細</string>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -639,6 +639,8 @@
     <string name="trust_fair">보통</string>
     <string name="trust_poor">낮음</string>
     <string name="trust_unknown">알 수 없음</string>
+    <string name="relay_trust_score">Relay 신뢰 점수</string>
+    <string name="relay_trust_score_description">trustedrelays.xyz에서 relay 신뢰 점수를 가져와 표시합니다</string>
     <string name="relays_used">사용된 relay</string>
     <string name="do_not_leave_the_app_until_the_key_is_generated">키가 생성될 때까지 앱을 벗어나지 마세요</string>
     <string name="status_detail">상태 상세</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -634,6 +634,8 @@
     <string name="trust_fair">Regular</string>
     <string name="trust_poor">Ruim</string>
     <string name="trust_unknown">Desconhecido</string>
+    <string name="relay_trust_score">Pontuações de confiança dos relays</string>
+    <string name="relay_trust_score_description">Obter e exibir as pontuações de confiança dos relays de trustedrelays.xyz</string>
     <string name="relays_used">Relays utilizados</string>
     <string name="do_not_leave_the_app_until_the_key_is_generated">Não saia do app até que a chave seja gerada</string>
     <string name="status_detail">Detalhes do status</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -639,6 +639,8 @@
     <string name="trust_fair">Удовлетворительно</string>
     <string name="trust_poor">Плохо</string>
     <string name="trust_unknown">Неизвестно</string>
+    <string name="relay_trust_score">Оценки доверия relay-серверов</string>
+    <string name="relay_trust_score_description">Получать и отображать оценки доверия relay-серверов с trustedrelays.xyz</string>
     <string name="relays_used">Используемые relay-серверы</string>
     <string name="do_not_leave_the_app_until_the_key_is_generated">Не покидайте приложение до завершения генерации ключа</string>
     <string name="status_detail">Подробности статуса</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -615,6 +615,8 @@
     <string name="trust_fair">พอใช้</string>
     <string name="trust_poor">แย่</string>
     <string name="trust_unknown">ไม่ทราบ</string>
+    <string name="relay_trust_score">คะแนนความน่าเชื่อถือของ relay</string>
+    <string name="relay_trust_score_description">ดึงและแสดงคะแนนความน่าเชื่อถือของ relay จาก trustedrelays.xyz</string>
     <string name="relays_used">Relay ที่ใช้</string>
     <string name="do_not_leave_the_app_until_the_key_is_generated">อย่าออกจากแอปจนกว่าจะสร้างคีย์เสร็จสิ้น</string>
     <string name="status_detail">รายละเอียดสถานะ</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -635,6 +635,8 @@
     <string name="trust_fair">Orta</string>
     <string name="trust_poor">Zayıf</string>
     <string name="trust_unknown">Bilinmiyor</string>
+    <string name="relay_trust_score">Relay güven puanları</string>
+    <string name="relay_trust_score_description">trustedrelays.xyz\'den relay güven puanlarını getir ve görüntüle</string>
     <string name="relays_used">Kullanılan röleler</string>
     <string name="do_not_leave_the_app_until_the_key_is_generated">Anahtar oluşturulana kadar uygulamadan ayrılmayın</string>
     <string name="status_detail">Durum Detayı</string>

--- a/app/src/main/res/values-vi-rVN/strings.xml
+++ b/app/src/main/res/values-vi-rVN/strings.xml
@@ -615,6 +615,8 @@
     <string name="trust_fair">Khá</string>
     <string name="trust_poor">Kém</string>
     <string name="trust_unknown">Không xác định</string>
+    <string name="relay_trust_score">Điểm tin cậy của relay</string>
+    <string name="relay_trust_score_description">Tải và hiển thị điểm tin cậy của relay từ trustedrelays.xyz</string>
     <string name="relays_used">Relay đã sử dụng</string>
     <string name="do_not_leave_the_app_until_the_key_is_generated">Không rời ứng dụng cho đến khi khóa được tạo xong</string>
     <string name="status_detail">Chi Tiết Trạng Thái</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -620,6 +620,8 @@
     <string name="trust_fair">合理</string>
     <string name="trust_poor">较差</string>
     <string name="trust_unknown">未知</string>
+    <string name="relay_trust_score">中继信任评分</string>
+    <string name="relay_trust_score_description">从 trustedrelays.xyz 获取并显示中继信任评分</string>
     <string name="relays_used">已使用的中继</string>
     <string name="do_not_leave_the_app_until_the_key_is_generated">在密钥生成之前不要离开应用</string>
     <string name="status_detail">状态详情</string>


### PR DESCRIPTION
## Summary
Add internationalized strings for relay trust score feature across all supported languages. This adds UI labels and descriptions for fetching and displaying relay trust scores from trustedrelays.xyz.

## Changes
- Added `relay_trust_score` string (feature label) to 13 language files
- Added `relay_trust_score_description` string (feature description) to 13 language files
- Translations provided for: German, Spanish, French, Indonesian, Italian, Japanese, Korean, Portuguese (Brazil), Russian, Thai, Turkish, Vietnamese, and Simplified Chinese

## Details
The strings are positioned consistently after the trust level definitions (`trust_fair`, `trust_poor`, `trust_unknown`) and before the `relays_used` string in each language file. This maintains a logical grouping of trust-related UI elements.

https://claude.ai/code/session_01MRQzUYa2Y6NsYfmdjk5p5s