### PR TITLE
Fix timestamp conversion in event detail modals

### DIFF
--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/EncryptDecryptDetailModal.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/EncryptDecryptDetailModal.kt
@@ -97,7 +97,7 @@ fun EncryptDecryptDetailModal(
                         )
                         EventSection(
                             stringResource(R.string.date),
-                            TimeUtils.formatLongToCustomDateTimeWithSeconds(event.createdAt),
+                            TimeUtils.formatLongToCustomDateTimeWithSeconds(event.createdAt * 1000),
                             { copyToClipboard(clipboard, "${event.createdAt}") },
                         )
                         if (event.content.isNotEmpty()) {

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/EventDetailModal.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/EventDetailModal.kt
@@ -110,7 +110,7 @@ fun EventDetailModal(
                 )
                 EventSection(
                     stringResource(R.string.date),
-                    TimeUtils.formatLongToCustomDateTimeWithSeconds(event.createdAt),
+                    TimeUtils.formatLongToCustomDateTimeWithSeconds(event.createdAt * 1000),
                     {
                         copyToClipboard(clipboard, "${event.createdAt}")
                     },


### PR DESCRIPTION
## Summary
Fixes incorrect timestamp formatting in event detail modals by converting Unix seconds to milliseconds before passing to the date formatting utility.

## Changes
- **EncryptDecryptDetailModal.kt**: Multiply `event.createdAt` by 1000 before formatting to convert from Unix seconds to milliseconds
- **EventDetailModal.kt**: Multiply `event.createdAt` by 1000 before formatting to convert from Unix seconds to milliseconds

## Details
The `TimeUtils.formatLongToCustomDateTimeWithSeconds()` function expects a timestamp in milliseconds, but `event.createdAt` is stored as Unix seconds (standard for Nostr events). Without the conversion, timestamps were being displayed incorrectly. This fix ensures both event detail modals display the correct date and time.

https://claude.ai/code/session_01RGJT3Vb91p82TwmDZxqGem