### PR TITLE
Add support for event kinds 12022 and 32022 (Expert List/Pack)

### DIFF
--- a/app/src/main/java/com/greenart7c3/nostrsigner/models/Permission.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/models/Permission.kt
@@ -214,6 +214,7 @@ data class Permission(
                 10102 -> context.getString(R.string.event_kind_10102)
                 10443 -> context.getString(R.string.event_kind_10443)
                 11125 -> context.getString(R.string.event_kind_11125)
+                12022 -> context.getString(R.string.event_kind_12022)
                 13194 -> context.getString(R.string.event_kind_13194)
                 14919 -> context.getString(R.string.event_kind_14919)
                 14920 -> context.getString(R.string.event_kind_14920)
@@ -269,6 +270,7 @@ data class Permission(
                 34235 -> context.getString(R.string.event_kind_34235)
                 34236 -> context.getString(R.string.event_kind_34236)
                 34237 -> context.getString(R.string.event_kind_34237)
+                32022 -> context.getString(R.string.event_kind_32022)
                 32267 -> context.getString(R.string.event_kind_32267)
                 34139 -> context.getString(R.string.event_kind_34139)
                 34550 -> context.getString(R.string.event_kind_34550)
@@ -506,6 +508,8 @@ val supportedKindNumbers = listOf(
     Permission("sign_event", 2003),
     Permission("sign_event", 2004),
     Permission("sign_event", 2022),
+    Permission("sign_event", 12022),
+    Permission("sign_event", 32022),
     Permission("sign_event", 4550),
     Permission("sign_event", 5000),
     Permission("sign_event", 5999),

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -486,6 +486,8 @@
     <string name="event_kind_2003">Torrent</string>
     <string name="event_kind_2004">Torrent-Kommentar</string>
     <string name="event_kind_2022">Coinjoin Pool</string>
+    <string name="event_kind_12022">Expertenliste</string>
+    <string name="event_kind_32022">Expertenpaket</string>
     <string name="event_kind_1630_1633">Status</string>
     <string name="event_kind_1622">Antworten</string>
     <string name="event_kind_1621">Issues</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -489,6 +489,8 @@
     <string name="event_kind_2003">Torrent</string>
     <string name="event_kind_2004">Comentario de torrent</string>
     <string name="event_kind_2022">Pool de Coinjoin</string>
+    <string name="event_kind_12022">Lista de Expertos</string>
+    <string name="event_kind_32022">Paquete de Expertos</string>
     <string name="event_kind_1630_1633">Estado</string>
     <string name="event_kind_1622">Respuestas</string>
     <string name="event_kind_1621">Incidencias</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -486,6 +486,8 @@
     <string name="event_kind_2003">Torrent</string>
     <string name="event_kind_2004">Commentaire de torrent</string>
     <string name="event_kind_2022">Pool Coinjoin</string>
+    <string name="event_kind_12022">Liste d\'experts</string>
+    <string name="event_kind_32022">Pack d\'experts</string>
     <string name="event_kind_1630_1633">Statut</string>
     <string name="event_kind_1622">Réponses</string>
     <string name="event_kind_1621">Problèmes</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -489,6 +489,8 @@
     <string name="event_kind_2003">Torrent</string>
     <string name="event_kind_2004">Komentar Torrent</string>
     <string name="event_kind_2022">Pool Coinjoin</string>
+    <string name="event_kind_12022">Daftar Ahli</string>
+    <string name="event_kind_32022">Paket Ahli</string>
     <string name="event_kind_1630_1633">Status</string>
     <string name="event_kind_1622">Balasan</string>
     <string name="event_kind_1621">Isu</string>

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -489,6 +489,8 @@
     <string name="event_kind_2003">Torrent</string>
     <string name="event_kind_2004">Commento torrent</string>
     <string name="event_kind_2022">Pool Coinjoin</string>
+    <string name="event_kind_12022">Elenco di esperti</string>
+    <string name="event_kind_32022">Pacchetto di esperti</string>
     <string name="event_kind_1630_1633">Stato</string>
     <string name="event_kind_1622">Risposte</string>
     <string name="event_kind_1621">Problemi</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -465,6 +465,8 @@
     <string name="event_kind_2003">トレント</string>
     <string name="event_kind_2004">トレントコメント</string>
     <string name="event_kind_2022">Coinjoin プール</string>
+    <string name="event_kind_12022">エキスパートリスト</string>
+    <string name="event_kind_32022">エキスパートパック</string>
     <string name="event_kind_1630_1633">ステータス</string>
     <string name="event_kind_1622">返信</string>
     <string name="event_kind_1621">課題</string>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -489,6 +489,8 @@
     <string name="event_kind_2003">토렌트</string>
     <string name="event_kind_2004">토렌트 댓글</string>
     <string name="event_kind_2022">코인조인 풀</string>
+    <string name="event_kind_12022">전문가 목록</string>
+    <string name="event_kind_32022">전문가 팩</string>
     <string name="event_kind_1630_1633">상태</string>
     <string name="event_kind_1622">답글</string>
     <string name="event_kind_1621">이슈</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -484,6 +484,8 @@
     <string name="event_kind_2003">Torrent</string>
     <string name="event_kind_2004">Comentário do Torrent</string>
     <string name="event_kind_2022">Pool de Coinjoin</string>
+    <string name="event_kind_12022">Lista de Especialistas</string>
+    <string name="event_kind_32022">Pacote de Especialistas</string>
     <string name="event_kind_1630_1633">Status</string>
     <string name="event_kind_1622">Respostas</string>
     <string name="event_kind_1621">Problemas</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -489,6 +489,8 @@
     <string name="event_kind_2003">Торрент</string>
     <string name="event_kind_2004">Комментарий к торренту</string>
     <string name="event_kind_2022">Пул Coinjoin</string>
+    <string name="event_kind_12022">Список экспертов</string>
+    <string name="event_kind_32022">Набор экспертов</string>
     <string name="event_kind_1630_1633">Статус</string>
     <string name="event_kind_1622">Ответы</string>
     <string name="event_kind_1621">Задачи</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -465,6 +465,8 @@
     <string name="event_kind_2003">Torrent</string>
     <string name="event_kind_2004">ความคิดเห็น Torrent</string>
     <string name="event_kind_2022">Coinjoin Pool</string>
+    <string name="event_kind_12022">รายชื่อผู้เชี่ยวชาญ</string>
+    <string name="event_kind_32022">แพ็กผู้เชี่ยวชาญ</string>
     <string name="event_kind_1630_1633">สถานะ</string>
     <string name="event_kind_1622">การตอบกลับ</string>
     <string name="event_kind_1621">ปัญหา</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -485,6 +485,8 @@
     <string name="event_kind_2003">Torrent</string>
     <string name="event_kind_2004">Torrent Yorumu</string>
     <string name="event_kind_2022">Coinjoin Havuzu</string>
+    <string name="event_kind_12022">Uzman Listesi</string>
+    <string name="event_kind_32022">Uzman Paketi</string>
     <string name="event_kind_1630_1633">Durum</string>
     <string name="event_kind_1622">Yanıtlar</string>
     <string name="event_kind_1621">Sorunlar</string>

--- a/app/src/main/res/values-vi-rVN/strings.xml
+++ b/app/src/main/res/values-vi-rVN/strings.xml
@@ -465,6 +465,8 @@
     <string name="event_kind_2003">Torrent</string>
     <string name="event_kind_2004">Bình luận Torrent</string>
     <string name="event_kind_2022">Nhóm Coinjoin</string>
+    <string name="event_kind_12022">Danh sách chuyên gia</string>
+    <string name="event_kind_32022">Gói chuyên gia</string>
     <string name="event_kind_1630_1633">Trạng thái</string>
     <string name="event_kind_1622">Trả lời</string>
     <string name="event_kind_1621">Vấn đề</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -470,6 +470,8 @@
     <string name="event_kind_2003">Torrent</string>
     <string name="event_kind_2004">Torrent 评论</string>
     <string name="event_kind_2022">Coinjoint 池</string>
+    <string name="event_kind_12022">专家列表</string>
+    <string name="event_kind_32022">专家包</string>
     <string name="event_kind_1630_1633">状态</string>
     <string name="event_kind_1622">回复</string>
     <string name="event_kind_1621">议题</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -513,6 +513,8 @@
     <string name="event_kind_2003">Torrent</string>
     <string name="event_kind_2004">Torrent Comment</string>
     <string name="event_kind_2022">Coinjoin Pool</string>
+    <string name="event_kind_12022">Expert List</string>
+    <string name="event_kind_32022">Expert Pack</string>
     <string name="event_kind_1630_1633">Status</string>
     <string name="event_kind_1622">Replies</string>
     <string name="event_kind_1621">Issues</string>


### PR DESCRIPTION
## Summary
Add support for two new Nostr event kinds: 12022 (Expert List) and 32022 (Expert Pack). These kinds are now recognized as signable event types and include localized display names across all supported languages.

## Changes
- **Permission.kt**: Added event kind mappings for 12022 and 32022 in the `getEventKindName()` function, and registered both kinds in the `supportedKindNumbers` list
- **Localization**: Added translated strings for both event kinds across 14 language files:
  - English (base), German, Spanish, French, Indonesian, Italian, Japanese, Korean, Portuguese (Brazil), Russian, Thai, Turkish, Vietnamese, and Chinese

## Implementation Details
- Kind 12022 is mapped to "Expert List" (English) with appropriate translations in each language
- Kind 32022 is mapped to "Expert Pack" (English) with appropriate translations in each language
- Both kinds are registered as `sign_event` permissions, allowing them to be requested and signed like other event kinds
- The placement in the code maintains alphabetical/numerical ordering within the existing kind mappings

https://claude.ai/code/session_019XXRmLErMYC7vrCJET8g63