### PR TITLE
Add Compose preview annotations to UI components

### DIFF
--- a/app/src/main/java/com/greenart7c3/nostrsigner/models/Account.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/models/Account.kt
@@ -22,6 +22,7 @@ import com.vitorpamplona.quartz.nip49PrivKeyEnc.Nip49
 import com.vitorpamplona.quartz.nip57Zaps.LnZapRequestEvent
 import com.vitorpamplona.quartz.nip57Zaps.PrivateZapRequestBuilder
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -38,6 +39,9 @@ class Account(
     val picture: MutableStateFlow<String>,
     signPolicy: Int,
     didBackup: Boolean,
+    // Watches name/picture to mark the account saveable; injectable so Compose
+    // previews can build an Account without the Amber Application singleton.
+    scope: CoroutineScope = Amber.instance.applicationIOScope,
 ) {
     var signPolicy: Int = signPolicy
         set(value) {
@@ -59,7 +63,7 @@ class Account(
     val saveable = _saveable.asStateFlow()
 
     init {
-        Amber.instance.applicationIOScope.launch {
+        scope.launch {
             combine(name, picture) { _, _ -> }.drop(1).collect {
                 _saveable.value = AccountState(this@Account)
             }

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/CenterCircularProgressIndicator.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/CenterCircularProgressIndicator.kt
@@ -12,6 +12,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.greenart7c3.nostrsigner.ui.theme.AmberPreview
+import com.greenart7c3.nostrsigner.ui.theme.ThemePreviews
 
 @Composable
 fun CenterCircularProgressIndicator(
@@ -32,5 +34,16 @@ fun CenterCircularProgressIndicator(
             }
             CircularProgressIndicator()
         }
+    }
+}
+
+@ThemePreviews
+@Composable
+private fun CenterCircularProgressIndicatorPreview() {
+    AmberPreview {
+        CenterCircularProgressIndicator(
+            modifier = Modifier.fillMaxSize(),
+            text = "Loading",
+        )
     }
 }

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/CenterCircularProgressIndicator.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/CenterCircularProgressIndicator.kt
@@ -39,7 +39,7 @@ fun CenterCircularProgressIndicator(
 
 @ThemePreviews
 @Composable
-private fun CenterCircularProgressIndicatorPreview() {
+fun CenterCircularProgressIndicatorPreview() {
     AmberPreview {
         CenterCircularProgressIndicator(
             modifier = Modifier.fillMaxSize(),

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/InvalidIntentScreen.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/InvalidIntentScreen.kt
@@ -78,7 +78,7 @@ fun InvalidIntentScreen(
 
 @ThemePreviews
 @Composable
-private fun InvalidIntentScreenPreview() {
+fun InvalidIntentScreenPreview() {
     AmberPreview {
         InvalidIntentScreen(onClose = {})
     }

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/InvalidIntentScreen.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/InvalidIntentScreen.kt
@@ -33,6 +33,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.greenart7c3.nostrsigner.R
+import com.greenart7c3.nostrsigner.ui.theme.AmberPreview
+import com.greenart7c3.nostrsigner.ui.theme.ThemePreviews
 
 @Composable
 fun InvalidIntentScreen(
@@ -71,5 +73,13 @@ fun InvalidIntentScreen(
         ) {
             Text(stringResource(R.string.invalid_intent_close_app))
         }
+    }
+}
+
+@ThemePreviews
+@Composable
+private fun InvalidIntentScreenPreview() {
+    AmberPreview {
+        InvalidIntentScreen(onClose = {})
     }
 }

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/QrCodeDrawer.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/QrCodeDrawer.kt
@@ -287,7 +287,7 @@ private fun DrawScope.drawQrCodeFinder(
 
 @ThemePreviews
 @Composable
-private fun QrCodeDrawerPreview() {
+fun QrCodeDrawerPreview() {
     AmberPreview {
         QrCodeDrawer(
             contents = "nostrconnect://460c25e682fda7832b52d1f22d3d22b3176d972f60dcdc3212ed8c92ef85065c?relay=wss%3A%2F%2Frelay.nsec.app",

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/QrCodeDrawer.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/QrCodeDrawer.kt
@@ -29,6 +29,8 @@ import com.google.zxing.qrcode.encoder.ByteMatrix
 import com.google.zxing.qrcode.encoder.Encoder
 import com.google.zxing.qrcode.encoder.QRCode
 import com.greenart7c3.nostrsigner.ui.actions.QrCodeDialog
+import com.greenart7c3.nostrsigner.ui.theme.AmberPreview
+import com.greenart7c3.nostrsigner.ui.theme.ThemePreviews
 
 const val QR_MARGIN_PX = 100f
 
@@ -281,4 +283,14 @@ private fun DrawScope.drawQrCodeFinder(
             )
         },
     )
+}
+
+@ThemePreviews
+@Composable
+private fun QrCodeDrawerPreview() {
+    AmberPreview {
+        QrCodeDrawer(
+            contents = "nostrconnect://460c25e682fda7832b52d1f22d3d22b3176d972f60dcdc3212ed8c92ef85065c?relay=wss%3A%2F%2Frelay.nsec.app",
+        )
+    }
 }

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/AcceptRejectButtons.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/AcceptRejectButtons.kt
@@ -44,7 +44,7 @@ fun AcceptRejectButtons(
 
 @ThemePreviews
 @Composable
-private fun AcceptRejectButtonsPreview() {
+fun AcceptRejectButtonsPreview() {
     AmberPreview {
         AcceptRejectButtons(
             onAccept = {},

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/AcceptRejectButtons.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/AcceptRejectButtons.kt
@@ -11,6 +11,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.greenart7c3.nostrsigner.R
+import com.greenart7c3.nostrsigner.ui.theme.AmberPreview
+import com.greenart7c3.nostrsigner.ui.theme.ThemePreviews
 
 @Composable
 fun AcceptRejectButtons(
@@ -36,6 +38,17 @@ fun AcceptRejectButtons(
             Modifier.weight(1f),
             onClick = onAccept,
             text = stringResource(R.string.accept),
+        )
+    }
+}
+
+@ThemePreviews
+@Composable
+private fun AcceptRejectButtonsPreview() {
+    AmberPreview {
+        AcceptRejectButtons(
+            onAccept = {},
+            onReject = {},
         )
     }
 }

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/AmberButton.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/AmberButton.kt
@@ -115,7 +115,7 @@ fun AmberElevatedButton(
 
 @ThemePreviews
 @Composable
-private fun AmberButtonPreview() {
+fun AmberButtonPreview() {
     AmberPreview {
         AmberButton(
             onClick = {},
@@ -126,7 +126,7 @@ private fun AmberButtonPreview() {
 
 @ThemePreviews
 @Composable
-private fun AmberButtonDisabledPreview() {
+fun AmberButtonDisabledPreview() {
     AmberPreview {
         AmberButton(
             onClick = {},
@@ -138,7 +138,7 @@ private fun AmberButtonDisabledPreview() {
 
 @ThemePreviews
 @Composable
-private fun AmberElevatedButtonPreview() {
+fun AmberElevatedButtonPreview() {
     AmberPreview {
         AmberElevatedButton(
             onClick = {},

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/AmberButton.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/AmberButton.kt
@@ -20,6 +20,8 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.dp
+import com.greenart7c3.nostrsigner.ui.theme.AmberPreview
+import com.greenart7c3.nostrsigner.ui.theme.ThemePreviews
 
 @Composable
 fun AmberButton(
@@ -108,5 +110,39 @@ fun AmberElevatedButton(
                 )
             }
         }
+    }
+}
+
+@ThemePreviews
+@Composable
+private fun AmberButtonPreview() {
+    AmberPreview {
+        AmberButton(
+            onClick = {},
+            text = "Accept",
+        )
+    }
+}
+
+@ThemePreviews
+@Composable
+private fun AmberButtonDisabledPreview() {
+    AmberPreview {
+        AmberButton(
+            onClick = {},
+            enabled = false,
+            text = "Accept",
+        )
+    }
+}
+
+@ThemePreviews
+@Composable
+private fun AmberElevatedButtonPreview() {
+    AmberPreview {
+        AmberElevatedButton(
+            onClick = {},
+            text = "Copy to clipboard",
+        )
     }
 }

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/AmberToggles.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/AmberToggles.kt
@@ -26,6 +26,8 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
+import com.greenart7c3.nostrsigner.ui.theme.AmberPreview
+import com.greenart7c3.nostrsigner.ui.theme.ThemePreviews
 import kotlin.math.roundToInt
 
 /**
@@ -143,5 +145,18 @@ fun <T> AmberToggles(
                 }
             }
         }
+    }
+}
+
+@ThemePreviews
+@Composable
+private fun AmberTogglesPreview() {
+    AmberPreview {
+        AmberToggles(
+            selected = "10 min",
+            options = listOf("Never", "10 min", "1 hour", "Always"),
+            onSelected = {},
+            label = { it },
+        )
     }
 }

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/AmberToggles.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/AmberToggles.kt
@@ -150,7 +150,7 @@ fun <T> AmberToggles(
 
 @ThemePreviews
 @Composable
-private fun AmberTogglesPreview() {
+fun AmberTogglesPreview() {
     AmberPreview {
         AmberToggles(
             selected = "10 min",

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/AmberWarningCard.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/AmberWarningCard.kt
@@ -59,7 +59,7 @@ fun AmberWarningCard(
 
 @ThemePreviews
 @Composable
-private fun AmberWarningCardPreview() {
+fun AmberWarningCardPreview() {
     AmberPreview {
         Box(Modifier.padding(8.dp)) {
             AmberWarningCard(

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/AmberWarningCard.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/AmberWarningCard.kt
@@ -16,6 +16,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.greenart7c3.nostrsigner.ui.theme.AmberPreview
+import com.greenart7c3.nostrsigner.ui.theme.ThemePreviews
 
 @Composable
 fun AmberWarningCard(
@@ -50,6 +52,20 @@ fun AmberWarningCard(
                         color = Color.Black,
                     )
                 },
+            )
+        }
+    }
+}
+
+@ThemePreviews
+@Composable
+private fun AmberWarningCardPreview() {
+    AmberPreview {
+        Box(Modifier.padding(8.dp)) {
+            AmberWarningCard(
+                message = "You have not backed up your account yet",
+                buttonText = "Back up now",
+                onClick = {},
             )
         }
     }

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/AppAvatar.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/AppAvatar.kt
@@ -95,7 +95,7 @@ fun AppAvatar(
 
 @ThemePreviews
 @Composable
-private fun AppAvatarPlaceholderPreview() {
+fun AppAvatarPlaceholderPreview() {
     AmberPreview {
         Box(Modifier.padding(8.dp)) {
             AppAvatar(name = "Amethyst")
@@ -105,7 +105,7 @@ private fun AppAvatarPlaceholderPreview() {
 
 @Preview(showBackground = true)
 @Composable
-private fun AppAvatarNoNamePreview() {
+fun AppAvatarNoNamePreview() {
     AmberPreview {
         Box(Modifier.padding(8.dp)) {
             AppAvatar()

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/AppAvatar.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/AppAvatar.kt
@@ -3,6 +3,7 @@ package com.greenart7c3.nostrsigner.ui.components
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.MaterialTheme
@@ -14,12 +15,15 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.core.graphics.drawable.toBitmap
 import coil3.compose.AsyncImage
 import com.greenart7c3.nostrsigner.BuildFlavorChecker
+import com.greenart7c3.nostrsigner.ui.theme.AmberPreview
+import com.greenart7c3.nostrsigner.ui.theme.ThemePreviews
 import java.io.File
 
 /**
@@ -85,6 +89,26 @@ fun AppAvatar(
                     fontSize = (size.value / 2).sp,
                 )
             }
+        }
+    }
+}
+
+@ThemePreviews
+@Composable
+private fun AppAvatarPlaceholderPreview() {
+    AmberPreview {
+        Box(Modifier.padding(8.dp)) {
+            AppAvatar(name = "Amethyst")
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun AppAvatarNoNamePreview() {
+    AmberPreview {
+        Box(Modifier.padding(8.dp)) {
+            AppAvatar()
         }
     }
 }

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/BackButtonBottomBar.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/BackButtonBottomBar.kt
@@ -7,6 +7,8 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import com.greenart7c3.nostrsigner.R
+import com.greenart7c3.nostrsigner.ui.theme.AmberPreview
+import com.greenart7c3.nostrsigner.ui.theme.ThemePreviews
 
 @Composable
 fun BackButtonAppBar(
@@ -31,6 +33,18 @@ fun BackButtonAppBar(
             icon = ImageVector.vectorResource(R.drawable.back),
             onClick = onPressed,
             tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@ThemePreviews
+@Composable
+private fun BackButtonAppBarPreview() {
+    AmberPreview {
+        BackButtonAppBar(
+            destinationRoute = "Settings",
+            localBackButtonTitle = "Applications",
+            onPressed = {},
         )
     }
 }

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/BackButtonBottomBar.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/BackButtonBottomBar.kt
@@ -39,7 +39,7 @@ fun BackButtonAppBar(
 
 @ThemePreviews
 @Composable
-private fun BackButtonAppBarPreview() {
+fun BackButtonAppBarPreview() {
     AmberPreview {
         BackButtonAppBar(
             destinationRoute = "Settings",

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/BunkerGetPubKeyScreen.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/BunkerGetPubKeyScreen.kt
@@ -76,7 +76,7 @@ fun BunkerGetPubKeyScreen(
 
 @ThemePreviews
 @Composable
-private fun BunkerGetPubKeyScreenPreview() {
+fun BunkerGetPubKeyScreenPreview() {
     AmberPreview {
         BunkerGetPubKeyScreen(
             modifier = Modifier

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/BunkerGetPubKeyScreen.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/BunkerGetPubKeyScreen.kt
@@ -3,6 +3,8 @@ package com.greenart7c3.nostrsigner.ui.components
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -13,10 +15,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.greenart7c3.nostrsigner.R
 import com.greenart7c3.nostrsigner.models.Permission
 import com.greenart7c3.nostrsigner.ui.RememberType
+import com.greenart7c3.nostrsigner.ui.theme.AmberPreview
+import com.greenart7c3.nostrsigner.ui.theme.ThemePreviews
 
 @Composable
 fun BunkerGetPubKeyScreen(
@@ -65,6 +70,22 @@ fun BunkerGetPubKeyScreen(
             onReject = {
                 onReject(rememberType)
             },
+        )
+    }
+}
+
+@ThemePreviews
+@Composable
+private fun BunkerGetPubKeyScreenPreview() {
+    AmberPreview {
+        BunkerGetPubKeyScreen(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(400.dp)
+                .padding(16.dp),
+            applicationName = "Amethyst",
+            onAccept = { _, _, _, _ -> },
+            onReject = {},
         )
     }
 }

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/BunkerPingScreen.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/BunkerPingScreen.kt
@@ -3,6 +3,7 @@ package com.greenart7c3.nostrsigner.ui.components
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Card
@@ -23,6 +24,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.greenart7c3.nostrsigner.R
 import com.greenart7c3.nostrsigner.ui.RememberType
+import com.greenart7c3.nostrsigner.ui.theme.AmberPreview
+import com.greenart7c3.nostrsigner.ui.theme.ThemePreviews
 
 @Composable
 fun BunkerPingScreen(
@@ -95,6 +98,23 @@ fun BunkerPingScreen(
             onReject = {
                 onReject(rememberType)
             },
+        )
+    }
+}
+
+@ThemePreviews
+@Composable
+private fun BunkerPingScreenPreview() {
+    AmberPreview {
+        BunkerPingScreen(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(500.dp)
+                .padding(16.dp),
+            shouldRunOnAccept = null,
+            appName = "Amethyst",
+            onAccept = {},
+            onReject = {},
         )
     }
 }

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/BunkerPingScreen.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/BunkerPingScreen.kt
@@ -104,7 +104,7 @@ fun BunkerPingScreen(
 
 @ThemePreviews
 @Composable
-private fun BunkerPingScreenPreview() {
+fun BunkerPingScreenPreview() {
     AmberPreview {
         BunkerPingScreen(
             modifier = Modifier

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/BunkerRelayAuthScreen.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/BunkerRelayAuthScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Text
@@ -26,6 +27,9 @@ import androidx.compose.ui.unit.sp
 import com.greenart7c3.nostrsigner.R
 import com.greenart7c3.nostrsigner.models.Account
 import com.greenart7c3.nostrsigner.ui.RememberType
+import com.greenart7c3.nostrsigner.ui.theme.AmberPreview
+import com.greenart7c3.nostrsigner.ui.theme.ThemePreviews
+import com.greenart7c3.nostrsigner.ui.theme.previewAccount
 
 /**
  * Scope for a kind 22242 relay authentication permission.
@@ -139,6 +143,26 @@ fun BunkerRelayAuthScreen(
         AcceptRejectButtons(
             onAccept = { onAccept(rememberType, scope) },
             onReject = { onReject(rememberType, scope) },
+        )
+    }
+}
+
+@ThemePreviews
+@Composable
+fun BunkerRelayAuthScreenPreview() {
+    AmberPreview {
+        BunkerRelayAuthScreen(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(600.dp)
+                .padding(16.dp),
+            appName = "Amethyst",
+            relayUrl = "wss://relay.damus.io",
+            shouldAcceptOrReject = null,
+            defaultScope = RelayAuthScope.SPECIFIC,
+            account = previewAccount(),
+            onAccept = { _, _ -> },
+            onReject = { _, _ -> },
         )
     }
 }

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/ChooseSignPolicy.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/ChooseSignPolicy.kt
@@ -23,6 +23,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.greenart7c3.nostrsigner.R
+import com.greenart7c3.nostrsigner.ui.theme.AmberPreview
+import com.greenart7c3.nostrsigner.ui.theme.ThemePreviews
 
 @Composable
 fun ChooseSignPolicy(
@@ -104,6 +106,19 @@ fun ChooseSignPolicy(
                     )
                 }
             }
+        }
+    }
+}
+
+@ThemePreviews
+@Composable
+private fun ChooseSignPolicyPreview() {
+    AmberPreview {
+        Column(Modifier.padding(8.dp)) {
+            ChooseSignPolicy(
+                selectedOption = 1,
+                onSelected = {},
+            )
         }
     }
 }

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/ChooseSignPolicy.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/ChooseSignPolicy.kt
@@ -112,7 +112,7 @@ fun ChooseSignPolicy(
 
 @ThemePreviews
 @Composable
-private fun ChooseSignPolicyPreview() {
+fun ChooseSignPolicyPreview() {
     AmberPreview {
         Column(Modifier.padding(8.dp)) {
             ChooseSignPolicy(

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/CloseButton.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/CloseButton.kt
@@ -2,7 +2,9 @@ package com.greenart7c3.nostrsigner.ui.components
 
 import androidx.compose.material3.Button
 import androidx.compose.runtime.Composable
+import com.greenart7c3.nostrsigner.ui.theme.AmberPreview
 import com.greenart7c3.nostrsigner.ui.theme.ButtonBorder
+import com.greenart7c3.nostrsigner.ui.theme.ThemePreviews
 
 @Composable
 fun CloseButton(onCancel: () -> Unit) {
@@ -13,5 +15,13 @@ fun CloseButton(onCancel: () -> Unit) {
         shape = ButtonBorder,
     ) {
         CloseIcon()
+    }
+}
+
+@ThemePreviews
+@Composable
+private fun CloseButtonPreview() {
+    AmberPreview {
+        CloseButton(onCancel = {})
     }
 }

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/CloseButton.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/CloseButton.kt
@@ -20,7 +20,7 @@ fun CloseButton(onCancel: () -> Unit) {
 
 @ThemePreviews
 @Composable
-private fun CloseButtonPreview() {
+fun CloseButtonPreview() {
     AmberPreview {
         CloseButton(onCancel = {})
     }

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/CloseIcon.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/CloseIcon.kt
@@ -5,7 +5,9 @@ import androidx.compose.material.icons.outlined.Close
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
+import com.greenart7c3.nostrsigner.ui.theme.AmberPreview
 import com.greenart7c3.nostrsigner.ui.theme.Size20Modifier
+import com.greenart7c3.nostrsigner.ui.theme.ThemePreviews
 
 @Composable
 fun CloseIcon() {
@@ -15,4 +17,12 @@ fun CloseIcon() {
         modifier = Size20Modifier,
         tint = Color.Black,
     )
+}
+
+@ThemePreviews
+@Composable
+private fun CloseIconPreview() {
+    AmberPreview {
+        CloseIcon()
+    }
 }

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/CloseIcon.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/CloseIcon.kt
@@ -21,7 +21,7 @@ fun CloseIcon() {
 
 @ThemePreviews
 @Composable
-private fun CloseIconPreview() {
+fun CloseIconPreview() {
     AmberPreview {
         CloseIcon()
     }

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/EnabledPermissions.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/EnabledPermissions.kt
@@ -27,6 +27,8 @@ import androidx.compose.ui.state.ToggleableState
 import androidx.compose.ui.unit.dp
 import com.greenart7c3.nostrsigner.R
 import com.greenart7c3.nostrsigner.models.Permission
+import com.greenart7c3.nostrsigner.ui.theme.AmberPreview
+import com.greenart7c3.nostrsigner.ui.theme.ThemePreviews
 
 @Composable
 fun EnabledPermissions(
@@ -106,5 +108,19 @@ fun EnabledPermissions(
                 }
             }
         }
+    }
+}
+
+@ThemePreviews
+@Composable
+private fun EnabledPermissionsPreview() {
+    AmberPreview {
+        EnabledPermissions(
+            localPermissions = listOf(
+                Permission("get_public_key", null),
+                Permission("sign_event", 1),
+                Permission("nip04_encrypt", null, checked = false),
+            ),
+        )
     }
 }

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/EnabledPermissions.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/EnabledPermissions.kt
@@ -113,7 +113,7 @@ fun EnabledPermissions(
 
 @ThemePreviews
 @Composable
-private fun EnabledPermissionsPreview() {
+fun EnabledPermissionsPreview() {
     AmberPreview {
         EnabledPermissions(
             localPermissions = listOf(

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/EncryptDecryptData.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/EncryptDecryptData.kt
@@ -3,6 +3,7 @@ package com.greenart7c3.nostrsigner.ui.components
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Card
@@ -35,6 +36,9 @@ import com.greenart7c3.nostrsigner.models.PrivateZapEncryptedDataKind
 import com.greenart7c3.nostrsigner.models.SignerType
 import com.greenart7c3.nostrsigner.models.TagArrayEncryptedDataKind
 import com.greenart7c3.nostrsigner.ui.RememberType
+import com.greenart7c3.nostrsigner.ui.theme.AmberPreview
+import com.greenart7c3.nostrsigner.ui.theme.ThemePreviews
+import com.greenart7c3.nostrsigner.ui.theme.previewAccount
 import com.vitorpamplona.quartz.nip02FollowList.ContactListEvent
 
 @Composable
@@ -436,6 +440,46 @@ fun BunkerEncryptDecryptData(
             onReject = {
                 onReject(rememberType, scope)
             },
+        )
+    }
+}
+
+@ThemePreviews
+@Composable
+fun EncryptDecryptDataPreview() {
+    AmberPreview {
+        EncryptDecryptData(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(600.dp)
+                .padding(16.dp),
+            encryptedData = ClearTextEncryptedDataKind("Hello Nostr!", "Hello Nostr!"),
+            shouldRunOnAccept = null,
+            packageName = null,
+            type = SignerType.NIP44_DECRYPT,
+            account = previewAccount(),
+            onAccept = { _, _ -> },
+            onReject = { _, _ -> },
+        )
+    }
+}
+
+@ThemePreviews
+@Composable
+fun BunkerEncryptDecryptDataPreview() {
+    AmberPreview {
+        BunkerEncryptDecryptData(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(600.dp)
+                .padding(16.dp),
+            encryptedData = ClearTextEncryptedDataKind("Hello Nostr!", "Hello Nostr!"),
+            shouldRunOnAccept = null,
+            appName = "Amethyst",
+            type = SignerType.NIP44_ENCRYPT,
+            account = previewAccount(),
+            onAccept = { _, _ -> },
+            onReject = { _, _ -> },
         )
     }
 }

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/EncryptedTagArraySection.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/EncryptedTagArraySection.kt
@@ -11,6 +11,8 @@ import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.res.stringResource
 import com.greenart7c3.nostrsigner.Amber
 import com.greenart7c3.nostrsigner.R
+import com.greenart7c3.nostrsigner.ui.theme.AmberPreview
+import com.greenart7c3.nostrsigner.ui.theme.ThemePreviews
 import com.vitorpamplona.quartz.nip01Core.core.TagArray
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -43,5 +45,19 @@ fun EncryptedTagArraySection(
                 color = MaterialTheme.colorScheme.primary,
             )
         }
+    }
+}
+
+@ThemePreviews
+@Composable
+fun EncryptedTagArraySectionPreview() {
+    AmberPreview {
+        EncryptedTagArraySection(
+            modifier = Modifier,
+            tags = arrayOf(
+                arrayOf("p", "460c25e682fda7832b52d1f22d3d22b3176d972f60dcdc3212ed8c92ef85065c"),
+                arrayOf("t", "amber"),
+            ),
+        )
     }
 }

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/EventData.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/EventData.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -32,6 +33,9 @@ import com.greenart7c3.nostrsigner.R
 import com.greenart7c3.nostrsigner.models.Account
 import com.greenart7c3.nostrsigner.models.Permission
 import com.greenart7c3.nostrsigner.ui.RememberType
+import com.greenart7c3.nostrsigner.ui.theme.AmberPreview
+import com.greenart7c3.nostrsigner.ui.theme.ThemePreviews
+import com.greenart7c3.nostrsigner.ui.theme.previewAccount
 import com.vitorpamplona.quartz.nip01Core.core.Event
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -238,4 +242,51 @@ fun ReportMissingEventKindButton(kind: Int, appName: String? = null) {
         },
         text = stringResource(R.string.report_missing_event_kind_translation),
     )
+}
+private fun previewEvent() = Event(
+    id = "0".repeat(64),
+    pubKey = "460c25e682fda7832b52d1f22d3d22b3176d972f60dcdc3212ed8c92ef85065c",
+    createdAt = 1735689600,
+    kind = 1,
+    tags = arrayOf(arrayOf("t", "amber")),
+    content = "Hello Nostr!",
+    sig = "",
+)
+
+@ThemePreviews
+@Composable
+fun EventDataPreview() {
+    AmberPreview {
+        EventData(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(650.dp)
+                .padding(16.dp),
+            shouldAcceptOrReject = null,
+            packageName = null,
+            event = previewEvent(),
+            account = previewAccount(),
+            onAccept = {},
+            onReject = {},
+        )
+    }
+}
+
+@ThemePreviews
+@Composable
+fun BunkerEventDataPreview() {
+    AmberPreview {
+        BunkerEventData(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(650.dp)
+                .padding(16.dp),
+            shouldAcceptOrReject = null,
+            appName = "Amethyst",
+            event = previewEvent(),
+            account = previewAccount(),
+            onAccept = {},
+            onReject = {},
+        )
+    }
 }

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/EventSection.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/EventSection.kt
@@ -80,7 +80,7 @@ fun EventSection(
 
 @ThemePreviews
 @Composable
-private fun EventSectionPreview() {
+fun EventSectionPreview() {
     AmberPreview {
         EventSection(
             label = "Content",
@@ -92,7 +92,7 @@ private fun EventSectionPreview() {
 
 @Preview(showBackground = true)
 @Composable
-private fun EventSectionExpandedPreview() {
+fun EventSectionExpandedPreview() {
     AmberPreview {
         EventSection(
             label = "Content",

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/EventSection.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/EventSection.kt
@@ -22,10 +22,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.greenart7c3.nostrsigner.R
+import com.greenart7c3.nostrsigner.ui.theme.AmberPreview
+import com.greenart7c3.nostrsigner.ui.theme.ThemePreviews
 
 @Composable
 fun EventSection(
@@ -71,6 +74,31 @@ fun EventSection(
                 },
             imageVector = Icons.Default.ContentCopy,
             contentDescription = stringResource(id = R.string.copy),
+        )
+    }
+}
+
+@ThemePreviews
+@Composable
+private fun EventSectionPreview() {
+    AmberPreview {
+        EventSection(
+            label = "Content",
+            displayValue = "Hello Nostr! This is a sample note that is long enough to be ellipsized when the section is collapsed.",
+            onCopy = {},
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun EventSectionExpandedPreview() {
+    AmberPreview {
+        EventSection(
+            label = "Content",
+            displayValue = "Hello Nostr! This is a sample note that is long enough to be ellipsized when the section is collapsed.",
+            onCopy = {},
+            showFullContent = true,
         )
     }
 }

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/IconRow.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/IconRow.kt
@@ -112,7 +112,7 @@ fun IconRow(
 
 @ThemePreviews
 @Composable
-private fun IconRowVectorPreview() {
+fun IconRowVectorPreview() {
     AmberPreview {
         IconRow(
             title = "Security",
@@ -125,7 +125,7 @@ private fun IconRowVectorPreview() {
 
 @ThemePreviews
 @Composable
-private fun IconRowDrawablePreview() {
+fun IconRowDrawablePreview() {
     AmberPreview {
         IconRow(
             title = "Go back",

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/IconRow.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/IconRow.kt
@@ -7,7 +7,10 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -18,6 +21,9 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.greenart7c3.nostrsigner.R
+import com.greenart7c3.nostrsigner.ui.theme.AmberPreview
+import com.greenart7c3.nostrsigner.ui.theme.ThemePreviews
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -101,5 +107,31 @@ fun IconRow(
                 overflow = TextOverflow.Ellipsis,
             )
         }
+    }
+}
+
+@ThemePreviews
+@Composable
+private fun IconRowVectorPreview() {
+    AmberPreview {
+        IconRow(
+            title = "Security",
+            icon = Icons.Default.Settings,
+            tint = MaterialTheme.colorScheme.onBackground,
+            onClick = {},
+        )
+    }
+}
+
+@ThemePreviews
+@Composable
+private fun IconRowDrawablePreview() {
+    AmberPreview {
+        IconRow(
+            title = "Go back",
+            icon = R.drawable.back,
+            tint = MaterialTheme.colorScheme.onBackground,
+            onClick = {},
+        )
     }
 }

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/LoginWithPubKey.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/LoginWithPubKey.kt
@@ -63,9 +63,13 @@ import com.greenart7c3.nostrsigner.models.Permission
 import com.greenart7c3.nostrsigner.service.toShortenHex
 import com.greenart7c3.nostrsigner.ui.RememberType
 import com.greenart7c3.nostrsigner.ui.navigation.Route
+import com.greenart7c3.nostrsigner.ui.theme.AmberPreview
+import com.greenart7c3.nostrsigner.ui.theme.ThemePreviews
 import com.greenart7c3.nostrsigner.ui.theme.fromHex
+import com.greenart7c3.nostrsigner.ui.theme.previewAccount
 import com.greenart7c3.nostrsigner.ui.theme.primaryVariant
 import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
 
 @Composable
 fun ProfilePictureIcon(account: Account) {
@@ -440,5 +444,25 @@ fun LoginWithPubKey(
                 text = stringResource(R.string.connect),
             )
         }
+    }
+}
+
+@ThemePreviews
+@Composable
+fun LoginWithPubKeyPreview() {
+    AmberPreview {
+        LoginWithPubKey(
+            horizontalPadding = 16.dp,
+            modifier = Modifier.padding(horizontal = 16.dp),
+            account = previewAccount(),
+            packageName = null,
+            permissions = persistentListOf(
+                Permission("get_public_key", null),
+                Permission("sign_event", 1),
+                Permission("nip04_encrypt", null),
+            ),
+            onAccept = { _, _, _, _, _ -> },
+            onReject = {},
+        )
     }
 }

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/MarkdownText.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/MarkdownText.kt
@@ -1,5 +1,6 @@
 package com.greenart7c3.nostrsigner.ui.components
 
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -18,6 +19,9 @@ import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.withLink
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.dp
+import com.greenart7c3.nostrsigner.ui.theme.AmberPreview
+import com.greenart7c3.nostrsigner.ui.theme.ThemePreviews
 
 /**
  * Renders a subset of Markdown as styled Compose text.
@@ -142,5 +146,23 @@ private fun AnnotatedString.Builder.appendMarkdownInline(
                 remaining = remaining.substring(count)
             }
         }
+    }
+}
+
+@ThemePreviews
+@Composable
+private fun MarkdownTextPreview() {
+    AmberPreview {
+        MarkdownText(
+            markdown = """
+                ## Amber
+                **Amber** is a Nostr event signer for Android.
+                - Keep your keys safe
+                - Sign events for [Nostr](https://nostr.com) apps
+                1. Install a Nostr client
+                2. Approve its requests
+            """.trimIndent(),
+            modifier = Modifier.padding(16.dp),
+        )
     }
 }

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/MarkdownText.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/MarkdownText.kt
@@ -151,7 +151,7 @@ private fun AnnotatedString.Builder.appendMarkdownInline(
 
 @ThemePreviews
 @Composable
-private fun MarkdownTextPreview() {
+fun MarkdownTextPreview() {
     AmberPreview {
         MarkdownText(
             markdown = """

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/MnemonicLoginInput.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/MnemonicLoginInput.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
@@ -42,6 +43,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.PopupProperties
 import com.greenart7c3.nostrsigner.R
+import com.greenart7c3.nostrsigner.ui.theme.AmberPreview
+import com.greenart7c3.nostrsigner.ui.theme.ThemePreviews
 import com.vitorpamplona.quartz.nip06KeyDerivation.Bip39Mnemonics
 
 @Composable
@@ -225,5 +228,20 @@ private fun WordField(
                 )
             }
         }
+    }
+}
+
+@ThemePreviews
+@Composable
+private fun MnemonicLoginInputPreview() {
+    AmberPreview {
+        MnemonicLoginInput(
+            wordCount = 12,
+            words = listOf("leader", "monkey", "parrot", "ring") + List(8) { "" },
+            onWordChange = { _, _ -> },
+            onWordCountChange = {},
+            onPaste = {},
+            modifier = Modifier.padding(16.dp),
+        )
     }
 }

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/MnemonicLoginInput.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/MnemonicLoginInput.kt
@@ -233,7 +233,7 @@ private fun WordField(
 
 @ThemePreviews
 @Composable
-private fun MnemonicLoginInputPreview() {
+fun MnemonicLoginInputPreview() {
     AmberPreview {
         MnemonicLoginInput(
             wordCount = 12,

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/NewBunkerFloatingButton.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/NewBunkerFloatingButton.kt
@@ -48,7 +48,7 @@ fun NewBunkerFloatingButton(
 
 @ThemePreviews
 @Composable
-private fun NewBunkerFloatingButtonPreview() {
+fun NewBunkerFloatingButtonPreview() {
     AmberPreview {
         NewBunkerFloatingButton(onClick = {})
     }

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/NewBunkerFloatingButton.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/NewBunkerFloatingButton.kt
@@ -15,6 +15,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.greenart7c3.nostrsigner.R
+import com.greenart7c3.nostrsigner.ui.theme.AmberPreview
+import com.greenart7c3.nostrsigner.ui.theme.ThemePreviews
 
 @Composable
 fun NewBunkerFloatingButton(
@@ -41,5 +43,13 @@ fun NewBunkerFloatingButton(
                 tint = Color.Black,
             )
         }
+    }
+}
+
+@ThemePreviews
+@Composable
+private fun NewBunkerFloatingButtonPreview() {
+    AmberPreview {
+        NewBunkerFloatingButton(onClick = {})
     }
 }

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/Nip44v3ApprovalData.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/Nip44v3ApprovalData.kt
@@ -3,6 +3,7 @@ package com.greenart7c3.nostrsigner.ui.components
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
@@ -27,11 +28,15 @@ import androidx.compose.ui.unit.sp
 import com.greenart7c3.nostrsigner.Amber
 import com.greenart7c3.nostrsigner.R
 import com.greenart7c3.nostrsigner.models.Account
+import com.greenart7c3.nostrsigner.models.ClearTextEncryptedDataKind
 import com.greenart7c3.nostrsigner.models.EncryptedDataKind
 import com.greenart7c3.nostrsigner.models.Permission
 import com.greenart7c3.nostrsigner.models.SignerType
 import com.greenart7c3.nostrsigner.models.nip44v3Plaintext
 import com.greenart7c3.nostrsigner.ui.RememberType
+import com.greenart7c3.nostrsigner.ui.theme.AmberPreview
+import com.greenart7c3.nostrsigner.ui.theme.ThemePreviews
+import com.greenart7c3.nostrsigner.ui.theme.previewAccount
 
 /**
  * Dedicated approval screen for NIP-44 v3 encrypt/decrypt requests.
@@ -181,5 +186,29 @@ fun Nip44v3ContextBox(
                 ),
             )
         }
+    }
+}
+
+@ThemePreviews
+@Composable
+fun Nip44v3ApprovalDataPreview() {
+    AmberPreview {
+        Nip44v3ApprovalData(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(700.dp)
+                .padding(16.dp),
+            isBunker = false,
+            appName = "Amethyst",
+            packageName = null,
+            type = SignerType.NIP44_V3_ENCRYPT,
+            account = previewAccount(),
+            kind = null,
+            scope = "chat",
+            encryptedData = ClearTextEncryptedDataKind("Hello Nostr!", "Hello Nostr!"),
+            shouldRunOnAccept = null,
+            onAccept = { _, _ -> },
+            onReject = { _, _ -> },
+        )
     }
 }

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/RandomPinInput.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/RandomPinInput.kt
@@ -39,6 +39,8 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import com.greenart7c3.nostrsigner.Amber
+import com.greenart7c3.nostrsigner.ui.theme.AmberPreview
+import com.greenart7c3.nostrsigner.ui.theme.ThemePreviews
 
 @Composable
 fun RandomPinInput(
@@ -201,6 +203,19 @@ fun RandomPinInput(
                     )
                 }
             }
+        }
+    }
+}
+
+@ThemePreviews
+@Composable
+private fun RandomPinInputPreview() {
+    AmberPreview {
+        Box(Modifier.height(600.dp)) {
+            RandomPinInput(
+                text = "Enter your PIN",
+                onPinEntered = {},
+            )
         }
     }
 }

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/RandomPinInput.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/RandomPinInput.kt
@@ -209,7 +209,7 @@ fun RandomPinInput(
 
 @ThemePreviews
 @Composable
-private fun RandomPinInputPreview() {
+fun RandomPinInputPreview() {
     AmberPreview {
         Box(Modifier.height(600.dp)) {
             RandomPinInput(

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/RawJsonButton.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/RawJsonButton.kt
@@ -35,7 +35,7 @@ fun RawJsonButton(
 
 @ThemePreviews
 @Composable
-private fun RawJsonButtonPreview() {
+fun RawJsonButtonPreview() {
     AmberPreview {
         RawJsonButton(
             onCLick = {},

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/RawJsonButton.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/RawJsonButton.kt
@@ -9,7 +9,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.greenart7c3.nostrsigner.ui.theme.AmberPreview
 import com.greenart7c3.nostrsigner.ui.theme.ButtonBorder
+import com.greenart7c3.nostrsigner.ui.theme.ThemePreviews
 
 @Composable
 fun RawJsonButton(
@@ -28,5 +30,16 @@ fun RawJsonButton(
         ) {
             Text(text)
         }
+    }
+}
+
+@ThemePreviews
+@Composable
+private fun RawJsonButtonPreview() {
+    AmberPreview {
+        RawJsonButton(
+            onCLick = {},
+            text = "Copy raw json",
+        )
     }
 }

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/RememberMyChoice.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/RememberMyChoice.kt
@@ -23,6 +23,8 @@ import androidx.compose.ui.unit.sp
 import com.greenart7c3.nostrsigner.R
 import com.greenart7c3.nostrsigner.ui.RememberType
 import com.greenart7c3.nostrsigner.ui.rememberTypeDisplayOrder
+import com.greenart7c3.nostrsigner.ui.theme.AmberPreview
+import com.greenart7c3.nostrsigner.ui.theme.ThemePreviews
 
 @Composable
 fun LabeledBorderBox(
@@ -90,5 +92,36 @@ fun RememberMyChoice(
                 label = { stringResource(it.shortResourceId) },
             )
         }
+    }
+}
+
+@ThemePreviews
+@Composable
+private fun LabeledBorderBoxPreview() {
+    AmberPreview {
+        LabeledBorderBox(
+            label = "Label",
+            modifier = Modifier.padding(8.dp),
+        ) {
+            Text(
+                text = "Content",
+                modifier = Modifier.padding(8.dp),
+            )
+        }
+    }
+}
+
+@ThemePreviews
+@Composable
+private fun RememberMyChoicePreview() {
+    AmberPreview {
+        RememberMyChoice(
+            shouldRunAcceptOrReject = null,
+            packageName = null,
+            alwaysShow = true,
+            onAccept = {},
+            onReject = {},
+            onChanged = {},
+        )
     }
 }

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/RememberMyChoice.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/RememberMyChoice.kt
@@ -97,7 +97,7 @@ fun RememberMyChoice(
 
 @ThemePreviews
 @Composable
-private fun LabeledBorderBoxPreview() {
+fun LabeledBorderBoxPreview() {
     AmberPreview {
         LabeledBorderBox(
             label = "Label",
@@ -113,7 +113,7 @@ private fun LabeledBorderBoxPreview() {
 
 @ThemePreviews
 @Composable
-private fun RememberMyChoicePreview() {
+fun RememberMyChoicePreview() {
     AmberPreview {
         RememberMyChoice(
             shouldRunAcceptOrReject = null,

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/RemoteAppIcon.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/RemoteAppIcon.kt
@@ -8,6 +8,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import com.greenart7c3.nostrsigner.ui.theme.AmberPreview
+import com.greenart7c3.nostrsigner.ui.theme.ThemePreviews
 
 /**
  * Centered avatar header for a request screen. Shows the remote client icon from
@@ -30,6 +32,17 @@ fun RemoteAppIcon(
             iconUrl = imageUrl,
             name = name,
             size = size,
+        )
+    }
+}
+
+@ThemePreviews
+@Composable
+private fun RemoteAppIconPreview() {
+    AmberPreview {
+        RemoteAppIcon(
+            imageUrl = null,
+            name = "Amethyst",
         )
     }
 }

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/RemoteAppIcon.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/RemoteAppIcon.kt
@@ -38,7 +38,7 @@ fun RemoteAppIcon(
 
 @ThemePreviews
 @Composable
-private fun RemoteAppIconPreview() {
+fun RemoteAppIconPreview() {
     AmberPreview {
         RemoteAppIcon(
             imageUrl = null,

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/SeedWordsPage.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/SeedWordsPage.kt
@@ -31,6 +31,8 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 import com.greenart7c3.nostrsigner.Amber
 import com.greenart7c3.nostrsigner.R
 import com.greenart7c3.nostrsigner.ui.setSensitiveClip
+import com.greenart7c3.nostrsigner.ui.theme.AmberPreview
+import com.greenart7c3.nostrsigner.ui.theme.ThemePreviews
 import com.greenart7c3.nostrsigner.ui.verticalScrollbar
 import kotlinx.coroutines.launch
 
@@ -167,5 +169,19 @@ fun SeedWordsPage(
             Amber.instance.getMainActivity()?.window?.clearFlags(WindowManager.LayoutParams.FLAG_SECURE)
             lifecycleOwner.lifecycle.removeObserver(observer)
         }
+    }
+}
+
+@ThemePreviews
+@Composable
+private fun SeedWordsPagePreview() {
+    AmberPreview {
+        SeedWordsPage(
+            seedWords = setOf(
+                "leader", "monkey", "parrot", "ring",
+                "crumble", "easily", "stove", "goose",
+                "spare", "tourist", "shell", "glance",
+            ),
+        )
     }
 }

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/SeedWordsPage.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/SeedWordsPage.kt
@@ -174,7 +174,7 @@ fun SeedWordsPage(
 
 @ThemePreviews
 @Composable
-private fun SeedWordsPagePreview() {
+fun SeedWordsPagePreview() {
     AmberPreview {
         SeedWordsPage(
             seedWords = setOf(

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/SignPsbt.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/SignPsbt.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Card
@@ -29,6 +30,8 @@ import com.greenart7c3.nostrsigner.R
 import com.greenart7c3.nostrsigner.service.DecodedPsbt
 import com.greenart7c3.nostrsigner.service.DecodedPsbtOutput
 import com.greenart7c3.nostrsigner.ui.RememberType
+import com.greenart7c3.nostrsigner.ui.theme.AmberPreview
+import com.greenart7c3.nostrsigner.ui.theme.ThemePreviews
 
 @Composable
 fun SignPsbt(
@@ -242,3 +245,61 @@ private fun RawPsbtCard(psbtHex: String) {
 }
 
 private fun formatSats(sats: Long): String = "$sats sats"
+private fun previewDecodedPsbt() = DecodedPsbt(
+    outputs = listOf(
+        DecodedPsbtOutput(
+            valueSats = 50_000,
+            scriptPubKeyHex = "0014751e76e8199196d454941c45d1b3a323f1433bd6",
+            address = "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4",
+            isChange = false,
+        ),
+        DecodedPsbtOutput(
+            valueSats = 12_345,
+            scriptPubKeyHex = "0014841b80d2cc75f5345c482af96294d04fdd66b2b7",
+            address = "bc1qssdcp5kvwh6nghzg9tuk99xsflwkdv4hgvq58q",
+            isChange = true,
+        ),
+    ),
+    totalSent = 50_000,
+    totalChange = 12_345,
+    feeSats = 500,
+    parseError = null,
+)
+
+@ThemePreviews
+@Composable
+fun SignPsbtPreview() {
+    AmberPreview {
+        SignPsbt(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(600.dp)
+                .padding(16.dp),
+            psbtHex = "70736274ff0100710200000001",
+            decoded = previewDecodedPsbt(),
+            shouldRunOnAccept = null,
+            packageName = null,
+            onAccept = {},
+            onReject = {},
+        )
+    }
+}
+
+@ThemePreviews
+@Composable
+fun BunkerSignPsbtPreview() {
+    AmberPreview {
+        BunkerSignPsbt(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(600.dp)
+                .padding(16.dp),
+            psbtHex = "70736274ff0100710200000001",
+            decoded = previewDecodedPsbt(),
+            shouldRunOnAccept = null,
+            appName = "Amethyst",
+            onAccept = {},
+            onReject = {},
+        )
+    }
+}

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/SignerConnectAppTab.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/SignerConnectAppTab.kt
@@ -1,12 +1,15 @@
 package com.greenart7c3.nostrsigner.ui.components
 
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.PrimaryTabRow
 import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.greenart7c3.nostrsigner.ui.theme.AmberPreview
+import com.greenart7c3.nostrsigner.ui.theme.ThemePreviews
 
 @Composable
 fun SignerConnectAppTab(
@@ -26,4 +29,23 @@ fun SignerConnectAppTab(
             )
         },
     )
+}
+
+@ThemePreviews
+@Composable
+private fun SignerConnectAppTabPreview() {
+    AmberPreview {
+        PrimaryTabRow(selectedTabIndex = 0) {
+            SignerConnectAppTab(
+                text = "Applications",
+                selected = true,
+                onClick = {},
+            )
+            SignerConnectAppTab(
+                text = "Activity",
+                selected = false,
+                onClick = {},
+            )
+        }
+    }
 }

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/SignerConnectAppTab.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/SignerConnectAppTab.kt
@@ -33,7 +33,7 @@ fun SignerConnectAppTab(
 
 @ThemePreviews
 @Composable
-private fun SignerConnectAppTabPreview() {
+fun SignerConnectAppTabPreview() {
     AmberPreview {
         PrimaryTabRow(selectedTabIndex = 0) {
             SignerConnectAppTab(

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/SigningAs.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/SigningAs.kt
@@ -29,7 +29,10 @@ import com.greenart7c3.nostrsigner.BuildFlavorChecker
 import com.greenart7c3.nostrsigner.R
 import com.greenart7c3.nostrsigner.models.Account
 import com.greenart7c3.nostrsigner.service.toShortenHex
+import com.greenart7c3.nostrsigner.ui.theme.AmberPreview
+import com.greenart7c3.nostrsigner.ui.theme.ThemePreviews
 import com.greenart7c3.nostrsigner.ui.theme.fromHex
+import com.greenart7c3.nostrsigner.ui.theme.previewAccount
 
 @Composable
 fun SigningAs(account: Account, modifier: Modifier = Modifier) {
@@ -111,5 +114,13 @@ fun SigningAs(account: Account, modifier: Modifier = Modifier) {
                 )
             }
         }
+    }
+}
+
+@ThemePreviews
+@Composable
+fun SigningAsPreview() {
+    AmberPreview {
+        SigningAs(previewAccount())
     }
 }

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/SimpleSearchBar.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/SimpleSearchBar.kt
@@ -28,6 +28,8 @@ import androidx.compose.ui.semantics.isTraversalGroup
 import androidx.compose.ui.semantics.semantics
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
+import com.greenart7c3.nostrsigner.ui.theme.AmberPreview
+import com.greenart7c3.nostrsigner.ui.theme.ThemePreviews
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -105,5 +107,17 @@ fun SimpleSearchBar(
                 }
             }
         }
+    }
+}
+
+@ThemePreviews
+@Composable
+private fun SimpleSearchBarPreview() {
+    AmberPreview {
+        SimpleSearchBar(
+            textFieldState = TextFieldState("amber"),
+            onSearch = {},
+            searchResults = emptyList(),
+        )
     }
 }

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/SimpleSearchBar.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/SimpleSearchBar.kt
@@ -112,7 +112,7 @@ fun SimpleSearchBar(
 
 @ThemePreviews
 @Composable
-private fun SimpleSearchBarPreview() {
+fun SimpleSearchBarPreview() {
     AmberPreview {
         SimpleSearchBar(
             textFieldState = TextFieldState("amber"),

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/TagsSection.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/TagsSection.kt
@@ -101,7 +101,7 @@ fun TagsSection(
 
 @ThemePreviews
 @Composable
-private fun TagsSectionPreview() {
+fun TagsSectionPreview() {
     AmberPreview {
         TagsSection(
             label = "Tags",

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/TagsSection.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/TagsSection.kt
@@ -25,6 +25,8 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.greenart7c3.nostrsigner.R
+import com.greenart7c3.nostrsigner.ui.theme.AmberPreview
+import com.greenart7c3.nostrsigner.ui.theme.ThemePreviews
 
 @Composable
 fun TagsSection(
@@ -93,6 +95,22 @@ fun TagsSection(
                 .clickable { onCopy() },
             imageVector = Icons.Default.ContentCopy,
             contentDescription = stringResource(id = R.string.copy_to_clipboard),
+        )
+    }
+}
+
+@ThemePreviews
+@Composable
+private fun TagsSectionPreview() {
+    AmberPreview {
+        TagsSection(
+            label = "Tags",
+            tags = arrayOf(
+                arrayOf("p", "460c25e682fda7832b52d1f22d3d22b3176d972f60dcdc3212ed8c92ef85065c"),
+                arrayOf("e", "3d842afecd5e293f28b6627933704a3fb8ce153aa91d790ab11f6a752d44a42d"),
+                arrayOf("t", "amber"),
+            ),
+            onCopy = {},
         )
     }
 }

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/TextSpinner.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/TextSpinner.kt
@@ -56,7 +56,10 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
+import com.greenart7c3.nostrsigner.ui.theme.AmberPreview
+import com.greenart7c3.nostrsigner.ui.theme.ThemePreviews
 import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
 
 @Composable
 fun TextSpinner(
@@ -212,3 +215,20 @@ fun <T> SpinnerSelectionDialog(
 }
 
 @Immutable data class TitleExplainer(val title: String, val explainer: String? = null)
+
+@ThemePreviews
+@Composable
+private fun TextSpinnerPreview() {
+    AmberPreview {
+        TextSpinner(
+            label = "Language",
+            placeholder = "English",
+            options = persistentListOf(
+                TitleExplainer("English"),
+                TitleExplainer("Português", "Brazilian Portuguese"),
+            ),
+            onSelect = {},
+            modifier = Modifier.padding(16.dp),
+        )
+    }
+}

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/TextSpinner.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/TextSpinner.kt
@@ -218,7 +218,7 @@ fun <T> SpinnerSelectionDialog(
 
 @ThemePreviews
 @Composable
-private fun TextSpinnerPreview() {
+fun TextSpinnerPreview() {
     AmberPreview {
         TextSpinner(
             label = "Language",

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/ToogleOption.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/ToogleOption.kt
@@ -4,7 +4,10 @@ import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -15,6 +18,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
+import com.greenart7c3.nostrsigner.ui.theme.AmberPreview
+import com.greenart7c3.nostrsigner.ui.theme.ThemePreviews
 
 @Composable
 fun ToggleOption(
@@ -43,5 +48,26 @@ fun ToggleOption(
             maxLines = 1,
             softWrap = false,
         )
+    }
+}
+
+@ThemePreviews
+@Composable
+private fun ToggleOptionPreview() {
+    AmberPreview {
+        Row(Modifier.height(32.dp)) {
+            ToggleOption(
+                text = "Always",
+                isSelected = true,
+                modifier = Modifier.width(80.dp),
+                onClick = {},
+            )
+            ToggleOption(
+                text = "Never",
+                isSelected = false,
+                modifier = Modifier.width(80.dp),
+                onClick = {},
+            )
+        }
     }
 }

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/ToogleOption.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/components/ToogleOption.kt
@@ -53,7 +53,7 @@ fun ToggleOption(
 
 @ThemePreviews
 @Composable
-private fun ToggleOptionPreview() {
+fun ToggleOptionPreview() {
     AmberPreview {
         Row(Modifier.height(32.dp)) {
             ToggleOption(

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/theme/Previews.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/theme/Previews.kt
@@ -1,0 +1,34 @@
+package com.greenart7c3.nostrsigner.ui.theme
+
+import android.content.res.Configuration
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+
+/**
+ * Multipreview annotation that renders a composable in both the light and
+ * dark variants of [NostrSignerTheme].
+ */
+@Preview(name = "Light", showBackground = true)
+@Preview(name = "Dark", showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
+annotation class ThemePreviews
+
+/**
+ * Shared wrapper for component previews: applies [NostrSignerTheme] and paints
+ * the theme background behind the content, so previews look like the real app
+ * in both themes.
+ *
+ * Previews must only compose components that don't reach global state
+ * ([com.greenart7c3.nostrsigner.Amber.instance] or an
+ * [com.greenart7c3.nostrsigner.models.Account]) during composition — the
+ * Application singleton doesn't exist in the preview renderer.
+ */
+@Composable
+fun AmberPreview(content: @Composable () -> Unit) {
+    NostrSignerTheme {
+        Surface(color = MaterialTheme.colorScheme.background) {
+            content()
+        }
+    }
+}

--- a/app/src/main/java/com/greenart7c3/nostrsigner/ui/theme/Previews.kt
+++ b/app/src/main/java/com/greenart7c3/nostrsigner/ui/theme/Previews.kt
@@ -5,6 +5,14 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
+import com.greenart7c3.nostrsigner.models.Account
+import com.vitorpamplona.quartz.nip01Core.core.hexToByteArray
+import com.vitorpamplona.quartz.nip01Core.crypto.KeyPair
+import com.vitorpamplona.quartz.nip01Core.signers.NostrSignerInternal
+import com.vitorpamplona.quartz.nip19Bech32.toNpub
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
 
 /**
  * Multipreview annotation that renders a composable in both the light and
@@ -32,3 +40,21 @@ fun AmberPreview(content: @Composable () -> Unit) {
         }
     }
 }
+
+private const val PREVIEW_PUBKEY = "460c25e682fda7832b52d1f22d3d22b3176d972f60dcdc3212ed8c92ef85065c"
+
+/**
+ * A read-only fake [Account] for previews of account-bound components. Built
+ * from a public key only, so no private key, native secp256k1 code, or the
+ * [com.greenart7c3.nostrsigner.Amber] singleton is touched at render time.
+ */
+fun previewAccount(name: String = "Preview Account"): Account = Account(
+    signer = NostrSignerInternal(KeyPair(pubKey = PREVIEW_PUBKEY.hexToByteArray())),
+    hexKey = PREVIEW_PUBKEY,
+    npub = PREVIEW_PUBKEY.hexToByteArray().toNpub(),
+    name = MutableStateFlow(name),
+    picture = MutableStateFlow(""),
+    signPolicy = 1,
+    didBackup = true,
+    scope = CoroutineScope(Dispatchers.Default),
+)


### PR DESCRIPTION
## Summary

This PR adds comprehensive Compose preview support across the UI component library by introducing a centralized preview infrastructure and annotating components with `@ThemePreviews` and `@AmberPreview` wrappers.

## Key Changes

- **New preview infrastructure** (`ui/theme/Previews.kt`):
  - Added `@ThemePreviews` multipreview annotation that renders components in both light and dark themes
  - Added `AmberPreview()` composable wrapper that applies `NostrSignerTheme` and background styling
  - Added `previewAccount()` helper function for account-bound component previews (read-only, no private keys)

- **Component preview additions** across 30+ files:
  - `SignPsbt.kt` — PSBT signing screens with mock decoded PSBT data
  - `EventData.kt` — Event approval screens with sample Nostr event
  - `EncryptDecryptData.kt` — NIP-44 encrypt/decrypt approval screens
  - `AmberButton.kt` — Button variants (enabled, disabled, elevated)
  - `RememberMyChoice.kt` — Permission remember UI components
  - `IconRow.kt` — Icon row with vector and drawable variants
  - `Nip44v3ApprovalData.kt` — NIP-44 v3 approval screen
  - `EventSection.kt` — Event content display (collapsed and expanded states)
  - `ToggleOption.kt` — Toggle button component
  - `AppAvatar.kt` — Avatar placeholder rendering
  - `BunkerRelayAuthScreen.kt` — Relay authentication approval
  - `LoginWithPubKey.kt` — Account login screen with permissions
  - `MarkdownText.kt` — Markdown rendering
  - `SignerConnectAppTab.kt` — Tab navigation
  - `BunkerGetPubKeyScreen.kt` — Public key request screen
  - `BunkerPingScreen.kt` — Ping/heartbeat screen
  - `TextSpinner.kt` — Dropdown selector
  - `MnemonicLoginInput.kt` — Seed word input
  - `TagsSection.kt` — Event tags display
  - `AmberWarningCard.kt` — Warning card component
  - `EnabledPermissions.kt` — Permission list display
  - `EncryptedTagArraySection.kt` — Encrypted tag array display
  - `SeedWordsPage.kt` — Seed words display
  - `AmberToggles.kt` — Multi-option toggle
  - `ChooseSignPolicy.kt` — Sign policy selection
  - `RandomPinInput.kt` — PIN entry screen
  - `BackButtonBottomBar.kt` — Navigation bar
  - `SimpleSearchBar.kt` — Search input
  - `CenterCircularProgressIndicator.kt` — Loading indicator
  - `AcceptRejectButtons.kt` — Approval button pair
  - `RawJsonButton.kt` — JSON display button
  - `RemoteAppIcon.kt` — Remote app icon header
  - `QrCodeDrawer.kt` — QR code rendering
  - `SigningAs.kt` — Account display
  - `InvalidIntentScreen.kt` — Error screen
  - `CloseButton.kt` & `CloseIcon.kt` — Close controls
  - `NewBunkerFloatingButton.kt` — Floating action button

- **Layout improvements**:
  - Added `height` layout imports where needed for preview sizing
  - Added `padding` imports for preview spacing

## Implementation Details

- Previews use mock data (e.g., `previewDecodedPsbt()`, `previewEvent()`, `previewAccount()`) to avoid touching global state (`Amber.instance`) during render
- All previews are wrapped in `AmberPreview {}` to ensure consistent theme application
- Most components use `@ThemePreviews` for dual light/dark rendering; a few use single `@Preview` annotations where appropriate
- Preview account is built from a public key only (no private key or secp256k1 code touched)
- Previews follow the pattern of setting `modifier`, `padding(

https://claude.ai/code/session_013z5Vbcd3C2SNG2B76QFNwZ